### PR TITLE
Add AirPlay output sink and rockbox-airplay crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,180 @@
+# CLAUDE.md — Rockbox Zig
+
+## Project overview
+
+Rockbox Zig is a modern wrapper around the [Rockbox](https://www.rockbox.org) open-source audio player firmware. It adds Rust/Zig services on top of the C firmware to expose gRPC, GraphQL, HTTP, and MPD APIs, a Typesense-backed search engine, Chromecast/AirPlay/Snapcast output sinks, and a desktop/web UI.
+
+The binary is called **`rockboxd`**. It is a single executable built by Zig that links:
+- The Rockbox C firmware (compiled by Make into `build-lib/libfirmware.a` and friends)
+- Rust crates (compiled by Cargo into `target/release/librockbox_cli.a` and `librockbox_server.a`)
+- SDL2 for audio/event handling on the host platform
+
+## Repository layout
+
+```
+firmware/          Rockbox C firmware (audio engine, codecs, DSP)
+apps/              Rockbox application layer (playlist, database, plugins)
+lib/               Codec libraries (rbcodec, fixedpoint, skin_parser, tlsf)
+build-lib/         Out-of-tree Make build directory (generated; do not edit)
+crates/            Rust workspace
+  airplay/         ALAC encoder + RAOP/RTP sender (AirPlay 1 output)
+  cli/             Entry point compiled to librockbox_cli.a (staticlib)
+  server/          gRPC / HTTP server
+  settings/        load_settings() — reads settings.toml, applies sinks
+  sys/             FFI bindings to the C firmware (unsafe extern "C")
+  library/         Audio file scanning and SQLite library management
+  typesense/       Typesense client for fast music search
+  netstream/       HTTP streaming (Range-request based fd multiplexing)
+  chromecast/      Chromecast output
+  rpc/             gRPC definitions / generated code
+  graphql/         GraphQL schema and resolvers
+  mpd/             MPD protocol server
+  mpris/           MPRIS D-Bus integration
+  tracklist/       Playlist / tracklist management
+  types/           Shared Rust types
+  traits/          Shared Rust traits
+zig/               Zig build script and thin main.zig entry point
+```
+
+## Build system
+
+### Step 1 — C firmware (Make)
+```sh
+cd build-lib
+make lib          # builds libfirmware.a, librockbox.a, codec libs
+```
+The `build-lib/` directory was pre-configured via Rockbox's `tools/configure` for the `sdlapp` target. Do **not** run `configure` again unless you know what you're doing — it regenerates the Makefile and overwrites any local edits.
+
+### Step 2 — Rust crates (Cargo)
+```sh
+cargo build --release -p rockbox-cli     # produces target/release/librockbox_cli.a
+cargo build --release -p rockbox-server  # produces target/release/librockbox_server.a
+```
+Both crates have `crate-type = ["staticlib"]`. All transitive rlib dependencies are bundled into the `.a`.
+
+### Step 3 — Zig linker
+```sh
+cd zig
+zig build          # links everything into zig-out/bin/rockboxd
+```
+
+### Quick full rebuild
+```sh
+cd build-lib && make lib && cd ..
+cargo build --release -p rockbox-cli -p rockbox-server
+cd zig && zig build
+```
+
+### Critical: stale binary pitfall
+`zig build` only re-links if the `.a` files are newer than the binary. After changing C code, always run `make lib` first. After changing Rust code, run `cargo build --release`. If behavior doesn't match the code, check timestamps:
+```sh
+ls -la zig/zig-out/bin/rockboxd build-lib/libfirmware.a target/release/librockbox_cli.a
+```
+
+## Runtime configuration
+
+Settings file: `~/.config/rockbox.org/settings.toml`
+
+```toml
+music_dir = "/path/to/Music"
+
+# Audio output — pick one:
+audio_output = "builtin"      # SDL audio (default)
+
+audio_output = "fifo"
+fifo_path = "/tmp/snapfifo"   # named FIFO for Snapcast; use "-" for stdout
+
+audio_output = "airplay"
+airplay_host = "192.168.1.x"  # RAOP receiver IP
+airplay_port = 5000            # optional, default 5000
+```
+
+## PCM sink architecture
+
+The audio output abstraction lives in `firmware/export/pcm_sink.h`. Each sink implements `struct pcm_sink_ops` (init / postinit / set_freq / lock / unlock / play / stop).
+
+| Enum constant      | Value | Implementation file                         |
+|--------------------|-------|---------------------------------------------|
+| `PCM_SINK_BUILTIN` | 0     | `firmware/target/hosted/sdl/pcm-sdl.c`     |
+| `PCM_SINK_FIFO`    | 1     | `firmware/target/hosted/pcm-fifo.c`        |
+| `PCM_SINK_AIRPLAY` | 2     | `firmware/target/hosted/pcm-airplay.c`     |
+
+`crates/settings/src/lib.rs:load_settings()` reads `audio_output` and calls `pcm::switch_sink()`.
+
+Rust constants + helpers live in `crates/sys/src/sound/pcm.rs`.
+
+### FIFO sink (Snapcast)
+- Pre-creates the named FIFO with `O_RDWR|O_NONBLOCK` in `pcm_fifo_set_path()` then clears `O_NONBLOCK`, so a permanent writer reference is held — readers never see premature EOF between tracks.
+- `sink_dma_stop()` does NOT close the fd; it stays open across track transitions.
+- **Startup order matters**: rockboxd must start before snapserver. If snapserver opens the FIFO first it may get EOF and stop reading.
+- On macOS, snapserver v0.35.0 ignores the `-s` sample-format CLI flag; use `/usr/local/etc/snapserver.conf`:
+  ```ini
+  [stream]
+  source = pipe:///tmp/snapfifo?name=default&sampleformat=44100:16:2
+  ```
+
+### AirPlay sink (RAOP)
+- `crates/airplay/` implements the full RAOP stack in pure Rust (no tokio needed).
+  - `alac.rs` — ALAC escape/verbatim frame encoder: 352 stereo S16LE samples → 1411-byte bitstream
+  - `rtp.rs` — RTP/UDP packet sender; RTCP NTP sync packets sent every ~44 frames
+  - `rtsp.rs` — synchronous RTSP client: ANNOUNCE (SDP) → SETUP → RECORD
+- `pcm_airplay_connect()` is called once per `sink_dma_start()` (idempotent if already connected).
+- The `rockbox-airplay` rlib must be force-included in `librockbox_cli.a` via the `use rockbox_airplay::_link_airplay as _` shim in `crates/cli/src/lib.rs`.
+
+## Key cross-cutting concerns
+
+### macOS SDL audio
+`SDL_InitSubSystem(SDL_INIT_AUDIO)` must be called explicitly on macOS because the SDL event thread (which normally does it) is `#ifndef __APPLE__`. This is done in `firmware/target/hosted/sdl/system-sdl.c` in the `#else` branch of the event-thread guard.
+
+### SIGTERM handling
+`system-hosted.c` installs a SIGTERM handler that loops forever (waits for SDL quit event). `crates/cli/src/lib.rs` overrides SIGTERM/SIGINT with a handler that kills the typesense child and calls `_exit(0)`.
+
+### Typesense subprocess
+Spawned in `crates/cli/src/lib.rs` with `Stdio::piped()`. stdout/stderr lines are forwarded to `tracing::debug!`/`tracing::warn!` in background threads, keeping the PCM stdout stream clean in FIFO mode.
+
+### Logging — use `tracing`, never `eprintln!`/`println!`
+All Rust logging must use the `tracing` crate (`tracing::debug!`, `tracing::info!`, `tracing::warn!`, `tracing::error!`). **Never use `eprintln!` or `println!` for diagnostic output** in Rust code — they bypass the structured log filter, pollute stdout (breaking FIFO/pipe mode), and can't be silenced at runtime.
+
+Severity guide:
+- `tracing::error!` — unrecoverable failures (connection refused, missing config)
+- `tracing::warn!` — recoverable issues (non-fatal fallbacks, unexpected-but-handled states)
+- `tracing::info!` — notable lifecycle events (session established, device paired)
+- `tracing::debug!` — per-packet/per-frame detail, protocol negotiation steps
+
+`tracing` is declared as a workspace dependency in the root `Cargo.toml`; add `tracing = { workspace = true }` to any crate that needs it. Control verbosity at runtime with `RUST_LOG`, e.g. `RUST_LOG=debug rockboxd` or `RUST_LOG=rockbox_airplay=debug,info`.
+
+### HTTP streaming
+HTTP fds are encoded as values `<= STREAM_HTTP_FD_BASE (-1000)`. `stream_open/read/lseek/close` in `crates/netstream/` dispatch between HTTP and POSIX based on fd value. The global `STREAMS` map holds `Arc<Mutex<StreamState>>` per handle so concurrent reads don't serialize on a single lock.
+
+## Adding a new PCM sink
+
+1. Create `firmware/target/hosted/pcm-<name>.c` — model on `pcm-fifo.c`.
+2. Add `PCM_SINK_<NAME>` to the enum in `firmware/export/pcm_sink.h`.
+3. Register `&<name>_pcm_sink` in the `sinks[]` array in `firmware/pcm.c`.
+4. Add `target/hosted/pcm-<name>.c` inside the `#if PLATFORM_HOSTED` block in `firmware/SOURCES`.
+5. Add Rust constant `PCM_SINK_<NAME>: i32` in `crates/sys/src/sound/pcm.rs`.
+6. Add a `set_<name>_*` wrapper if configuration is needed.
+7. Handle in `crates/settings/src/lib.rs:load_settings()`.
+8. If the sink has a Rust implementation in a new crate: add a `_link_<name>()` dummy fn and reference it from `crates/cli/src/lib.rs` to force inclusion in the staticlib.
+
+## Useful commands
+
+```sh
+# Run the daemon
+./zig/zig-out/bin/rockboxd
+
+# Run with AirPlay debug logging
+RUST_LOG=debug ./zig/zig-out/bin/rockboxd
+
+# Test FIFO → stdout pipe
+./zig/zig-out/bin/rockboxd | ffplay -f s16le -ar 44100 -ac 2 -
+
+# Check binary vs library timestamps
+ls -la zig/zig-out/bin/rockboxd build-lib/libfirmware.a target/release/librockbox_cli.a
+
+# Verify AirPlay symbols are present
+nm zig/zig-out/bin/rockboxd | grep pcm_airplay
+
+# Verify a crate is in the staticlib
+ar t target/release/librockbox_cli.a | grep airplay
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures 0.2.14",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -1616,6 +1627,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1658,6 +1682,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.6",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -8135,6 +8160,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.14",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8644,7 +8680,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -9080,6 +9116,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rockbox-airplay"
+version = "0.1.0"
+dependencies = [
+ "chacha20poly1305",
+ "dirs 6.0.0",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "sha2",
+ "tracing",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "rockbox-chromecast"
 version = "0.1.0"
 dependencies = [
@@ -9106,6 +9159,7 @@ dependencies = [
  "dirs 6.0.0",
  "libc",
  "owo-colors 4.1.0",
+ "rockbox-airplay",
  "rockbox-library",
  "rockbox-rocksky",
  "rockbox-settings",

--- a/cli/src/api/rockbox.v1alpha1.rs
+++ b/cli/src/api/rockbox.v1alpha1.rs
@@ -43,10 +43,10 @@ pub mod browse_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BrowseServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -90,8 +90,9 @@ pub mod browse_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BrowseServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -129,20 +130,27 @@ pub mod browse_service_client {
         pub async fn tree_get_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.BrowseService",
-                "TreeGetEntries",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.BrowseService", "TreeGetEntries"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -154,7 +162,7 @@ pub mod browse_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BrowseServiceServer.
@@ -163,7 +171,10 @@ pub mod browse_service_server {
         async fn tree_get_entries(
             &self,
             request: tonic::Request<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct BrowseServiceServer<T> {
@@ -186,7 +197,10 @@ pub mod browse_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -241,18 +255,23 @@ pub mod browse_service_server {
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries" => {
                     #[allow(non_camel_case_types)]
                     struct TreeGetEntriesSvc<T: BrowseService>(pub Arc<T>);
-                    impl<T: BrowseService> tonic::server::UnaryService<super::TreeGetEntriesRequest>
-                        for TreeGetEntriesSvc<T>
-                    {
+                    impl<
+                        T: BrowseService,
+                    > tonic::server::UnaryService<super::TreeGetEntriesRequest>
+                    for TreeGetEntriesSvc<T> {
                         type Response = super::TreeGetEntriesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TreeGetEntriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BrowseService>::tree_get_entries(&inner, request).await
+                                <T as BrowseService>::tree_get_entries(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -279,19 +298,23 @@ pub mod browse_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -527,10 +550,10 @@ pub mod library_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct LibraryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -574,8 +597,9 @@ pub mod library_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LibraryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -613,245 +637,343 @@ pub mod library_service_client {
         pub async fn get_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbums");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbums",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbums",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbums"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtists");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtists",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtists",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtists"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTracks");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTracks",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTracks",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTracks"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_album(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artist(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtist");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtist",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtist",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtist"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_track(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_track(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_album(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_album(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedAlbums",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedAlbums"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn scan_library(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "ScanLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "ScanLibrary"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/Search");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/Search",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "Search"));
@@ -866,7 +988,7 @@ pub mod library_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LibraryServiceServer.
@@ -875,55 +997,94 @@ pub mod library_service_server {
         async fn get_albums(
             &self,
             request: tonic::Request<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn get_artists(
             &self,
             request: tonic::Request<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        >;
         async fn get_tracks(
             &self,
             request: tonic::Request<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_album(
             &self,
             request: tonic::Request<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_artist(
             &self,
             request: tonic::Request<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        >;
         async fn get_track(
             &self,
             request: tonic::Request<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_track(
             &self,
             request: tonic::Request<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn unlike_track(
             &self,
             request: tonic::Request<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_album(
             &self,
             request: tonic::Request<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn unlike_album(
             &self,
             request: tonic::Request<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_tracks(
             &self,
             request: tonic::Request<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_albums(
             &self,
             request: tonic::Request<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn scan_library(
             &self,
             request: tonic::Request<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        >;
         async fn search(
             &self,
             request: tonic::Request<super::SearchRequest>,
@@ -950,7 +1111,10 @@ pub mod library_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1005,9 +1169,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumsRequest> for GetAlbumsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumsRequest>
+                    for GetAlbumsSvc<T> {
                         type Response = super::GetAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumsRequest>,
@@ -1044,9 +1214,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtists" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistsRequest> for GetArtistsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistsRequest>
+                    for GetArtistsSvc<T> {
                         type Response = super::GetArtistsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistsRequest>,
@@ -1083,9 +1259,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTracksRequest> for GetTracksSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTracksRequest>
+                    for GetTracksSvc<T> {
                         type Response = super::GetTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTracksRequest>,
@@ -1122,9 +1304,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumRequest> for GetAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumRequest>
+                    for GetAlbumSvc<T> {
                         type Response = super::GetAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumRequest>,
@@ -1161,9 +1349,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtist" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistRequest> for GetArtistSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistRequest>
+                    for GetArtistSvc<T> {
                         type Response = super::GetArtistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistRequest>,
@@ -1200,9 +1394,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTrack" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTrackRequest> for GetTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTrackRequest>
+                    for GetTrackSvc<T> {
                         type Response = super::GetTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackRequest>,
@@ -1239,9 +1439,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct LikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeTrackRequest> for LikeTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeTrackRequest>
+                    for LikeTrackSvc<T> {
                         type Response = super::LikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeTrackRequest>,
@@ -1278,11 +1484,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeTrackRequest>
-                        for UnlikeTrackSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeTrackRequest>
+                    for UnlikeTrackSvc<T> {
                         type Response = super::UnlikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeTrackRequest>,
@@ -1319,9 +1529,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct LikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeAlbumRequest> for LikeAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeAlbumRequest>
+                    for LikeAlbumSvc<T> {
                         type Response = super::LikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeAlbumRequest>,
@@ -1358,11 +1574,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeAlbumRequest>
-                        for UnlikeAlbumSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeAlbumRequest>
+                    for UnlikeAlbumSvc<T> {
                         type Response = super::UnlikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeAlbumRequest>,
@@ -1399,19 +1619,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedTracksRequest>
-                        for GetLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedTracksRequest>
+                    for GetLikedTracksSvc<T> {
                         type Response = super::GetLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_tracks(&inner, request).await
+                                <T as LibraryService>::get_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1441,19 +1665,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedAlbumsRequest>
-                        for GetLikedAlbumsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedAlbumsRequest>
+                    for GetLikedAlbumsSvc<T> {
                         type Response = super::GetLikedAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedAlbumsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_albums(&inner, request).await
+                                <T as LibraryService>::get_liked_albums(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1483,11 +1711,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct ScanLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::ScanLibraryRequest>
-                        for ScanLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::ScanLibraryRequest>
+                    for ScanLibrarySvc<T> {
                         type Response = super::ScanLibraryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScanLibraryRequest>,
@@ -1524,16 +1756,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::SearchRequest>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as LibraryService>::search(&inner, request).await };
+                            let fut = async move {
+                                <T as LibraryService>::search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1559,19 +1798,23 @@ pub mod library_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1600,10 +1843,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1647,8 +1890,9 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1692,7 +1936,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1719,7 +1963,10 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1771,19 +2018,23 @@ pub mod metadata_service_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2067,10 +2318,10 @@ pub mod playback_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaybackServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2114,8 +2365,9 @@ pub mod playback_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaybackServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2154,12 +2406,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PlayRequest>,
         ) -> std::result::Result<tonic::Response<super::PlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Play");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Play",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Play"));
@@ -2169,12 +2427,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PauseRequest>,
         ) -> std::result::Result<tonic::Response<super::PauseResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Pause");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Pause",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Pause"));
@@ -2183,49 +2447,66 @@ pub mod playback_service_client {
         pub async fn play_or_pause(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayOrPause",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayOrPause"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeRequest>,
         ) -> std::result::Result<tonic::Response<super::ResumeResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Resume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Resume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Resume",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Resume"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::NextRequest>,
         ) -> std::result::Result<tonic::Response<super::NextResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Next");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Next",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Next"));
@@ -2234,293 +2515,426 @@ pub mod playback_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Previous");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Previous",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Previous",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Previous"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn fast_forward_rewind(
             &mut self,
             request: impl tonic::IntoRequest<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FastForwardRewind",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FastForwardRewind",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Status");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Status",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Status",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Status"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn current_track(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "CurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "CurrentTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn next_track(
             &mut self,
             request: impl tonic::IntoRequest<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/NextTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/NextTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "NextTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "NextTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn flush_and_reload_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FlushAndReloadTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FlushAndReloadTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_file_position(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "GetFilePosition",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "GetFilePosition",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn hard_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/HardStop");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/HardStop",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "HardStop",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "HardStop"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_album(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayDirectory"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_music_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayMusicDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayMusicDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_track(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayLikedTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAllTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_current_track(
@@ -2530,18 +2944,26 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::CurrentTrackResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamCurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "StreamCurrentTrack",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_status(
@@ -2551,18 +2973,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamStatus"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_playlist(
@@ -2572,18 +2999,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::PlaylistResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamPlaylist"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
     }
@@ -2595,7 +3027,7 @@ pub mod playback_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaybackServiceServer.
@@ -2612,7 +3044,10 @@ pub mod playback_service_server {
         async fn play_or_pause(
             &self,
             request: tonic::Request<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        >;
         async fn resume(
             &self,
             request: tonic::Request<super::ResumeRequest>,
@@ -2624,11 +3059,17 @@ pub mod playback_service_server {
         async fn previous(
             &self,
             request: tonic::Request<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        >;
         async fn fast_forward_rewind(
             &self,
             request: tonic::Request<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        >;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
@@ -2636,82 +3077,133 @@ pub mod playback_service_server {
         async fn current_track(
             &self,
             request: tonic::Request<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        >;
         async fn next_track(
             &self,
             request: tonic::Request<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        >;
         async fn flush_and_reload_tracks(
             &self,
             request: tonic::Request<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_file_position(
             &self,
             request: tonic::Request<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        >;
         async fn hard_stop(
             &self,
             request: tonic::Request<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        >;
         async fn play_album(
             &self,
             request: tonic::Request<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        >;
         async fn play_artist_tracks(
             &self,
             request: tonic::Request<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_playlist(
             &self,
             request: tonic::Request<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn play_directory(
             &self,
             request: tonic::Request<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_music_directory(
             &self,
             request: tonic::Request<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_track(
             &self,
             request: tonic::Request<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        >;
         async fn play_liked_tracks(
             &self,
             request: tonic::Request<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_all_tracks(
             &self,
             request: tonic::Request<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamCurrentTrack method.
         type StreamCurrentTrackStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CurrentTrackResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_current_track(
             &self,
             request: tonic::Request<super::StreamCurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamCurrentTrackStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamCurrentTrackStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamStatus method.
         type StreamStatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_status(
             &self,
             request: tonic::Request<super::StreamStatusRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamStatusStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamStatusStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamPlaylist method.
         type StreamPlaylistStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::PlaylistResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_playlist(
             &self,
             request: tonic::Request<super::StreamPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamPlaylistStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamPlaylistStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaybackServiceServer<T> {
@@ -2734,7 +3226,10 @@ pub mod playback_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2789,16 +3284,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Play" => {
                     #[allow(non_camel_case_types)]
                     struct PlaySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
                         type Response = super::PlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::play(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::play(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2827,16 +3328,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Pause" => {
                     #[allow(non_camel_case_types)]
                     struct PauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
                         type Response = super::PauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PauseRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::pause(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::pause(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2865,11 +3372,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause" => {
                     #[allow(non_camel_case_types)]
                     struct PlayOrPauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayOrPauseRequest>
-                        for PlayOrPauseSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayOrPauseRequest>
+                    for PlayOrPauseSvc<T> {
                         type Response = super::PlayOrPauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayOrPauseRequest>,
@@ -2906,9 +3417,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Resume" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::ResumeRequest> for ResumeSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::ResumeRequest>
+                    for ResumeSvc<T> {
                         type Response = super::ResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeRequest>,
@@ -2945,16 +3462,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
                         type Response = super::NextResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::next(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::next(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2983,9 +3506,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PreviousRequest> for PreviousSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PreviousRequest>
+                    for PreviousSvc<T> {
                         type Response = super::PreviousResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PreviousRequest>,
@@ -3022,19 +3551,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind" => {
                     #[allow(non_camel_case_types)]
                     struct FastForwardRewindSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FastForwardRewindRequest>
-                        for FastForwardRewindSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FastForwardRewindRequest>
+                    for FastForwardRewindSvc<T> {
                         type Response = super::FastForwardRewindResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FastForwardRewindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::fast_forward_rewind(&inner, request).await
+                                <T as PlaybackService>::fast_forward_rewind(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3064,9 +3597,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Status" => {
                     #[allow(non_camel_case_types)]
                     struct StatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::StatusRequest> for StatusSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::StatusRequest>
+                    for StatusSvc<T> {
                         type Response = super::StatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
@@ -3103,11 +3642,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct CurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::CurrentTrackRequest>
-                        for CurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::CurrentTrackRequest>
+                    for CurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CurrentTrackRequest>,
@@ -3144,9 +3687,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/NextTrack" => {
                     #[allow(non_camel_case_types)]
                     struct NextTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextTrackRequest> for NextTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextTrackRequest>
+                    for NextTrackSvc<T> {
                         type Response = super::NextTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextTrackRequest>,
@@ -3183,19 +3732,25 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks" => {
                     #[allow(non_camel_case_types)]
                     struct FlushAndReloadTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
-                        for FlushAndReloadTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
+                    for FlushAndReloadTracksSvc<T> {
                         type Response = super::FlushAndReloadTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FlushAndReloadTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::flush_and_reload_tracks(&inner, request)
+                                <T as PlaybackService>::flush_and_reload_tracks(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -3226,19 +3781,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition" => {
                     #[allow(non_camel_case_types)]
                     struct GetFilePositionSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::GetFilePositionRequest>
-                        for GetFilePositionSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::GetFilePositionRequest>
+                    for GetFilePositionSvc<T> {
                         type Response = super::GetFilePositionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFilePositionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::get_file_position(&inner, request).await
+                                <T as PlaybackService>::get_file_position(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3268,9 +3827,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/HardStop" => {
                     #[allow(non_camel_case_types)]
                     struct HardStopSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::HardStopRequest> for HardStopSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::HardStopRequest>
+                    for HardStopSvc<T> {
                         type Response = super::HardStopResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HardStopRequest>,
@@ -3307,9 +3872,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAlbumSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayAlbumRequest> for PlayAlbumSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAlbumRequest>
+                    for PlayAlbumSvc<T> {
                         type Response = super::PlayAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAlbumRequest>,
@@ -3346,19 +3917,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayArtistTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayArtistTracksRequest>
-                        for PlayArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayArtistTracksRequest>
+                    for PlayArtistTracksSvc<T> {
                         type Response = super::PlayArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_artist_tracks(&inner, request).await
+                                <T as PlaybackService>::play_artist_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3388,11 +3963,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct PlayPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayPlaylistRequest>
-                        for PlayPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayPlaylistRequest>
+                    for PlayPlaylistSvc<T> {
                         type Response = super::PlayPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayPlaylistRequest>,
@@ -3429,19 +4008,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayDirectoryRequest>
-                        for PlayDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayDirectoryRequest>
+                    for PlayDirectorySvc<T> {
                         type Response = super::PlayDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_directory(&inner, request).await
+                                <T as PlaybackService>::play_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3471,19 +4054,26 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayMusicDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
-                        for PlayMusicDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
+                    for PlayMusicDirectorySvc<T> {
                         type Response = super::PlayMusicDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayMusicDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_music_directory(&inner, request).await
+                                <T as PlaybackService>::play_music_directory(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3513,9 +4103,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayTrack" => {
                     #[allow(non_camel_case_types)]
                     struct PlayTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayTrackRequest> for PlayTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayTrackRequest>
+                    for PlayTrackSvc<T> {
                         type Response = super::PlayTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayTrackRequest>,
@@ -3552,19 +4148,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayLikedTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayLikedTracksRequest>
-                        for PlayLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayLikedTracksRequest>
+                    for PlayLikedTracksSvc<T> {
                         type Response = super::PlayLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_liked_tracks(&inner, request).await
+                                <T as PlaybackService>::play_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3594,19 +4194,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAllTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayAllTracksRequest>
-                        for PlayAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAllTracksRequest>
+                    for PlayAllTracksSvc<T> {
                         type Response = super::PlayAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_all_tracks(&inner, request).await
+                                <T as PlaybackService>::play_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3636,21 +4240,28 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct StreamCurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamCurrentTrackRequest>
-                        for StreamCurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamCurrentTrackRequest,
+                    > for StreamCurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
                         type ResponseStream = T::StreamCurrentTrackStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamCurrentTrackRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_current_track(&inner, request).await
+                                <T as PlaybackService>::stream_current_track(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3680,14 +4291,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus" => {
                     #[allow(non_camel_case_types)]
                     struct StreamStatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamStatusRequest>
-                        for StreamStatusSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamStatusRequest>
+                    for StreamStatusSvc<T> {
                         type Response = super::StatusResponse;
                         type ResponseStream = T::StreamStatusStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamStatusRequest>,
@@ -3724,21 +4337,24 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct StreamPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
-                        for StreamPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
+                    for StreamPlaylistSvc<T> {
                         type Response = super::PlaylistResponse;
                         type ResponseStream = T::StreamPlaylistStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_playlist(&inner, request).await
+                                <T as PlaybackService>::stream_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3765,19 +4381,23 @@ pub mod playback_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -3984,10 +4604,10 @@ pub mod playlist_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaylistServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4031,8 +4651,9 @@ pub mod playlist_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaylistServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4070,182 +4691,251 @@ pub mod playlist_service_client {
         pub async fn get_current(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_resume_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetResumeInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetResumeInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetTrackInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetTrackInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_first_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetFirstIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetFirstIndex"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_display_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetDisplayIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "GetDisplayIndex",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn amount(
             &mut self,
             request: impl tonic::IntoRequest<super::AmountRequest>,
         ) -> std::result::Result<tonic::Response<super::AmountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Amount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Amount",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "Amount",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Amount"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn playlist_resume(
             &mut self,
             request: impl tonic::IntoRequest<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "PlaylistResume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "PlaylistResume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume_track(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ResumeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "ResumeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_modified(
             &mut self,
             request: impl tonic::IntoRequest<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/SetModified",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "SetModified",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "SetModified"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn start(
             &mut self,
             request: impl tonic::IntoRequest<super::StartRequest>,
         ) -> std::result::Result<tonic::Response<super::StartResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Start");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Start",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Start"));
@@ -4255,12 +4945,18 @@ pub mod playlist_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncRequest>,
         ) -> std::result::Result<tonic::Response<super::SyncResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Sync");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Sync",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Sync"));
@@ -4269,172 +4965,247 @@ pub mod playlist_service_client {
         pub async fn remove_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "RemoveAllTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "RemoveTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn create_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "CreatePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "CreatePlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_album(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn shuffle_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ShufflePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "ShufflePlaylist",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -4446,7 +5217,7 @@ pub mod playlist_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaylistServiceServer.
@@ -4455,23 +5226,38 @@ pub mod playlist_service_server {
         async fn get_current(
             &self,
             request: tonic::Request<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        >;
         async fn get_resume_info(
             &self,
             request: tonic::Request<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_track_info(
             &self,
             request: tonic::Request<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_first_index(
             &self,
             request: tonic::Request<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        >;
         async fn get_display_index(
             &self,
             request: tonic::Request<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        >;
         async fn amount(
             &self,
             request: tonic::Request<super::AmountRequest>,
@@ -4479,15 +5265,24 @@ pub mod playlist_service_server {
         async fn playlist_resume(
             &self,
             request: tonic::Request<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        >;
         async fn resume_track(
             &self,
             request: tonic::Request<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        >;
         async fn set_modified(
             &self,
             request: tonic::Request<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        >;
         async fn start(
             &self,
             request: tonic::Request<super::StartRequest>,
@@ -4499,39 +5294,66 @@ pub mod playlist_service_server {
         async fn remove_all_tracks(
             &self,
             request: tonic::Request<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        >;
         async fn remove_tracks(
             &self,
             request: tonic::Request<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        >;
         async fn create_playlist(
             &self,
             request: tonic::Request<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_tracks(
             &self,
             request: tonic::Request<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        >;
         async fn insert_directory(
             &self,
             request: tonic::Request<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn insert_playlist(
             &self,
             request: tonic::Request<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_album(
             &self,
             request: tonic::Request<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        >;
         async fn insert_artist_tracks(
             &self,
             request: tonic::Request<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn shuffle_playlist(
             &self,
             request: tonic::Request<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaylistServiceServer<T> {
@@ -4554,7 +5376,10 @@ pub mod playlist_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4609,11 +5434,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetCurrentRequest>
-                        for GetCurrentSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetCurrentRequest>
+                    for GetCurrentSvc<T> {
                         type Response = super::GetCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCurrentRequest>,
@@ -4650,19 +5479,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetResumeInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetResumeInfoRequest>
-                        for GetResumeInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetResumeInfoRequest>
+                    for GetResumeInfoSvc<T> {
                         type Response = super::GetResumeInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetResumeInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_resume_info(&inner, request).await
+                                <T as PlaylistService>::get_resume_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4692,18 +5525,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetTrackInfoRequest>
-                        for GetTrackInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetTrackInfoRequest>
+                    for GetTrackInfoSvc<T> {
                         type Response = super::GetTrackInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_track_info(&inner, request).await
+                                <T as PlaylistService>::get_track_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4733,19 +5571,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetFirstIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetFirstIndexRequest>
-                        for GetFirstIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetFirstIndexRequest>
+                    for GetFirstIndexSvc<T> {
                         type Response = super::GetFirstIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFirstIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_first_index(&inner, request).await
+                                <T as PlaylistService>::get_first_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4775,19 +5617,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetDisplayIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetDisplayIndexRequest>
-                        for GetDisplayIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetDisplayIndexRequest>
+                    for GetDisplayIndexSvc<T> {
                         type Response = super::GetDisplayIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetDisplayIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_display_index(&inner, request).await
+                                <T as PlaylistService>::get_display_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4817,9 +5663,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Amount" => {
                     #[allow(non_camel_case_types)]
                     struct AmountSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::AmountRequest> for AmountSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::AmountRequest>
+                    for AmountSvc<T> {
                         type Response = super::AmountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AmountRequest>,
@@ -4856,19 +5708,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume" => {
                     #[allow(non_camel_case_types)]
                     struct PlaylistResumeSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::PlaylistResumeRequest>
-                        for PlaylistResumeSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::PlaylistResumeRequest>
+                    for PlaylistResumeSvc<T> {
                         type Response = super::PlaylistResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlaylistResumeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::playlist_resume(&inner, request).await
+                                <T as PlaylistService>::playlist_resume(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4898,11 +5754,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeTrackSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::ResumeTrackRequest>
-                        for ResumeTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ResumeTrackRequest>
+                    for ResumeTrackSvc<T> {
                         type Response = super::ResumeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeTrackRequest>,
@@ -4939,11 +5799,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/SetModified" => {
                     #[allow(non_camel_case_types)]
                     struct SetModifiedSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SetModifiedRequest>
-                        for SetModifiedSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SetModifiedRequest>
+                    for SetModifiedSvc<T> {
                         type Response = super::SetModifiedResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetModifiedRequest>,
@@ -4980,16 +5844,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Start" => {
                     #[allow(non_camel_case_types)]
                     struct StartSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
                         type Response = super::StartResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StartRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::start(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::start(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5018,16 +5888,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
                         type Response = super::SyncResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::sync(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::sync(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5056,19 +5932,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveAllTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::RemoveAllTracksRequest>
-                        for RemoveAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveAllTracksRequest>
+                    for RemoveAllTracksSvc<T> {
                         type Response = super::RemoveAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::remove_all_tracks(&inner, request).await
+                                <T as PlaylistService>::remove_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5098,11 +5978,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::RemoveTracksRequest>
-                        for RemoveTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveTracksRequest>
+                    for RemoveTracksSvc<T> {
                         type Response = super::RemoveTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveTracksRequest>,
@@ -5139,19 +6023,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct CreatePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::CreatePlaylistRequest>
-                        for CreatePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::CreatePlaylistRequest>
+                    for CreatePlaylistSvc<T> {
                         type Response = super::CreatePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreatePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::create_playlist(&inner, request).await
+                                <T as PlaylistService>::create_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5181,11 +6069,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertTracksRequest>
-                        for InsertTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertTracksRequest>
+                    for InsertTracksSvc<T> {
                         type Response = super::InsertTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertTracksRequest>,
@@ -5222,19 +6114,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct InsertDirectorySvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertDirectoryRequest>
-                        for InsertDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertDirectoryRequest>
+                    for InsertDirectorySvc<T> {
                         type Response = super::InsertDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_directory(&inner, request).await
+                                <T as PlaylistService>::insert_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5264,19 +6160,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct InsertPlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertPlaylistRequest>
-                        for InsertPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertPlaylistRequest>
+                    for InsertPlaylistSvc<T> {
                         type Response = super::InsertPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_playlist(&inner, request).await
+                                <T as PlaylistService>::insert_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5306,11 +6206,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct InsertAlbumSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertAlbumRequest>
-                        for InsertAlbumSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertAlbumRequest>
+                    for InsertAlbumSvc<T> {
                         type Response = super::InsertAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertAlbumRequest>,
@@ -5347,19 +6251,26 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertArtistTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertArtistTracksRequest>
-                        for InsertArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertArtistTracksRequest>
+                    for InsertArtistTracksSvc<T> {
                         type Response = super::InsertArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_artist_tracks(&inner, request).await
+                                <T as PlaylistService>::insert_artist_tracks(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5389,19 +6300,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct ShufflePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::ShufflePlaylistRequest>
-                        for ShufflePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ShufflePlaylistRequest>
+                    for ShufflePlaylistSvc<T> {
                         type Response = super::ShufflePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ShufflePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::shuffle_playlist(&inner, request).await
+                                <T as PlaylistService>::shuffle_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5428,19 +6343,23 @@ pub mod playlist_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -5950,10 +6869,10 @@ pub mod settings_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SettingsServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -5997,8 +6916,9 @@ pub mod settings_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SettingsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6036,58 +6956,85 @@ pub mod settings_service_client {
         pub async fn get_settings_list(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetSettingsList",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetSettingsList",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetGlobalSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetGlobalSettings",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn save_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/SaveSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "SaveSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SettingsService", "SaveSettings"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6099,7 +7046,7 @@ pub mod settings_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SettingsServiceServer.
@@ -6108,15 +7055,24 @@ pub mod settings_service_server {
         async fn get_settings_list(
             &self,
             request: tonic::Request<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        >;
         async fn get_global_settings(
             &self,
             request: tonic::Request<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        >;
         async fn save_settings(
             &self,
             request: tonic::Request<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SettingsServiceServer<T> {
@@ -6139,7 +7095,10 @@ pub mod settings_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6194,19 +7153,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList" => {
                     #[allow(non_camel_case_types)]
                     struct GetSettingsListSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetSettingsListRequest>
-                        for GetSettingsListSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetSettingsListRequest>
+                    for GetSettingsListSvc<T> {
                         type Response = super::GetSettingsListResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSettingsListRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_settings_list(&inner, request).await
+                                <T as SettingsService>::get_settings_list(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6236,19 +7199,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetGlobalSettingsRequest>
-                        for GetGlobalSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetGlobalSettingsRequest>
+                    for GetGlobalSettingsSvc<T> {
                         type Response = super::GetGlobalSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalSettingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_global_settings(&inner, request).await
+                                <T as SettingsService>::get_global_settings(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6278,11 +7245,15 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/SaveSettings" => {
                     #[allow(non_camel_case_types)]
                     struct SaveSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService> tonic::server::UnaryService<super::SaveSettingsRequest>
-                        for SaveSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::SaveSettingsRequest>
+                    for SaveSettingsSvc<T> {
                         type Response = super::SaveSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SaveSettingsRequest>,
@@ -6316,19 +7287,23 @@ pub mod settings_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6486,10 +7461,10 @@ pub mod sound_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SoundServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6533,8 +7508,9 @@ pub mod sound_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SoundServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6572,31 +7548,48 @@ pub mod sound_service_client {
         pub async fn adjust_volume(
             &mut self,
             request: impl tonic::IntoRequest<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/AdjustVolume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/AdjustVolume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "AdjustVolume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "AdjustVolume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_set(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundSet");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundSet",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundSet"));
@@ -6605,49 +7598,74 @@ pub mod sound_service_client {
         pub async fn sound_current(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundCurrent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundCurrent",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_default(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundDefault");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundDefault",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundDefault",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundDefault"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_min(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMin");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMin",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMin"));
@@ -6656,13 +7674,22 @@ pub mod sound_service_client {
         pub async fn sound_max(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMax");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMax",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMax"));
@@ -6671,49 +7698,72 @@ pub mod sound_service_client {
         pub async fn sound_unit(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundUnit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundUnit",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundUnit",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundUnit"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_val2_phys(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundVal2Phys",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundVal2Phys"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/GetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/GetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "GetPitch"));
@@ -6722,13 +7772,22 @@ pub mod sound_service_client {
         pub async fn set_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SetPitch"));
@@ -6737,13 +7796,22 @@ pub mod sound_service_client {
         pub async fn beep_play(
             &mut self,
             request: impl tonic::IntoRequest<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/BeepPlay");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/BeepPlay",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "BeepPlay"));
@@ -6752,76 +7820,106 @@ pub mod sound_service_client {
         pub async fn pcmbuf_fade(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/PcmbufFade");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/PcmbufFade",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufFade",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "PcmbufFade"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn pcmbuf_set_low_latency(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufSetLowLatency",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SoundService",
+                        "PcmbufSetLowLatency",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn system_sound_play(
             &mut self,
             request: impl tonic::IntoRequest<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SystemSoundPlay",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SystemSoundPlay"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn keyclick_click(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/KeyclickClick",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "KeyclickClick",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "KeyclickClick"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6833,7 +7931,7 @@ pub mod sound_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SoundServiceServer.
@@ -6842,63 +7940,108 @@ pub mod sound_service_server {
         async fn adjust_volume(
             &self,
             request: tonic::Request<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        >;
         async fn sound_set(
             &self,
             request: tonic::Request<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        >;
         async fn sound_current(
             &self,
             request: tonic::Request<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        >;
         async fn sound_default(
             &self,
             request: tonic::Request<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        >;
         async fn sound_min(
             &self,
             request: tonic::Request<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        >;
         async fn sound_max(
             &self,
             request: tonic::Request<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        >;
         async fn sound_unit(
             &self,
             request: tonic::Request<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        >;
         async fn sound_val2_phys(
             &self,
             request: tonic::Request<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        >;
         async fn get_pitch(
             &self,
             request: tonic::Request<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        >;
         async fn set_pitch(
             &self,
             request: tonic::Request<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        >;
         async fn beep_play(
             &self,
             request: tonic::Request<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_fade(
             &self,
             request: tonic::Request<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_set_low_latency(
             &self,
             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        >;
         async fn system_sound_play(
             &self,
             request: tonic::Request<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        >;
         async fn keyclick_click(
             &self,
             request: tonic::Request<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SoundServiceServer<T> {
@@ -6921,7 +8064,10 @@ pub mod sound_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6976,11 +8122,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/AdjustVolume" => {
                     #[allow(non_camel_case_types)]
                     struct AdjustVolumeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::AdjustVolumeRequest>
-                        for AdjustVolumeSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::AdjustVolumeRequest>
+                    for AdjustVolumeSvc<T> {
                         type Response = super::AdjustVolumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AdjustVolumeRequest>,
@@ -7017,9 +8167,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundSet" => {
                     #[allow(non_camel_case_types)]
                     struct SoundSetSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundSetRequest> for SoundSetSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundSetRequest>
+                    for SoundSetSvc<T> {
                         type Response = super::SoundSetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundSetRequest>,
@@ -7056,11 +8212,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct SoundCurrentSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundCurrentRequest>
-                        for SoundCurrentSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundCurrentRequest>
+                    for SoundCurrentSvc<T> {
                         type Response = super::SoundCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundCurrentRequest>,
@@ -7097,11 +8257,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundDefault" => {
                     #[allow(non_camel_case_types)]
                     struct SoundDefaultSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundDefaultRequest>
-                        for SoundDefaultSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundDefaultRequest>
+                    for SoundDefaultSvc<T> {
                         type Response = super::SoundDefaultResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundDefaultRequest>,
@@ -7138,9 +8302,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMin" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMinSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMinRequest> for SoundMinSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMinRequest>
+                    for SoundMinSvc<T> {
                         type Response = super::SoundMinResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMinRequest>,
@@ -7177,9 +8347,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMax" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMaxSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMaxRequest> for SoundMaxSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMaxRequest>
+                    for SoundMaxSvc<T> {
                         type Response = super::SoundMaxResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMaxRequest>,
@@ -7216,9 +8392,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundUnit" => {
                     #[allow(non_camel_case_types)]
                     struct SoundUnitSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundUnitRequest> for SoundUnitSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundUnitRequest>
+                    for SoundUnitSvc<T> {
                         type Response = super::SoundUnitResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundUnitRequest>,
@@ -7255,11 +8437,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys" => {
                     #[allow(non_camel_case_types)]
                     struct SoundVal2PhysSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundVal2PhysRequest>
-                        for SoundVal2PhysSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundVal2PhysRequest>
+                    for SoundVal2PhysSvc<T> {
                         type Response = super::SoundVal2PhysResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundVal2PhysRequest>,
@@ -7296,9 +8482,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/GetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct GetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::GetPitchRequest> for GetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::GetPitchRequest>
+                    for GetPitchSvc<T> {
                         type Response = super::GetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPitchRequest>,
@@ -7335,9 +8527,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct SetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SetPitchRequest> for SetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SetPitchRequest>
+                    for SetPitchSvc<T> {
                         type Response = super::SetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPitchRequest>,
@@ -7374,9 +8572,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/BeepPlay" => {
                     #[allow(non_camel_case_types)]
                     struct BeepPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::BeepPlayRequest> for BeepPlaySvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::BeepPlayRequest>
+                    for BeepPlaySvc<T> {
                         type Response = super::BeepPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BeepPlayRequest>,
@@ -7413,9 +8617,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufFade" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufFadeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::PcmbufFadeRequest> for PcmbufFadeSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufFadeRequest>
+                    for PcmbufFadeSvc<T> {
                         type Response = super::PcmbufFadeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufFadeRequest>,
@@ -7452,19 +8662,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufSetLowLatencySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService>
-                        tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
-                        for PcmbufSetLowLatencySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
+                    for PcmbufSetLowLatencySvc<T> {
                         type Response = super::PcmbufSetLowLatencyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request).await
+                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7494,18 +8708,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay" => {
                     #[allow(non_camel_case_types)]
                     struct SystemSoundPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SystemSoundPlayRequest>
-                        for SystemSoundPlaySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SystemSoundPlayRequest>
+                    for SystemSoundPlaySvc<T> {
                         type Response = super::SystemSoundPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SystemSoundPlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::system_sound_play(&inner, request).await
+                                <T as SoundService>::system_sound_play(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7535,11 +8754,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/KeyclickClick" => {
                     #[allow(non_camel_case_types)]
                     struct KeyclickClickSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::KeyclickClickRequest>
-                        for KeyclickClickSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::KeyclickClickRequest>
+                    for KeyclickClickSvc<T> {
                         type Response = super::KeyclickClickResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::KeyclickClickRequest>,
@@ -7573,19 +8796,23 @@ pub mod sound_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -7646,10 +8873,10 @@ pub mod system_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SystemServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7693,8 +8920,9 @@ pub mod system_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SystemServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7732,39 +8960,56 @@ pub mod system_service_client {
         pub async fn get_rockbox_version(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetRockboxVersion",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SystemService",
+                        "GetRockboxVersion",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetGlobalStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SystemService", "GetGlobalStatus"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7776,7 +9021,7 @@ pub mod system_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SystemServiceServer.
@@ -7785,11 +9030,17 @@ pub mod system_service_server {
         async fn get_rockbox_version(
             &self,
             request: tonic::Request<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        >;
         async fn get_global_status(
             &self,
             request: tonic::Request<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SystemServiceServer<T> {
@@ -7812,7 +9063,10 @@ pub mod system_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7867,19 +9121,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion" => {
                     #[allow(non_camel_case_types)]
                     struct GetRockboxVersionSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetRockboxVersionRequest>
-                        for GetRockboxVersionSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetRockboxVersionRequest>
+                    for GetRockboxVersionSvc<T> {
                         type Response = super::GetRockboxVersionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRockboxVersionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_rockbox_version(&inner, request).await
+                                <T as SystemService>::get_rockbox_version(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7909,19 +9167,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalStatusSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetGlobalStatusRequest>
-                        for GetGlobalStatusSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetGlobalStatusRequest>
+                    for GetGlobalStatusSvc<T> {
                         type Response = super::GetGlobalStatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_global_status(&inner, request).await
+                                <T as SystemService>::get_global_status(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7948,19 +9210,23 @@ pub mod system_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/crates/airplay/Cargo.toml
+++ b/crates/airplay/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rockbox-airplay"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+rand = { version = "=0.8.5" }
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+chacha20poly1305 = "0.10"
+sha2 = { workspace = true }
+hkdf = { workspace = true }
+hmac = "0.12"
+num-bigint = { workspace = true }
+num-traits = "0.2"
+dirs = "6.0.0"
+tracing = { workspace = true }

--- a/crates/airplay/src/airplay2/http.rs
+++ b/crates/airplay/src/airplay2/http.rs
@@ -1,0 +1,123 @@
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+
+/// POST `path` with Content-Type: application/pairing+tlv8, return the body.
+pub fn http_post_tlv8(host: &str, port: u16, path: &str, body: &[u8]) -> io::Result<Vec<u8>> {
+    http_post(host, port, path, "application/pairing+tlv8", body)
+}
+
+/// POST `path` with `content_type`, return the response body.
+pub fn http_post(
+    host: &str,
+    port: u16,
+    path: &str,
+    content_type: &str,
+    body: &[u8],
+) -> io::Result<Vec<u8>> {
+    let mut stream = TcpStream::connect(format!("{}:{}", host, port))?;
+    let req = format!(
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        path, host, port, content_type, body.len()
+    );
+    stream.write_all(req.as_bytes())?;
+    stream.write_all(body)?;
+    stream.flush()?;
+
+    let mut reader = BufReader::new(stream);
+
+    // Parse status line
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line)?;
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    tracing::debug!("<< {}", status_line.trim());
+
+    if status != 200 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("HTTP {} returned status {}", path, status),
+        ));
+    }
+
+    // Parse headers to get Content-Length
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        let trimmed = line.trim_end_matches(|c| c == '\r' || c == '\n');
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = trimmed.split_once(':') {
+            if k.trim().to_lowercase() == "content-length" {
+                content_length = v.trim().parse().ok();
+            }
+        }
+    }
+
+    // Read body
+    let mut resp_body = Vec::new();
+    if let Some(len) = content_length {
+        resp_body.resize(len, 0);
+        reader.read_exact(&mut resp_body)?;
+    } else {
+        reader.read_to_end(&mut resp_body)?;
+    }
+
+    Ok(resp_body)
+}
+
+/// GET `path`, return the response body.
+pub fn http_get(host: &str, port: u16, path: &str) -> io::Result<Vec<u8>> {
+    let mut stream = TcpStream::connect(format!("{}:{}", host, port))?;
+    let req = format!(
+        "GET {} HTTP/1.1\r\nHost: {}:{}\r\nConnection: close\r\n\r\n",
+        path, host, port
+    );
+    stream.write_all(req.as_bytes())?;
+    stream.flush()?;
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line)?;
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    if status != 200 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("HTTP GET {} returned {}", path, status),
+        ));
+    }
+
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        let trimmed = line.trim_end_matches(|c| c == '\r' || c == '\n');
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = trimmed.split_once(':') {
+            if k.trim().to_lowercase() == "content-length" {
+                content_length = v.trim().parse().ok();
+            }
+        }
+    }
+
+    let mut resp_body = Vec::new();
+    if let Some(len) = content_length {
+        resp_body.resize(len, 0);
+        reader.read_exact(&mut resp_body)?;
+    } else {
+        reader.read_to_end(&mut resp_body)?;
+    }
+    Ok(resp_body)
+}

--- a/crates/airplay/src/airplay2/mod.rs
+++ b/crates/airplay/src/airplay2/mod.rs
@@ -1,0 +1,80 @@
+pub mod http;
+pub mod pairing;
+pub mod srp;
+pub mod tlv8;
+pub mod verify;
+
+use std::io;
+use std::path::PathBuf;
+
+use ed25519_dalek::SigningKey;
+
+use pairing::pair_setup;
+use verify::pair_verify;
+
+/// Load or generate the client's persistent Ed25519 identity key.
+pub fn load_or_create_identity() -> io::Result<(SigningKey, String)> {
+    let path = identity_path();
+    let signing_key = if path.exists() {
+        let bytes = std::fs::read(&path)?;
+        if bytes.len() != 32 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "bad identity key length"));
+        }
+        let arr: [u8; 32] = bytes.try_into().unwrap();
+        SigningKey::from_bytes(&arr)
+    } else {
+        let key = SigningKey::generate(&mut rand::thread_rng());
+        let dir = path.parent().unwrap();
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(&path, key.to_bytes())?;
+        tracing::info!("generated new identity key → {}", path.display());
+        key
+    };
+
+    // Device ID: hex encoding of the verifying key (first 16 bytes)
+    let vk = signing_key.verifying_key();
+    let device_id: String = vk.as_bytes()[..8]
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect();
+
+    Ok((signing_key, device_id))
+}
+
+/// Attempt AirPlay 2 handshake:
+/// 1. PAIR-VERIFY (fast path for already-paired devices / Allow Everyone).
+/// 2. If PAIR-VERIFY fails with an authentication error, try PAIR-SETUP with `pin`
+///    and then PAIR-VERIFY again.
+///
+/// Returns `Ok(())` on success; caller proceeds with RTSP ANNOUNCE/SETUP/RECORD.
+pub fn connect(host: &str, port: u16, pin: Option<&str>) -> io::Result<()> {
+    let (signing_key, device_id) = load_or_create_identity()?;
+
+    tracing::debug!("device_id={}", device_id);
+
+    // Fast path: just PAIR-VERIFY (works if already paired or server allows everyone)
+    match pair_verify(host, port, &device_id, &signing_key) {
+        Ok(_result) => {
+            tracing::info!("PAIR-VERIFY succeeded");
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::debug!("PAIR-VERIFY failed: {} — trying PAIR-SETUP", e);
+        }
+    }
+
+    // Full pair-setup if we have a PIN (or try with empty string for no-password mode)
+    let pin_str = pin.unwrap_or("00000000");
+    pair_setup(host, port, pin_str, &device_id, &signing_key)?;
+
+    // Retry verify with the freshly obtained credentials
+    pair_verify(host, port, &device_id, &signing_key)?;
+    tracing::info!("connected after PAIR-SETUP + PAIR-VERIFY");
+    Ok(())
+}
+
+fn identity_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".config/rockbox/airplay_identity.key")
+}

--- a/crates/airplay/src/airplay2/pairing.rs
+++ b/crates/airplay/src/airplay2/pairing.rs
@@ -1,0 +1,160 @@
+/// AirPlay 2 PAIR-SETUP (HAP SRP6a, M1-M6).
+///
+/// This is only needed once per device; after completion the server stores
+/// the client's Ed25519 long-term public key and subsequent connections only
+/// need PAIR-VERIFY.
+
+use std::io;
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    ChaCha20Poly1305, Key, Nonce,
+};
+use ed25519_dalek::{Signer, SigningKey};
+use hkdf::Hkdf;
+use sha2::Sha512;
+
+use super::srp::SrpClient;
+use super::tlv8::{self, types::*, Tlv8Item};
+use super::http::http_post_tlv8;
+
+pub fn pair_setup(
+    host: &str,
+    port: u16,
+    pin: &str,
+    device_id: &str,
+    signing_key: &SigningKey,
+) -> io::Result<()> {
+    // --- M1: Start SRP ---
+    let m1 = tlv8::encode(&[
+        Tlv8Item { typ: STATE, value: vec![0x01] },
+        Tlv8Item { typ: METHOD, value: vec![0x00] },
+    ]);
+    tracing::debug!("PAIR-SETUP M1 → {}:{}", host, port);
+    let resp_m2 = http_post_tlv8(host, port, "/pair-setup", &m1)?;
+    let items_m2 = tlv8::decode(&resp_m2);
+    check_state(&items_m2, 2, "PAIR-SETUP M2")?;
+
+    let server_pub = tlv8::find(&items_m2, PUBLIC_KEY)
+        .ok_or_else(|| err("M2: missing PublicKey"))?
+        .to_vec();
+    let salt = tlv8::find(&items_m2, SALT)
+        .ok_or_else(|| err("M2: missing Salt"))?
+        .to_vec();
+
+    // --- M3: Send SRP client key + proof ---
+    let srp = SrpClient::new();
+    let (m1_proof, session_key) = srp
+        .compute("Pair-Setup", pin, &salt, &server_pub)
+        .ok_or_else(|| err("SRP compute failed"))?;
+
+    let m3 = tlv8::encode(&[
+        Tlv8Item { typ: STATE, value: vec![0x03] },
+        Tlv8Item { typ: PUBLIC_KEY, value: srp.a_pub.clone() },
+        Tlv8Item { typ: PROOF, value: m1_proof.clone() },
+    ]);
+    tracing::debug!("PAIR-SETUP M3 → {}:{}", host, port);
+    let resp_m4 = http_post_tlv8(host, port, "/pair-setup", &m3)?;
+    let items_m4 = tlv8::decode(&resp_m4);
+    check_state(&items_m4, 4, "PAIR-SETUP M4")?;
+
+    let server_proof = tlv8::find(&items_m4, PROOF)
+        .ok_or_else(|| err("M4: missing server Proof"))?;
+    if !SrpClient::verify_server(&srp.a_pub, &m1_proof, &session_key, server_proof) {
+        return Err(err("M4: server proof verification failed"));
+    }
+    tracing::debug!("SRP verified");
+
+    // --- M5: Send encrypted client identity ---
+    let encrypt_key = derive_key(&session_key, b"Pair-Setup-Encrypt-Salt", b"Pair-Setup-Encrypt-Info");
+
+    let lt_pub = signing_key.verifying_key();
+    let sig_msg: Vec<u8> = [
+        derive_key(&session_key, b"Pair-Setup-Controller-Sign-Salt", b"Pair-Setup-Controller-Sign-Info").as_slice(),
+        device_id.as_bytes(),
+        lt_pub.as_bytes(),
+    ]
+    .concat();
+    let signature = signing_key.sign(&sig_msg);
+
+    let m5_inner = tlv8::encode(&[
+        Tlv8Item { typ: IDENTIFIER, value: device_id.as_bytes().to_vec() },
+        Tlv8Item { typ: PUBLIC_KEY, value: lt_pub.as_bytes().to_vec() },
+        Tlv8Item { typ: SIGNATURE, value: signature.to_bytes().to_vec() },
+    ]);
+    let encrypted_m5 = chacha_encrypt(&encrypt_key, b"PS-Msg05", &m5_inner)?;
+
+    let m5 = tlv8::encode(&[
+        Tlv8Item { typ: STATE, value: vec![0x05] },
+        Tlv8Item { typ: ENCRYPTED_DATA, value: encrypted_m5 },
+    ]);
+    tracing::debug!("PAIR-SETUP M5 → {}:{}", host, port);
+    let resp_m6 = http_post_tlv8(host, port, "/pair-setup", &m5)?;
+    let items_m6 = tlv8::decode(&resp_m6);
+    check_state(&items_m6, 6, "PAIR-SETUP M6")?;
+
+    let encrypted_m6 = tlv8::find(&items_m6, ENCRYPTED_DATA)
+        .ok_or_else(|| err("M6: missing EncryptedData"))?;
+    let m6_inner = chacha_decrypt(&encrypt_key, b"PS-Msg06", encrypted_m6)?;
+    let items_m6_inner = tlv8::decode(&m6_inner);
+
+    // Store server's long-term public key for future PAIR-VERIFY signature checks
+    if let (Some(server_id), Some(server_ltpk)) = (
+        tlv8::find(&items_m6_inner, IDENTIFIER),
+        tlv8::find(&items_m6_inner, PUBLIC_KEY),
+    ) {
+        save_server_ltpk(server_id, server_ltpk);
+    }
+
+    tracing::info!("PAIR-SETUP complete — device paired");
+    Ok(())
+}
+
+fn derive_key(ikm: &[u8], salt: &[u8], info: &[u8]) -> Vec<u8> {
+    let hk = Hkdf::<Sha512>::new(Some(salt), ikm);
+    let mut okm = vec![0u8; 32];
+    hk.expand(info, &mut okm).expect("hkdf expand");
+    okm
+}
+
+fn chacha_encrypt(key: &[u8], nonce_prefix: &[u8; 8], plaintext: &[u8]) -> io::Result<Vec<u8>> {
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
+    let mut nonce_bytes = [0u8; 12];
+    nonce_bytes[4..].copy_from_slice(nonce_prefix);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    cipher.encrypt(nonce, plaintext).map_err(|_| err("encrypt failed"))
+}
+
+fn chacha_decrypt(key: &[u8], nonce_prefix: &[u8; 8], ciphertext: &[u8]) -> io::Result<Vec<u8>> {
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
+    let mut nonce_bytes = [0u8; 12];
+    nonce_bytes[4..].copy_from_slice(nonce_prefix);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    cipher.decrypt(nonce, ciphertext).map_err(|_| err("decrypt failed"))
+}
+
+fn check_state(items: &[tlv8::Tlv8Item], expected: u8, ctx: &str) -> io::Result<()> {
+    if let Some(state) = tlv8::find(items, STATE) {
+        if state.first() == Some(&expected) {
+            return Ok(());
+        }
+    }
+    if let Some(e) = tlv8::find(items, ERROR) {
+        return Err(err(&format!("{}: error code {:?}", ctx, e)));
+    }
+    Err(err(&format!("{}: unexpected state", ctx)))
+}
+
+fn err(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, msg)
+}
+
+fn save_server_ltpk(server_id: &[u8], ltpk: &[u8]) {
+    let id_hex: String = server_id.iter().map(|b| format!("{:02x}", b)).collect();
+    let dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".config/rockbox");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join(format!("airplay_server_{}.ltpk", id_hex));
+    let _ = std::fs::write(&path, ltpk);
+}

--- a/crates/airplay/src/airplay2/srp.rs
+++ b/crates/airplay/src/airplay2/srp.rs
@@ -1,0 +1,153 @@
+/// SRP6a as used by HAP (HomeKit Accessory Protocol / AirPlay 2 PAIR-SETUP).
+///
+/// Group: 3072-bit prime from RFC 3526 §7, g = 5.
+/// Hash: SHA-512.
+/// Username (I): "Pair-Setup"
+/// Password (P): 8-digit PIN string, e.g. "12345678"
+
+use num_bigint::BigUint;
+use num_traits::Zero;
+use sha2::{Digest, Sha512};
+
+// RFC 3526 3072-bit prime
+const N_HEX: &str = concat!(
+    "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1",
+    "29024E088A67CC74020BBEA63B139B22514A08798E3404DD",
+    "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245",
+    "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED",
+    "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D",
+    "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F",
+    "83655D23DCA3AD961C62F356208552BB9ED529077096966D",
+    "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B",
+    "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9",
+    "DE2BCBF6955817183995497CEA956AE515D2261898FA0510",
+    "15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64",
+    "ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7",
+    "ABF5AE8CDB0933D71E8CE9396A2C4F8C6F8D78D6E3BE6A2E",
+    "F41A7D2CF2F4C3A1B7BC6BBEB12E7A9E01C49B85A6A9D3AF",
+    "F0517867B7EC5D3A8A01B2FE46DC2EF7C18C0A9B7D8EBEA2",
+    "F3B50B8A1EB0ECF5D58B64B1E9B3DAD9D8AD8C0B46BBBDCE",
+    "2DEE6E37",
+);
+const G: u64 = 5;
+
+pub struct SrpClient {
+    n: BigUint,
+    g: BigUint,
+    /// Client private key (random 256-bit)
+    a: BigUint,
+    /// Client public key A = g^a mod N
+    pub a_pub: Vec<u8>,
+}
+
+impl SrpClient {
+    pub fn new() -> Self {
+        let n = BigUint::parse_bytes(N_HEX.as_bytes(), 16).unwrap();
+        let g = BigUint::from(G);
+
+        // Random 256-bit private key
+        let a_bytes: [u8; 32] = rand::random();
+        let a = BigUint::from_bytes_be(&a_bytes);
+        let a_pub = g.modpow(&a, &n).to_bytes_be();
+
+        Self { n, g, a, a_pub }
+    }
+
+    /// Given salt (s) and server public key (B), compute the client proof M1
+    /// and the shared session key K. Returns (M1, K).
+    pub fn compute(
+        &self,
+        username: &str,
+        password: &str,
+        salt: &[u8],
+        b_pub: &[u8],
+    ) -> Option<(Vec<u8>, Vec<u8>)> {
+        let n = &self.n;
+        let g = &self.g;
+        let n_len = (n.bits() as usize + 7) / 8;
+
+        let b = BigUint::from_bytes_be(b_pub);
+        // B must be non-zero and < N
+        if b.is_zero() || b >= *n {
+            return None;
+        }
+
+        // k = H(N | PAD(g))
+        let k = {
+            let mut h = Sha512::new();
+            h.update(pad(n.to_bytes_be(), n_len));
+            h.update(pad(g.to_bytes_be(), n_len));
+            BigUint::from_bytes_be(&h.finalize())
+        };
+
+        // x = H(s | H(I ":" P))
+        let x = {
+            let mut h1 = Sha512::new();
+            h1.update(username.as_bytes());
+            h1.update(b":");
+            h1.update(password.as_bytes());
+            let ih = h1.finalize();
+            let mut h2 = Sha512::new();
+            h2.update(salt);
+            h2.update(&ih);
+            BigUint::from_bytes_be(&h2.finalize())
+        };
+
+        // u = H(PAD(A) | PAD(B))
+        let u = {
+            let mut h = Sha512::new();
+            h.update(pad(self.a_pub.clone(), n_len));
+            h.update(pad(b_pub.to_vec(), n_len));
+            BigUint::from_bytes_be(&h.finalize())
+        };
+
+        // S = (B - k*v)^(a + u*x) mod N  where v = g^x mod N
+        let v = g.modpow(&x, n);
+        let kv = (k * &v) % n;
+        let base = if b >= kv { (b - kv) % n } else { (b + n - kv % n) % n };
+        let exp = (&self.a + &u * &x) % (n - BigUint::from(1u32));
+        let s_val = base.modpow(&exp, n);
+
+        let s_bytes = pad(s_val.to_bytes_be(), n_len);
+
+        // K = H(S)
+        let k_session: Vec<u8> = Sha512::digest(&s_bytes).to_vec();
+
+        // M1 = H(H(N) XOR H(g) | H(I) | s | A | B | K)
+        let h_n: Vec<u8> = Sha512::digest(&pad(n.to_bytes_be(), n_len)).to_vec();
+        let h_g: Vec<u8> = Sha512::digest(&pad(g.to_bytes_be(), n_len)).to_vec();
+        let h_ng: Vec<u8> = h_n.iter().zip(h_g.iter()).map(|(a, b)| a ^ b).collect();
+        let h_i: Vec<u8> = Sha512::digest(username.as_bytes()).to_vec();
+
+        let m1 = {
+            let mut h = Sha512::new();
+            h.update(&h_ng);
+            h.update(&h_i);
+            h.update(salt);
+            h.update(pad(self.a_pub.clone(), n_len));
+            h.update(pad(b_pub.to_vec(), n_len));
+            h.update(&k_session);
+            h.finalize().to_vec()
+        };
+
+        Some((m1, k_session))
+    }
+
+    /// Verify the server's proof M2 = H(A | M1 | K).
+    pub fn verify_server(a_pub: &[u8], m1: &[u8], k: &[u8], m2_server: &[u8]) -> bool {
+        let expected = Sha512::digest(
+            [a_pub, m1, k].concat()
+        );
+        expected.as_slice() == m2_server
+    }
+}
+
+fn pad(mut v: Vec<u8>, len: usize) -> Vec<u8> {
+    if v.len() < len {
+        let mut padded = vec![0u8; len - v.len()];
+        padded.append(&mut v);
+        padded
+    } else {
+        v
+    }
+}

--- a/crates/airplay/src/airplay2/tlv8.rs
+++ b/crates/airplay/src/airplay2/tlv8.rs
@@ -1,0 +1,63 @@
+/// TLV8 type codes used in HAP pairing (AirPlay 2 / HomeKit).
+pub mod types {
+    pub const METHOD: u8 = 0x00;
+    pub const IDENTIFIER: u8 = 0x01;
+    pub const SALT: u8 = 0x02;
+    pub const PUBLIC_KEY: u8 = 0x03;
+    pub const PROOF: u8 = 0x04;
+    pub const ENCRYPTED_DATA: u8 = 0x05;
+    pub const STATE: u8 = 0x06;
+    pub const ERROR: u8 = 0x07;
+    pub const SIGNATURE: u8 = 0x0A;
+    pub const SEPARATOR: u8 = 0xFF;
+}
+
+pub struct Tlv8Item {
+    pub typ: u8,
+    pub value: Vec<u8>,
+}
+
+/// Encode a slice of TLV8 items. Values > 255 bytes are split across fragments
+/// with the same type byte (as required by the HAP spec).
+pub fn encode(items: &[Tlv8Item]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for item in items {
+        if item.value.is_empty() {
+            out.push(item.typ);
+            out.push(0u8);
+        } else {
+            for chunk in item.value.chunks(255) {
+                out.push(item.typ);
+                out.push(chunk.len() as u8);
+                out.extend_from_slice(chunk);
+            }
+        }
+    }
+    out
+}
+
+/// Decode a TLV8 byte stream. Adjacent fragments with the same type are merged.
+pub fn decode(data: &[u8]) -> Vec<Tlv8Item> {
+    let mut items: Vec<Tlv8Item> = Vec::new();
+    let mut i = 0;
+    while i + 1 < data.len() {
+        let typ = data[i];
+        let len = data[i + 1] as usize;
+        i += 2;
+        let end = (i + len).min(data.len());
+        let value = data[i..end].to_vec();
+        i = end;
+        if let Some(last) = items.last_mut() {
+            if last.typ == typ {
+                last.value.extend_from_slice(&value);
+                continue;
+            }
+        }
+        items.push(Tlv8Item { typ, value });
+    }
+    items
+}
+
+pub fn find(items: &[Tlv8Item], typ: u8) -> Option<&[u8]> {
+    items.iter().find(|i| i.typ == typ).map(|i| i.value.as_slice())
+}

--- a/crates/airplay/src/airplay2/verify.rs
+++ b/crates/airplay/src/airplay2/verify.rs
@@ -1,0 +1,178 @@
+use std::io;
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    ChaCha20Poly1305, Key, Nonce,
+};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use hkdf::Hkdf;
+use sha2::Sha512;
+use x25519_dalek::{EphemeralSecret, PublicKey as X25519Public};
+
+use super::tlv8::{self, types::*, Tlv8Item};
+use super::http::http_post_tlv8;
+
+pub struct VerifyResult {
+    /// Derived session key (32 bytes) — used for media encryption if needed.
+    pub session_key: Vec<u8>,
+}
+
+/// Perform AirPlay 2 PAIR-VERIFY (M1→M4) against `host:port`.
+///
+/// Uses the client's persistent `signing_key` (Ed25519) as the long-term
+/// identity that was registered during PAIR-SETUP.
+pub fn pair_verify(
+    host: &str,
+    port: u16,
+    device_id: &str,
+    signing_key: &SigningKey,
+) -> io::Result<VerifyResult> {
+    // --- M1: send ephemeral Curve25519 public key ---
+    let ephemeral_secret = EphemeralSecret::random_from_rng(rand::thread_rng());
+    let ephemeral_pub = X25519Public::from(&ephemeral_secret);
+
+    let m1 = tlv8::encode(&[
+        Tlv8Item { typ: STATE, value: vec![0x01] },
+        Tlv8Item { typ: PUBLIC_KEY, value: ephemeral_pub.as_bytes().to_vec() },
+    ]);
+
+    tracing::debug!("PAIR-VERIFY M1 → {}:{}", host, port);
+    let resp_m2 = http_post_tlv8(host, port, "/pair-verify", &m1)?;
+    let items_m2 = tlv8::decode(&resp_m2);
+
+    check_state(&items_m2, 2, "PAIR-VERIFY M2")?;
+
+    let server_pub_bytes = tlv8::find(&items_m2, PUBLIC_KEY)
+        .ok_or_else(|| err("PAIR-VERIFY M2: missing PublicKey"))?;
+    let encrypted_m2 = tlv8::find(&items_m2, ENCRYPTED_DATA)
+        .ok_or_else(|| err("PAIR-VERIFY M2: missing EncryptedData"))?;
+
+    let server_pub_arr: [u8; 32] = server_pub_bytes
+        .try_into()
+        .map_err(|_| err("PAIR-VERIFY M2: PublicKey wrong length"))?;
+    let server_pub = X25519Public::from(server_pub_arr);
+
+    // --- ECDH + derive verify-encrypt key ---
+    let shared = ephemeral_secret.diffie_hellman(&server_pub);
+    let verify_key = derive_key(
+        shared.as_bytes(),
+        b"Pair-Verify-Encrypt-Salt",
+        b"Pair-Verify-Encrypt-Info",
+    );
+
+    // --- Decrypt M2 server data ---
+    let m2_inner = chacha_decrypt(&verify_key, b"PV-Msg02", encrypted_m2)?;
+    let items_inner = tlv8::decode(&m2_inner);
+
+    // Verify server signature over <server_curve25519_pub || client_curve25519_pub>
+    if let Some(server_id) = tlv8::find(&items_inner, IDENTIFIER) {
+        if let Some(sig_bytes) = tlv8::find(&items_inner, SIGNATURE) {
+            if let (Some(server_ltpk), _) = load_server_ltpk(server_id) {
+                let msg: Vec<u8> = [server_pub.as_bytes().as_ref(), ephemeral_pub.as_bytes().as_ref()].concat();
+                if let Ok(sig) = ed25519_dalek::Signature::from_slice(sig_bytes) {
+                    let _ = server_ltpk.verify_strict(&msg, &sig); // log but don't abort
+                }
+            }
+        }
+    }
+
+    // --- M3: send client signature encrypted ---
+    let msg: Vec<u8> = [ephemeral_pub.as_bytes().as_ref(), server_pub.as_bytes().as_ref()].concat();
+    let client_sig = signing_key.sign(&msg);
+
+    let m3_inner = tlv8::encode(&[
+        Tlv8Item { typ: IDENTIFIER, value: device_id.as_bytes().to_vec() },
+        Tlv8Item { typ: SIGNATURE, value: client_sig.to_bytes().to_vec() },
+    ]);
+    let encrypted_m3 = chacha_encrypt(&verify_key, b"PV-Msg03", &m3_inner)?;
+
+    let m3 = tlv8::encode(&[
+        Tlv8Item { typ: STATE, value: vec![0x03] },
+        Tlv8Item { typ: ENCRYPTED_DATA, value: encrypted_m3 },
+    ]);
+
+    tracing::debug!("PAIR-VERIFY M3 → {}:{}", host, port);
+    let resp_m4 = http_post_tlv8(host, port, "/pair-verify", &m3)?;
+    let items_m4 = tlv8::decode(&resp_m4);
+    check_state(&items_m4, 4, "PAIR-VERIFY M4")?;
+    tracing::debug!("PAIR-VERIFY complete");
+
+    // Derive session key
+    let session_key = derive_key(
+        shared.as_bytes(),
+        b"MediaRemote-Salt",
+        b"MediaRemote-Key",
+    );
+
+    Ok(VerifyResult { session_key })
+}
+
+fn derive_key(ikm: &[u8], salt: &[u8], info: &[u8]) -> Vec<u8> {
+    let hk = Hkdf::<Sha512>::new(Some(salt), ikm);
+    let mut okm = vec![0u8; 32];
+    hk.expand(info, &mut okm).expect("hkdf expand");
+    okm
+}
+
+fn chacha_decrypt(key: &[u8], nonce_prefix: &[u8; 8], ciphertext: &[u8]) -> io::Result<Vec<u8>> {
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
+    // HAP uses 12-byte nonce: 4 zero bytes + 8-byte label
+    let mut nonce_bytes = [0u8; 12];
+    nonce_bytes[4..].copy_from_slice(nonce_prefix);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| err("ChaCha20 decrypt failed"))
+}
+
+fn chacha_encrypt(key: &[u8], nonce_prefix: &[u8; 8], plaintext: &[u8]) -> io::Result<Vec<u8>> {
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
+    let mut nonce_bytes = [0u8; 12];
+    nonce_bytes[4..].copy_from_slice(nonce_prefix);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| err("ChaCha20 encrypt failed"))
+}
+
+fn check_state(items: &[tlv8::Tlv8Item], expected: u8, ctx: &str) -> io::Result<()> {
+    if let Some(state) = tlv8::find(items, STATE) {
+        if state.first() == Some(&expected) {
+            return Ok(());
+        }
+    }
+    if let Some(error) = tlv8::find(items, ERROR) {
+        return Err(err(&format!("{}: error code {:?}", ctx, error)));
+    }
+    Err(err(&format!("{}: unexpected state", ctx)))
+}
+
+fn err(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, msg)
+}
+
+/// Look up a previously stored server long-term public key by server identifier.
+/// Returns (Some(verifying_key), true) if found, (None, false) otherwise.
+fn load_server_ltpk(server_id: &[u8]) -> (Option<VerifyingKey>, bool) {
+    let path = server_ltpk_path(server_id);
+    if let Ok(bytes) = std::fs::read(&path) {
+        if bytes.len() == 32 {
+            if let Ok(vk) = VerifyingKey::from_bytes(bytes.as_slice().try_into().unwrap()) {
+                return (Some(vk), true);
+            }
+        }
+    }
+    (None, false)
+}
+
+fn server_ltpk_path(server_id: &[u8]) -> std::path::PathBuf {
+    let id_hex = server_id.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+    let dir = dirs_config();
+    dir.join(format!("airplay_server_{}.ltpk", id_hex))
+}
+
+fn dirs_config() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".config/rockbox")
+}

--- a/crates/airplay/src/alac.rs
+++ b/crates/airplay/src/alac.rs
@@ -1,0 +1,76 @@
+// ALAC verbatim/escape frame encoder for 352 stereo 16-bit PCM samples.
+//
+// Layout matching David Hammerton's ALAC decoder (used by shairport-sync).
+// The hammerton decoder does NOT parse AAC element-type tags from the bitstream;
+// instead the first 3 bits are a "channel count" field (value 1 = stereo), and
+// there is NO 4-bit element-instance field after it.
+//
+//   3 bits  channels = 0b001 (1 = stereo)
+//   4 bits  output_waiting = 0   (read and discarded)
+//  12 bits  unknown = 0          (read and discarded)
+//   1 bit   hassize = 0
+//   2 bits  uncompressed_bytes = 0
+//   1 bit   isNotCompressed = 1   ← bit 22 from frame start
+//   352 × (16-bit left, 16-bit right) — interleaved per sample
+//   pad to byte boundary            (no END tag)
+//   → total: 23 + 352×32 = 11287 bits → 1411 bytes
+
+pub const FRAME_SAMPLES: usize = 352;
+pub const PCM_BYTES_PER_FRAME: usize = FRAME_SAMPLES * 4; // stereo S16LE
+pub const ALAC_FRAME_BYTES: usize = 1411;
+
+struct BitWriter<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> BitWriter<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn write(&mut self, value: u32, nbits: usize) {
+        for i in (0..nbits).rev() {
+            let bit = (value >> i) & 1;
+            let byte_idx = self.pos / 8;
+            let bit_idx = 7 - (self.pos % 8);
+            if bit == 1 {
+                self.buf[byte_idx] |= 1 << bit_idx;
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn align(&mut self) {
+        if self.pos % 8 != 0 {
+            self.pos = (self.pos + 7) & !7;
+        }
+    }
+}
+
+pub fn encode_frame(pcm: &[u8]) -> [u8; ALAC_FRAME_BYTES] {
+    assert_eq!(pcm.len(), PCM_BYTES_PER_FRAME);
+    let mut out = [0u8; ALAC_FRAME_BYTES];
+    let mut w = BitWriter::new(&mut out);
+
+    // 23-bit header — matches the exact readbits() sequence in hammerton alac.c:
+    w.write(0b001, 3); // channels = 1 (stereo); decoder: readbits(3)
+    w.write(0, 4);     // output_waiting;          decoder: readbits(4) — discarded
+    w.write(0, 12);    // unknown;                  decoder: readbits(12) — discarded
+    w.write(0, 1);     // hassize = 0;              decoder: readbits(1)
+    w.write(0, 2);     // uncompressed_bytes = 0;   decoder: readbits(2)
+    w.write(1, 1);     // isNotCompressed = 1;      decoder: readbits(1) — bit 22
+
+    // Interleaved samples: L0, R0, L1, R1, ...
+    for i in 0..FRAME_SAMPLES {
+        let base = i * 4;
+        let l = i16::from_le_bytes([pcm[base],     pcm[base + 1]]) as u16 as u32;
+        let r = i16::from_le_bytes([pcm[base + 2], pcm[base + 3]]) as u16 as u32;
+        w.write(l, 16);
+        w.write(r, 16);
+    }
+
+    w.align(); // pad to byte boundary (hammerton has no END tag)
+
+    out
+}

--- a/crates/airplay/src/lib.rs
+++ b/crates/airplay/src/lib.rs
@@ -1,0 +1,197 @@
+mod airplay2;
+mod alac;
+mod rtp;
+mod rtsp;
+
+// Called from rockbox-cli to force this crate's symbols into librockbox_cli.a
+#[doc(hidden)]
+pub fn _link_airplay() {}
+
+use alac::{encode_frame, PCM_BYTES_PER_FRAME};
+use rtp::RtpSender;
+use rtsp::RtspClient;
+
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_ushort};
+use std::sync::Mutex;
+
+static SESSION: Mutex<Option<AirPlaySession>> = Mutex::new(None);
+
+struct AirPlaySession {
+    sender: RtpSender,
+    rtsp: RtspClient,
+    buf: Vec<u8>,
+    first_frame: bool,
+}
+
+static CONFIG: Mutex<AirPlayConfig> = Mutex::new(AirPlayConfig {
+    host: None,
+    port: 5000,
+});
+
+struct AirPlayConfig {
+    host: Option<String>,
+    port: u16,
+}
+
+// Safety: the raw pointer in host is only touched inside the mutex
+unsafe impl Send for AirPlayConfig {}
+
+#[no_mangle]
+pub extern "C" fn pcm_airplay_set_host(host: *const c_char, port: c_ushort) {
+    if host.is_null() {
+        return;
+    }
+    let s = unsafe { CStr::from_ptr(host) }.to_string_lossy().into_owned();
+    let mut cfg = CONFIG.lock().unwrap();
+    cfg.host = Some(s);
+    cfg.port = port;
+}
+
+#[no_mangle]
+pub extern "C" fn pcm_airplay_connect() -> c_int {
+    // Already connected — don't redo the RTSP handshake for every DMA chunk.
+    if SESSION.lock().unwrap().is_some() {
+        return 0;
+    }
+
+    let cfg = CONFIG.lock().unwrap();
+    let host = match cfg.host.clone() {
+        Some(h) => h,
+        None => {
+            tracing::error!("pcm_airplay_connect: no host configured");
+            return -1;
+        }
+    };
+    let port = cfg.port;
+    drop(cfg);
+
+    let local_ip = local_ip_for(&host).unwrap_or_else(|| "127.0.0.1".to_string());
+    tracing::info!("connecting to {}:{} (local_ip={})", host, port, local_ip);
+
+    // Attempt AirPlay 2 pairing (PAIR-VERIFY / PAIR-SETUP).
+    // Failure here is non-fatal — many AirPlay 1 receivers don't have the endpoint.
+    match airplay2::connect(&host, port, None) {
+        Ok(()) => tracing::info!("AirPlay 2 handshake complete"),
+        Err(e) => tracing::debug!("AirPlay 2 handshake skipped ({}), using AirPlay 1", e),
+    }
+
+    let session_token: u64 = rand::random();
+    let ssrc: u32 = rand::random();
+    let initial_rtptime: u32 = rand::random();
+
+    // Bind all UDP sockets first so we know the local ports before SETUP.
+    let mut sender = match RtpSender::bind(ssrc, initial_rtptime) {
+        Ok(s) => s,
+        Err(e) => { tracing::error!("bind failed: {}", e); return -1; }
+    };
+    let local_ctrl_port   = sender.local_ctrl_port;
+    let local_timing_port = sender.local_timing_port;
+
+    let mut rtsp = match RtspClient::connect(&host, port, session_token) {
+        Ok(c) => c,
+        Err(e) => { tracing::error!("RTSP TCP connect failed: {}", e); return -1; }
+    };
+
+    if let Err(e) = rtsp.announce(&local_ip, &host) {
+        tracing::error!("ANNOUNCE failed: {}", e);
+        return -1;
+    }
+
+    let (server_audio, server_ctrl, _server_timing) =
+        match rtsp.setup(local_ctrl_port, local_timing_port) {
+            Ok(ports) => ports,
+            Err(e) => { tracing::error!("SETUP failed: {}", e); return -1; }
+        };
+
+    if let Err(e) = sender.connect_server(&host, server_audio, server_ctrl) {
+        tracing::error!("connect_server failed: {}", e);
+        return -1;
+    }
+
+    if let Err(e) = rtsp.record(0, initial_rtptime) {
+        tracing::error!("RECORD failed: {}", e);
+        return -1;
+    }
+
+    // Set volume to maximum; RAOP range: -144.0 (mute) to 0.0 (full).
+    if let Err(e) = rtsp.set_parameter_volume(0.0) {
+        tracing::warn!("SET_PARAMETER volume failed (non-fatal): {}", e);
+    }
+
+    sender.send_initial_sync();
+    tracing::info!("session established — sending audio to {}:{}", host, server_audio);
+
+    let mut guard = SESSION.lock().unwrap();
+    *guard = Some(AirPlaySession {
+        sender,
+        rtsp,
+        buf: Vec::with_capacity(PCM_BYTES_PER_FRAME * 4),
+        first_frame: true,
+    });
+
+    0
+}
+
+/// Write raw S16LE stereo PCM. Buffers into 352-sample frames, encodes ALAC, sends RTP.
+#[no_mangle]
+pub extern "C" fn pcm_airplay_write(data: *const u8, len: usize) -> c_int {
+    if data.is_null() || len == 0 {
+        return 0;
+    }
+    let input = unsafe { std::slice::from_raw_parts(data, len) };
+
+    let mut guard = SESSION.lock().unwrap();
+    let session = match guard.as_mut() {
+        Some(s) => s,
+        None => {
+            tracing::warn!("pcm_airplay_write: no session");
+            return -1;
+        }
+    };
+
+    if session.first_frame {
+        tracing::debug!("first write: {} bytes", len);
+    }
+
+    session.buf.extend_from_slice(input);
+
+    while session.buf.len() >= PCM_BYTES_PER_FRAME {
+        let frame_bytes: [u8; PCM_BYTES_PER_FRAME] = session.buf[..PCM_BYTES_PER_FRAME]
+            .try_into()
+            .unwrap();
+        session.buf.drain(..PCM_BYTES_PER_FRAME);
+
+        let alac = encode_frame(&frame_bytes);
+        let first = session.first_frame;
+        session.first_frame = false;
+        session.sender.send_audio(&alac, first);
+    }
+
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn pcm_airplay_stop() {
+    let mut guard = SESSION.lock().unwrap();
+    if let Some(ref mut session) = *guard {
+        let _ = session.rtsp.teardown();
+    }
+    *guard = None;
+}
+
+#[no_mangle]
+pub extern "C" fn pcm_airplay_close() {
+    let mut guard = SESSION.lock().unwrap();
+    if let Some(ref mut session) = *guard {
+        let _ = session.rtsp.teardown();
+    }
+    *guard = None;
+}
+
+fn local_ip_for(remote: &str) -> Option<String> {
+    use std::net::UdpSocket;
+    let sock = UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect(format!("{}:80", remote)).ok()?;
+    sock.local_addr().ok().map(|a| a.ip().to_string())
+}

--- a/crates/airplay/src/rtp.rs
+++ b/crates/airplay/src/rtp.rs
@@ -1,0 +1,244 @@
+use std::net::UdpSocket;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::alac::{ALAC_FRAME_BYTES, FRAME_SAMPLES};
+
+const RTP_HEADER_BYTES: usize = 12;
+pub const RTP_PACKET_BYTES: usize = RTP_HEADER_BYTES + ALAC_FRAME_BYTES;
+
+const NTP_EPOCH_DELTA: u32 = 0x83AA_7E80;
+
+// Duration of one ALAC frame at 44100 Hz
+const FRAME_DURATION_US: u64 = FRAME_SAMPLES as u64 * 1_000_000 / 44100; // ~7982 µs
+
+pub struct RtpSender {
+    audio_sock: UdpSocket,
+    ctrl_sock: UdpSocket,
+    server_ctrl_addr: std::net::SocketAddr,
+    ssrc: u32,
+    seqnum: u16,
+    rtptime: u32,
+    initial_rtptime: u32,
+    frames_sent: u64,
+    pub local_ctrl_port: u16,
+    pub local_timing_port: u16,
+    stream_start: Option<Instant>,
+    // kept alive so the OS port stays open; responder thread holds the other Arc
+    _timing_sock: Arc<UdpSocket>,
+}
+
+impl RtpSender {
+    /// Bind all local UDP sockets. `connect_server()` must be called after SETUP
+    /// once the server's ports are known.
+    pub fn bind(ssrc: u32, initial_rtptime: u32) -> std::io::Result<Self> {
+        let audio_sock = UdpSocket::bind("0.0.0.0:0")?;
+        let ctrl_sock = UdpSocket::bind("0.0.0.0:0")?;
+        let local_ctrl_port = ctrl_sock.local_addr()?.port();
+        let timing_sock = Arc::new(UdpSocket::bind("0.0.0.0:0")?);
+        let local_timing_port = timing_sock.local_addr()?.port();
+
+        // Respond to NTP timing requests from the receiver so it can synchronise
+        // and actually start playing. Without this, the timing port gets ICMP
+        // unreachable replies and many receivers stall indefinitely.
+        let timing_thread = Arc::clone(&timing_sock);
+        thread::spawn(move || timing_responder(timing_thread));
+
+        let server_ctrl_addr = "0.0.0.0:0".parse().unwrap();
+        tracing::debug!("local ctrl_port={} timing_port={}", local_ctrl_port, local_timing_port);
+
+        Ok(Self {
+            audio_sock,
+            ctrl_sock,
+            server_ctrl_addr,
+            ssrc,
+            seqnum: 0,
+            rtptime: initial_rtptime,
+            initial_rtptime,
+            frames_sent: 0,
+            local_ctrl_port,
+            local_timing_port,
+            stream_start: None,
+            _timing_sock: timing_sock,
+        })
+    }
+
+    /// Connect the audio socket to the server's RTP port and record the ctrl addr.
+    pub fn connect_server(&mut self, host: &str, audio_port: u16, ctrl_port: u16) -> std::io::Result<()> {
+        tracing::debug!("connecting audio → {}:{}", host, audio_port);
+        self.audio_sock.connect(format!("{}:{}", host, audio_port))?;
+        self.server_ctrl_addr = format!("{}:{}", host, ctrl_port)
+            .parse()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+        Ok(())
+    }
+
+    pub fn send_audio(&mut self, alac_frame: &[u8; ALAC_FRAME_BYTES], first: bool) {
+        let start = *self.stream_start.get_or_insert_with(Instant::now);
+
+        let mut pkt = [0u8; RTP_PACKET_BYTES];
+        pkt[0] = 0x80;
+        pkt[1] = if first { 0x60 | 0x80 } else { 0x60 }; // M=1 on first, PT=96
+        pkt[2] = (self.seqnum >> 8) as u8;
+        pkt[3] = self.seqnum as u8;
+        pkt[4] = (self.rtptime >> 24) as u8;
+        pkt[5] = (self.rtptime >> 16) as u8;
+        pkt[6] = (self.rtptime >> 8) as u8;
+        pkt[7] = self.rtptime as u8;
+        pkt[8]  = (self.ssrc >> 24) as u8;
+        pkt[9]  = (self.ssrc >> 16) as u8;
+        pkt[10] = (self.ssrc >> 8) as u8;
+        pkt[11] = self.ssrc as u8;
+        pkt[RTP_HEADER_BYTES..].copy_from_slice(alac_frame);
+
+        match self.audio_sock.send(&pkt) {
+            Ok(_) => {
+                if self.frames_sent < 5 {
+                    tracing::debug!("sent frame {} ts={} seq={} first={}",
+                              self.frames_sent, self.rtptime, self.seqnum, first);
+                }
+            }
+            Err(e) => tracing::warn!("send error on frame {}: {}", self.frames_sent, e),
+        }
+
+        self.seqnum = self.seqnum.wrapping_add(1);
+        self.rtptime = self.rtptime.wrapping_add(FRAME_SAMPLES as u32);
+        self.frames_sent += 1;
+
+        // RTCP NTP sync every ~44 frames (~0.35 s)
+        if self.frames_sent % 44 == 0 {
+            self.send_sync(false);
+        }
+
+        // Real-time pacing — sleep until the frame's playout deadline.
+        let expected = start + Duration::from_micros(self.frames_sent * FRAME_DURATION_US);
+        let now = Instant::now();
+        if expected > now {
+            std::thread::sleep(expected - now);
+        }
+    }
+
+    fn send_sync(&self, first: bool) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        let ntp_sec  = now.as_secs() as u32 + NTP_EPOCH_DELTA;
+        let ntp_frac = ((now.subsec_nanos() as u64 * (1u64 << 32)) / 1_000_000_000) as u32;
+
+        // "current" timestamp = frame we just sent (rtptime was already incremented)
+        let current_ts = self.rtptime.wrapping_sub(FRAME_SAMPLES as u32);
+        // "next" timestamp = self.rtptime (next frame to be sent)
+        let next_ts = self.rtptime;
+
+        let mut pkt = [0u8; 20];
+        pkt[0] = if first { 0x90 } else { 0x80 };
+        pkt[1] = 0xd4;
+        pkt[2] = 0x00;
+        pkt[3] = 0x07;
+        pkt[4]  = (current_ts >> 24) as u8;
+        pkt[5]  = (current_ts >> 16) as u8;
+        pkt[6]  = (current_ts >> 8)  as u8;
+        pkt[7]  =  current_ts        as u8;
+        pkt[8]  = (ntp_sec >> 24)    as u8;
+        pkt[9]  = (ntp_sec >> 16)    as u8;
+        pkt[10] = (ntp_sec >> 8)     as u8;
+        pkt[11] =  ntp_sec           as u8;
+        pkt[12] = (ntp_frac >> 24)   as u8;
+        pkt[13] = (ntp_frac >> 16)   as u8;
+        pkt[14] = (ntp_frac >> 8)    as u8;
+        pkt[15] =  ntp_frac          as u8;
+        pkt[16] = (next_ts >> 24)    as u8;
+        pkt[17] = (next_ts >> 16)    as u8;
+        pkt[18] = (next_ts >> 8)     as u8;
+        pkt[19] =  next_ts           as u8;
+
+        let _ = self.ctrl_sock.send_to(&pkt, self.server_ctrl_addr);
+    }
+
+    pub fn send_initial_sync(&self) {
+        // At startup no frames have been sent yet; use initial_rtptime for both
+        // "current" and "next" so we don't send a backwards-wrapped timestamp.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        let ntp_sec  = now.as_secs() as u32 + NTP_EPOCH_DELTA;
+        let ntp_frac = ((now.subsec_nanos() as u64 * (1u64 << 32)) / 1_000_000_000) as u32;
+        let ts = self.initial_rtptime;
+
+        let mut pkt = [0u8; 20];
+        pkt[0]  = 0x90; // first sync: extension bit set
+        pkt[1]  = 0xd4;
+        pkt[2]  = 0x00;
+        pkt[3]  = 0x07;
+        pkt[4]  = (ts >> 24) as u8;
+        pkt[5]  = (ts >> 16) as u8;
+        pkt[6]  = (ts >>  8) as u8;
+        pkt[7]  =  ts        as u8;
+        pkt[8]  = (ntp_sec  >> 24) as u8;
+        pkt[9]  = (ntp_sec  >> 16) as u8;
+        pkt[10] = (ntp_sec  >>  8) as u8;
+        pkt[11] =  ntp_sec         as u8;
+        pkt[12] = (ntp_frac >> 24) as u8;
+        pkt[13] = (ntp_frac >> 16) as u8;
+        pkt[14] = (ntp_frac >>  8) as u8;
+        pkt[15] =  ntp_frac        as u8;
+        pkt[16] = (ts >> 24) as u8;
+        pkt[17] = (ts >> 16) as u8;
+        pkt[18] = (ts >>  8) as u8;
+        pkt[19] =  ts        as u8;
+
+        let _ = self.ctrl_sock.send_to(&pkt, self.server_ctrl_addr);
+        tracing::debug!("sent initial sync ts={}", ts);
+    }
+
+    pub fn reset_clock(&mut self) {
+        self.stream_start = None;
+        self.frames_sent = 0;
+    }
+}
+
+// RAOP NTP timing responder.
+//
+// The receiver sends 32-byte timing requests (PT=0xD2) on the timing port we
+// advertised in SETUP. We reply with PT=0xD3 so it can synchronise playback.
+fn timing_responder(sock: Arc<UdpSocket>) {
+    let mut buf = [0u8; 64];
+    loop {
+        let (len, src) = match sock.recv_from(&mut buf) {
+            Ok(x) => x,
+            Err(_) => break,
+        };
+        if len < 32 || buf[1] != 0xD2 {
+            tracing::debug!("timing: unexpected packet len={} type=0x{:02X} from {}", len, buf[1], src);
+            continue;
+        }
+        tracing::debug!("timing request from {}", src);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        let ntp_sec  = now.as_secs() as u32 + NTP_EPOCH_DELTA;
+        let ntp_frac = ((now.subsec_nanos() as u64 * (1u64 << 32)) / 1_000_000_000) as u32;
+
+        let mut resp = [0u8; 32];
+        resp[0] = 0x80;
+        resp[1] = 0xD3; // timing response
+        resp[2] = buf[2]; // seq
+        resp[3] = buf[3];
+        // [8-15] reference — leave as zero
+        // [16-23] originate = client's send time from request [16-23]
+        resp[16..24].copy_from_slice(&buf[16..24]);
+        // [24-31] receive + transmit = our current NTP
+        resp[24] = (ntp_sec >> 24) as u8;
+        resp[25] = (ntp_sec >> 16) as u8;
+        resp[26] = (ntp_sec >> 8)  as u8;
+        resp[27] =  ntp_sec        as u8;
+        resp[28] = (ntp_frac >> 24) as u8;
+        resp[29] = (ntp_frac >> 16) as u8;
+        resp[30] = (ntp_frac >> 8)  as u8;
+        resp[31] =  ntp_frac        as u8;
+
+        let _ = sock.send_to(&resp, src);
+    }
+}

--- a/crates/airplay/src/rtsp.rs
+++ b/crates/airplay/src/rtsp.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+use std::io::{self, BufRead, BufReader, Write as IoWrite};
+use std::net::TcpStream;
+
+pub struct RtspClient {
+    stream: TcpStream,
+    reader: BufReader<TcpStream>,
+    cseq: u32,
+    pub session_id: Option<String>,
+    base_url: String,
+    dacp_id: u64,
+    active_remote: u32,
+}
+
+/// RTSP response: status code + headers.
+struct Response {
+    status: u16,
+    headers: HashMap<String, String>,
+}
+
+impl RtspClient {
+    pub fn connect(host: &str, port: u16, session_token: u64) -> io::Result<Self> {
+        let stream = TcpStream::connect(format!("{}:{}", host, port))?;
+        let reader = BufReader::new(stream.try_clone()?);
+        // Use a plain decimal session id — some receivers choke on hex
+        let base_url = format!("rtsp://{}:{}/{}", host, port, session_token);
+        let dacp_id: u64 = rand::random();
+        let active_remote: u32 = rand::random();
+        Ok(Self { stream, reader, cseq: 0, session_id: None, base_url, dacp_id, active_remote })
+    }
+
+    fn send_request(
+        &mut self,
+        method: &str,
+        uri: &str,
+        headers: &[(&str, &str)],
+        body: Option<&str>,
+    ) -> io::Result<Response> {
+        self.cseq += 1;
+        let dacp_str = format!("{:016X}", self.dacp_id);
+        let active_str = format!("{}", self.active_remote);
+        let mut req = format!(
+            "{} {} RTSP/1.0\r\nCSeq: {}\r\nUser-Agent: iTunes/12.0 (Rockbox)\r\nClient-Instance: {}\r\nDacp-ID: {}\r\nActive-Remote: {}\r\n",
+            method, uri, self.cseq, dacp_str, dacp_str, active_str,
+        );
+        for (k, v) in headers {
+            req.push_str(&format!("{}: {}\r\n", k, v));
+        }
+        if let Some(b) = body {
+            req.push_str(&format!("Content-Length: {}\r\n", b.len()));
+        }
+        req.push_str("\r\n");
+        if let Some(b) = body {
+            req.push_str(b);
+        }
+        tracing::debug!(">> {} {}", method, uri);
+        self.stream.write_all(req.as_bytes())?;
+        self.stream.flush()?;
+        self.read_response()
+    }
+
+    fn read_response(&mut self) -> io::Result<Response> {
+        let mut status_line = String::new();
+        self.reader.read_line(&mut status_line)?;
+        let status_line = status_line.trim().to_string();
+        tracing::debug!("<< {}", status_line);
+
+        let status: u16 = status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let mut headers = HashMap::new();
+        loop {
+            let mut line = String::new();
+            self.reader.read_line(&mut line)?;
+            let trimmed = line.trim_end_matches(|c| c == '\r' || c == '\n');
+            if trimmed.is_empty() {
+                break;
+            }
+            tracing::debug!("<< {}", trimmed);
+            if let Some((key, val)) = trimmed.split_once(':') {
+                headers.insert(key.trim().to_lowercase(), val.trim().to_string());
+            }
+        }
+
+        // Consume body
+        if let Some(len_str) = headers.get("content-length") {
+            if let Ok(len) = len_str.parse::<usize>() {
+                let mut body = vec![0u8; len];
+                use std::io::Read;
+                self.reader.read_exact(&mut body)?;
+            }
+        }
+
+        Ok(Response { status, headers })
+    }
+
+    fn check_ok(resp: &Response, method: &str) -> io::Result<()> {
+        if resp.status != 200 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("RTSP {} returned status {}", method, resp.status),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn announce(&mut self, local_ip: &str, server_ip: &str) -> io::Result<()> {
+        // m=audio 0: port 0 because the client is the sender; server port comes from SETUP
+        let sdp = format!(
+            "v=0\r\n\
+             o=iTunes 3413821438 0 IN IP4 {local_ip}\r\n\
+             s=iTunes\r\n\
+             c=IN IP4 {server_ip}\r\n\
+             t=0 0\r\n\
+             m=audio 0 RTP/AVP 96\r\n\
+             a=rtpmap:96 AppleLossless\r\n\
+             a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n\
+             a=min-latency:3528\r\n"
+        );
+        let url = self.base_url.clone();
+        let resp = self.send_request("ANNOUNCE", &url, &[
+            ("Content-Type", "application/sdp"),
+        ], Some(&sdp))?;
+        Self::check_ok(&resp, "ANNOUNCE")
+    }
+
+    /// Returns (server_audio_port, server_ctrl_port, server_timing_port).
+    pub fn setup(&mut self, local_ctrl_port: u16, local_timing_port: u16) -> io::Result<(u16, u16, u16)> {
+        // interleaved=0-1 is required by Apple receivers even for UDP transport.
+        let transport = format!(
+            "RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;control_port={};timing_port={}",
+            local_ctrl_port, local_timing_port
+        );
+        let url = self.base_url.clone();
+        let resp = self.send_request("SETUP", &url, &[
+            ("Transport", &transport),
+        ], None)?;
+        Self::check_ok(&resp, "SETUP")?;
+
+        if let Some(sid) = resp.headers.get("session") {
+            self.session_id = Some(sid.split(';').next().unwrap_or(sid).trim().to_string());
+        }
+
+        let transport_resp = resp.headers.get("transport").cloned().unwrap_or_default();
+        let server_audio  = parse_port(&transport_resp, "server_port").unwrap_or(6000);
+        let server_ctrl   = parse_port(&transport_resp, "control_port").unwrap_or(6001);
+        let server_timing = parse_port(&transport_resp, "timing_port").unwrap_or(6002);
+        tracing::debug!("server ports: audio={} ctrl={} timing={}", server_audio, server_ctrl, server_timing);
+        Ok((server_audio, server_ctrl, server_timing))
+    }
+
+    pub fn record(&mut self, seqnum: u16, rtptime: u32) -> io::Result<()> {
+        let rtp_info = format!("seq={};rtptime={}", seqnum, rtptime);
+        let sid = self.session_id.clone().unwrap_or_default();
+        let url = self.base_url.clone();
+        let all_hdrs: Vec<(&str, &str)> = vec![
+            ("Range", "npt=0-"),
+            ("Session", &sid),
+            ("RTP-Info", &rtp_info),
+        ];
+        let resp = self.send_request("RECORD", &url, &all_hdrs, None)?;
+        Self::check_ok(&resp, "RECORD")
+    }
+
+    /// Send SET_PARAMETER with a `volume` value in RAOP range [-144.0, 0.0].
+    /// 0.0 = full volume, -144.0 = mute.
+    pub fn set_parameter_volume(&mut self, volume: f32) -> io::Result<()> {
+        let body = format!("volume: {:.6}\r\n", volume);
+        let sid = self.session_id.clone().unwrap_or_default();
+        let url = self.base_url.clone();
+        let resp = self.send_request("SET_PARAMETER", &url, &[
+            ("Session", &sid),
+            ("Content-Type", "text/parameters"),
+        ], Some(&body))?;
+        Self::check_ok(&resp, "SET_PARAMETER")
+    }
+
+    pub fn teardown(&mut self) -> io::Result<()> {
+        let sid = self.session_id.clone().unwrap_or_default();
+        let url = self.base_url.clone();
+        let resp = self.send_request("TEARDOWN", &url, &[("Session", &sid)], None)?;
+        Self::check_ok(&resp, "TEARDOWN")
+    }
+}
+
+fn parse_port(transport: &str, key: &str) -> Option<u16> {
+    for part in transport.split(';') {
+        let part = part.trim();
+        if let Some(rest) = part.strip_prefix(key) {
+            let rest = rest.trim_start_matches('=');
+            return rest.split('-').next()?.parse().ok();
+        }
+    }
+    None
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 anyhow = "1.0.90"
+rockbox-airplay = {path = "../airplay"}
 clap = "4.5.16"
 owo-colors = "4.1.0"
 rockbox-library = {path = "../library"}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,8 @@
 use anyhow::Error;
+
+// Force rockbox-airplay symbols into librockbox_cli.a
+#[allow(unused_imports)]
+use rockbox_airplay::_link_airplay as _;
 use clap::Command;
 use owo_colors::OwoColorize;
 use rockbox_library::audio_scan::{save_audio_metadata, scan_audio_files};

--- a/crates/rocksky/src/api/rockbox.v1alpha1.rs
+++ b/crates/rocksky/src/api/rockbox.v1alpha1.rs
@@ -43,10 +43,10 @@ pub mod browse_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BrowseServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -90,8 +90,9 @@ pub mod browse_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BrowseServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -129,20 +130,27 @@ pub mod browse_service_client {
         pub async fn tree_get_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.BrowseService",
-                "TreeGetEntries",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.BrowseService", "TreeGetEntries"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -154,7 +162,7 @@ pub mod browse_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BrowseServiceServer.
@@ -163,7 +171,10 @@ pub mod browse_service_server {
         async fn tree_get_entries(
             &self,
             request: tonic::Request<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct BrowseServiceServer<T> {
@@ -186,7 +197,10 @@ pub mod browse_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -241,18 +255,23 @@ pub mod browse_service_server {
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries" => {
                     #[allow(non_camel_case_types)]
                     struct TreeGetEntriesSvc<T: BrowseService>(pub Arc<T>);
-                    impl<T: BrowseService> tonic::server::UnaryService<super::TreeGetEntriesRequest>
-                        for TreeGetEntriesSvc<T>
-                    {
+                    impl<
+                        T: BrowseService,
+                    > tonic::server::UnaryService<super::TreeGetEntriesRequest>
+                    for TreeGetEntriesSvc<T> {
                         type Response = super::TreeGetEntriesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TreeGetEntriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BrowseService>::tree_get_entries(&inner, request).await
+                                <T as BrowseService>::tree_get_entries(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -279,19 +298,23 @@ pub mod browse_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -527,10 +550,10 @@ pub mod library_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct LibraryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -574,8 +597,9 @@ pub mod library_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LibraryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -613,245 +637,343 @@ pub mod library_service_client {
         pub async fn get_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbums");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbums",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbums",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbums"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtists");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtists",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtists",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtists"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTracks");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTracks",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTracks",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTracks"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_album(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artist(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtist");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtist",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtist",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtist"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_track(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_track(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_album(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_album(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedAlbums",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedAlbums"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn scan_library(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "ScanLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "ScanLibrary"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/Search");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/Search",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "Search"));
@@ -866,7 +988,7 @@ pub mod library_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LibraryServiceServer.
@@ -875,55 +997,94 @@ pub mod library_service_server {
         async fn get_albums(
             &self,
             request: tonic::Request<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn get_artists(
             &self,
             request: tonic::Request<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        >;
         async fn get_tracks(
             &self,
             request: tonic::Request<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_album(
             &self,
             request: tonic::Request<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_artist(
             &self,
             request: tonic::Request<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        >;
         async fn get_track(
             &self,
             request: tonic::Request<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_track(
             &self,
             request: tonic::Request<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn unlike_track(
             &self,
             request: tonic::Request<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_album(
             &self,
             request: tonic::Request<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn unlike_album(
             &self,
             request: tonic::Request<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_tracks(
             &self,
             request: tonic::Request<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_albums(
             &self,
             request: tonic::Request<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn scan_library(
             &self,
             request: tonic::Request<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        >;
         async fn search(
             &self,
             request: tonic::Request<super::SearchRequest>,
@@ -950,7 +1111,10 @@ pub mod library_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1005,9 +1169,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumsRequest> for GetAlbumsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumsRequest>
+                    for GetAlbumsSvc<T> {
                         type Response = super::GetAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumsRequest>,
@@ -1044,9 +1214,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtists" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistsRequest> for GetArtistsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistsRequest>
+                    for GetArtistsSvc<T> {
                         type Response = super::GetArtistsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistsRequest>,
@@ -1083,9 +1259,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTracksRequest> for GetTracksSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTracksRequest>
+                    for GetTracksSvc<T> {
                         type Response = super::GetTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTracksRequest>,
@@ -1122,9 +1304,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumRequest> for GetAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumRequest>
+                    for GetAlbumSvc<T> {
                         type Response = super::GetAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumRequest>,
@@ -1161,9 +1349,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtist" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistRequest> for GetArtistSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistRequest>
+                    for GetArtistSvc<T> {
                         type Response = super::GetArtistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistRequest>,
@@ -1200,9 +1394,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTrack" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTrackRequest> for GetTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTrackRequest>
+                    for GetTrackSvc<T> {
                         type Response = super::GetTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackRequest>,
@@ -1239,9 +1439,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct LikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeTrackRequest> for LikeTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeTrackRequest>
+                    for LikeTrackSvc<T> {
                         type Response = super::LikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeTrackRequest>,
@@ -1278,11 +1484,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeTrackRequest>
-                        for UnlikeTrackSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeTrackRequest>
+                    for UnlikeTrackSvc<T> {
                         type Response = super::UnlikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeTrackRequest>,
@@ -1319,9 +1529,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct LikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeAlbumRequest> for LikeAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeAlbumRequest>
+                    for LikeAlbumSvc<T> {
                         type Response = super::LikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeAlbumRequest>,
@@ -1358,11 +1574,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeAlbumRequest>
-                        for UnlikeAlbumSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeAlbumRequest>
+                    for UnlikeAlbumSvc<T> {
                         type Response = super::UnlikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeAlbumRequest>,
@@ -1399,19 +1619,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedTracksRequest>
-                        for GetLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedTracksRequest>
+                    for GetLikedTracksSvc<T> {
                         type Response = super::GetLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_tracks(&inner, request).await
+                                <T as LibraryService>::get_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1441,19 +1665,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedAlbumsRequest>
-                        for GetLikedAlbumsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedAlbumsRequest>
+                    for GetLikedAlbumsSvc<T> {
                         type Response = super::GetLikedAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedAlbumsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_albums(&inner, request).await
+                                <T as LibraryService>::get_liked_albums(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1483,11 +1711,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct ScanLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::ScanLibraryRequest>
-                        for ScanLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::ScanLibraryRequest>
+                    for ScanLibrarySvc<T> {
                         type Response = super::ScanLibraryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScanLibraryRequest>,
@@ -1524,16 +1756,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::SearchRequest>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as LibraryService>::search(&inner, request).await };
+                            let fut = async move {
+                                <T as LibraryService>::search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1559,19 +1798,23 @@ pub mod library_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1600,10 +1843,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1647,8 +1890,9 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1692,7 +1936,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1719,7 +1963,10 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1771,19 +2018,23 @@ pub mod metadata_service_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2067,10 +2318,10 @@ pub mod playback_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaybackServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2114,8 +2365,9 @@ pub mod playback_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaybackServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2154,12 +2406,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PlayRequest>,
         ) -> std::result::Result<tonic::Response<super::PlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Play");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Play",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Play"));
@@ -2169,12 +2427,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PauseRequest>,
         ) -> std::result::Result<tonic::Response<super::PauseResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Pause");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Pause",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Pause"));
@@ -2183,49 +2447,66 @@ pub mod playback_service_client {
         pub async fn play_or_pause(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayOrPause",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayOrPause"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeRequest>,
         ) -> std::result::Result<tonic::Response<super::ResumeResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Resume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Resume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Resume",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Resume"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::NextRequest>,
         ) -> std::result::Result<tonic::Response<super::NextResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Next");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Next",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Next"));
@@ -2234,293 +2515,426 @@ pub mod playback_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Previous");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Previous",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Previous",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Previous"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn fast_forward_rewind(
             &mut self,
             request: impl tonic::IntoRequest<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FastForwardRewind",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FastForwardRewind",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Status");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Status",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Status",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Status"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn current_track(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "CurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "CurrentTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn next_track(
             &mut self,
             request: impl tonic::IntoRequest<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/NextTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/NextTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "NextTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "NextTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn flush_and_reload_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FlushAndReloadTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FlushAndReloadTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_file_position(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "GetFilePosition",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "GetFilePosition",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn hard_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/HardStop");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/HardStop",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "HardStop",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "HardStop"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_album(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayDirectory"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_music_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayMusicDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayMusicDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_track(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayLikedTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAllTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_current_track(
@@ -2530,18 +2944,26 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::CurrentTrackResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamCurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "StreamCurrentTrack",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_status(
@@ -2551,18 +2973,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamStatus"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_playlist(
@@ -2572,18 +2999,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::PlaylistResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamPlaylist"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
     }
@@ -2595,7 +3027,7 @@ pub mod playback_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaybackServiceServer.
@@ -2612,7 +3044,10 @@ pub mod playback_service_server {
         async fn play_or_pause(
             &self,
             request: tonic::Request<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        >;
         async fn resume(
             &self,
             request: tonic::Request<super::ResumeRequest>,
@@ -2624,11 +3059,17 @@ pub mod playback_service_server {
         async fn previous(
             &self,
             request: tonic::Request<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        >;
         async fn fast_forward_rewind(
             &self,
             request: tonic::Request<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        >;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
@@ -2636,82 +3077,133 @@ pub mod playback_service_server {
         async fn current_track(
             &self,
             request: tonic::Request<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        >;
         async fn next_track(
             &self,
             request: tonic::Request<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        >;
         async fn flush_and_reload_tracks(
             &self,
             request: tonic::Request<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_file_position(
             &self,
             request: tonic::Request<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        >;
         async fn hard_stop(
             &self,
             request: tonic::Request<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        >;
         async fn play_album(
             &self,
             request: tonic::Request<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        >;
         async fn play_artist_tracks(
             &self,
             request: tonic::Request<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_playlist(
             &self,
             request: tonic::Request<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn play_directory(
             &self,
             request: tonic::Request<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_music_directory(
             &self,
             request: tonic::Request<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_track(
             &self,
             request: tonic::Request<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        >;
         async fn play_liked_tracks(
             &self,
             request: tonic::Request<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_all_tracks(
             &self,
             request: tonic::Request<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamCurrentTrack method.
         type StreamCurrentTrackStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CurrentTrackResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_current_track(
             &self,
             request: tonic::Request<super::StreamCurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamCurrentTrackStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamCurrentTrackStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamStatus method.
         type StreamStatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_status(
             &self,
             request: tonic::Request<super::StreamStatusRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamStatusStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamStatusStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamPlaylist method.
         type StreamPlaylistStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::PlaylistResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_playlist(
             &self,
             request: tonic::Request<super::StreamPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamPlaylistStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamPlaylistStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaybackServiceServer<T> {
@@ -2734,7 +3226,10 @@ pub mod playback_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2789,16 +3284,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Play" => {
                     #[allow(non_camel_case_types)]
                     struct PlaySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
                         type Response = super::PlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::play(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::play(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2827,16 +3328,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Pause" => {
                     #[allow(non_camel_case_types)]
                     struct PauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
                         type Response = super::PauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PauseRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::pause(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::pause(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2865,11 +3372,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause" => {
                     #[allow(non_camel_case_types)]
                     struct PlayOrPauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayOrPauseRequest>
-                        for PlayOrPauseSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayOrPauseRequest>
+                    for PlayOrPauseSvc<T> {
                         type Response = super::PlayOrPauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayOrPauseRequest>,
@@ -2906,9 +3417,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Resume" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::ResumeRequest> for ResumeSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::ResumeRequest>
+                    for ResumeSvc<T> {
                         type Response = super::ResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeRequest>,
@@ -2945,16 +3462,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
                         type Response = super::NextResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::next(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::next(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2983,9 +3506,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PreviousRequest> for PreviousSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PreviousRequest>
+                    for PreviousSvc<T> {
                         type Response = super::PreviousResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PreviousRequest>,
@@ -3022,19 +3551,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind" => {
                     #[allow(non_camel_case_types)]
                     struct FastForwardRewindSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FastForwardRewindRequest>
-                        for FastForwardRewindSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FastForwardRewindRequest>
+                    for FastForwardRewindSvc<T> {
                         type Response = super::FastForwardRewindResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FastForwardRewindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::fast_forward_rewind(&inner, request).await
+                                <T as PlaybackService>::fast_forward_rewind(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3064,9 +3597,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Status" => {
                     #[allow(non_camel_case_types)]
                     struct StatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::StatusRequest> for StatusSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::StatusRequest>
+                    for StatusSvc<T> {
                         type Response = super::StatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
@@ -3103,11 +3642,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct CurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::CurrentTrackRequest>
-                        for CurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::CurrentTrackRequest>
+                    for CurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CurrentTrackRequest>,
@@ -3144,9 +3687,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/NextTrack" => {
                     #[allow(non_camel_case_types)]
                     struct NextTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextTrackRequest> for NextTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextTrackRequest>
+                    for NextTrackSvc<T> {
                         type Response = super::NextTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextTrackRequest>,
@@ -3183,19 +3732,25 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks" => {
                     #[allow(non_camel_case_types)]
                     struct FlushAndReloadTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
-                        for FlushAndReloadTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
+                    for FlushAndReloadTracksSvc<T> {
                         type Response = super::FlushAndReloadTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FlushAndReloadTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::flush_and_reload_tracks(&inner, request)
+                                <T as PlaybackService>::flush_and_reload_tracks(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -3226,19 +3781,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition" => {
                     #[allow(non_camel_case_types)]
                     struct GetFilePositionSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::GetFilePositionRequest>
-                        for GetFilePositionSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::GetFilePositionRequest>
+                    for GetFilePositionSvc<T> {
                         type Response = super::GetFilePositionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFilePositionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::get_file_position(&inner, request).await
+                                <T as PlaybackService>::get_file_position(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3268,9 +3827,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/HardStop" => {
                     #[allow(non_camel_case_types)]
                     struct HardStopSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::HardStopRequest> for HardStopSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::HardStopRequest>
+                    for HardStopSvc<T> {
                         type Response = super::HardStopResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HardStopRequest>,
@@ -3307,9 +3872,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAlbumSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayAlbumRequest> for PlayAlbumSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAlbumRequest>
+                    for PlayAlbumSvc<T> {
                         type Response = super::PlayAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAlbumRequest>,
@@ -3346,19 +3917,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayArtistTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayArtistTracksRequest>
-                        for PlayArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayArtistTracksRequest>
+                    for PlayArtistTracksSvc<T> {
                         type Response = super::PlayArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_artist_tracks(&inner, request).await
+                                <T as PlaybackService>::play_artist_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3388,11 +3963,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct PlayPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayPlaylistRequest>
-                        for PlayPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayPlaylistRequest>
+                    for PlayPlaylistSvc<T> {
                         type Response = super::PlayPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayPlaylistRequest>,
@@ -3429,19 +4008,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayDirectoryRequest>
-                        for PlayDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayDirectoryRequest>
+                    for PlayDirectorySvc<T> {
                         type Response = super::PlayDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_directory(&inner, request).await
+                                <T as PlaybackService>::play_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3471,19 +4054,26 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayMusicDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
-                        for PlayMusicDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
+                    for PlayMusicDirectorySvc<T> {
                         type Response = super::PlayMusicDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayMusicDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_music_directory(&inner, request).await
+                                <T as PlaybackService>::play_music_directory(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3513,9 +4103,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayTrack" => {
                     #[allow(non_camel_case_types)]
                     struct PlayTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayTrackRequest> for PlayTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayTrackRequest>
+                    for PlayTrackSvc<T> {
                         type Response = super::PlayTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayTrackRequest>,
@@ -3552,19 +4148,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayLikedTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayLikedTracksRequest>
-                        for PlayLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayLikedTracksRequest>
+                    for PlayLikedTracksSvc<T> {
                         type Response = super::PlayLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_liked_tracks(&inner, request).await
+                                <T as PlaybackService>::play_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3594,19 +4194,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAllTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayAllTracksRequest>
-                        for PlayAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAllTracksRequest>
+                    for PlayAllTracksSvc<T> {
                         type Response = super::PlayAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_all_tracks(&inner, request).await
+                                <T as PlaybackService>::play_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3636,21 +4240,28 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct StreamCurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamCurrentTrackRequest>
-                        for StreamCurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamCurrentTrackRequest,
+                    > for StreamCurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
                         type ResponseStream = T::StreamCurrentTrackStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamCurrentTrackRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_current_track(&inner, request).await
+                                <T as PlaybackService>::stream_current_track(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3680,14 +4291,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus" => {
                     #[allow(non_camel_case_types)]
                     struct StreamStatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamStatusRequest>
-                        for StreamStatusSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamStatusRequest>
+                    for StreamStatusSvc<T> {
                         type Response = super::StatusResponse;
                         type ResponseStream = T::StreamStatusStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamStatusRequest>,
@@ -3724,21 +4337,24 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct StreamPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
-                        for StreamPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
+                    for StreamPlaylistSvc<T> {
                         type Response = super::PlaylistResponse;
                         type ResponseStream = T::StreamPlaylistStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_playlist(&inner, request).await
+                                <T as PlaybackService>::stream_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3765,19 +4381,23 @@ pub mod playback_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -3984,10 +4604,10 @@ pub mod playlist_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaylistServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4031,8 +4651,9 @@ pub mod playlist_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaylistServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4070,182 +4691,251 @@ pub mod playlist_service_client {
         pub async fn get_current(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_resume_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetResumeInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetResumeInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetTrackInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetTrackInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_first_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetFirstIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetFirstIndex"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_display_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetDisplayIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "GetDisplayIndex",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn amount(
             &mut self,
             request: impl tonic::IntoRequest<super::AmountRequest>,
         ) -> std::result::Result<tonic::Response<super::AmountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Amount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Amount",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "Amount",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Amount"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn playlist_resume(
             &mut self,
             request: impl tonic::IntoRequest<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "PlaylistResume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "PlaylistResume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume_track(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ResumeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "ResumeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_modified(
             &mut self,
             request: impl tonic::IntoRequest<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/SetModified",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "SetModified",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "SetModified"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn start(
             &mut self,
             request: impl tonic::IntoRequest<super::StartRequest>,
         ) -> std::result::Result<tonic::Response<super::StartResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Start");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Start",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Start"));
@@ -4255,12 +4945,18 @@ pub mod playlist_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncRequest>,
         ) -> std::result::Result<tonic::Response<super::SyncResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Sync");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Sync",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Sync"));
@@ -4269,172 +4965,247 @@ pub mod playlist_service_client {
         pub async fn remove_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "RemoveAllTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "RemoveTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn create_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "CreatePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "CreatePlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_album(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn shuffle_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ShufflePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "ShufflePlaylist",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -4446,7 +5217,7 @@ pub mod playlist_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaylistServiceServer.
@@ -4455,23 +5226,38 @@ pub mod playlist_service_server {
         async fn get_current(
             &self,
             request: tonic::Request<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        >;
         async fn get_resume_info(
             &self,
             request: tonic::Request<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_track_info(
             &self,
             request: tonic::Request<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_first_index(
             &self,
             request: tonic::Request<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        >;
         async fn get_display_index(
             &self,
             request: tonic::Request<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        >;
         async fn amount(
             &self,
             request: tonic::Request<super::AmountRequest>,
@@ -4479,15 +5265,24 @@ pub mod playlist_service_server {
         async fn playlist_resume(
             &self,
             request: tonic::Request<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        >;
         async fn resume_track(
             &self,
             request: tonic::Request<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        >;
         async fn set_modified(
             &self,
             request: tonic::Request<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        >;
         async fn start(
             &self,
             request: tonic::Request<super::StartRequest>,
@@ -4499,39 +5294,66 @@ pub mod playlist_service_server {
         async fn remove_all_tracks(
             &self,
             request: tonic::Request<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        >;
         async fn remove_tracks(
             &self,
             request: tonic::Request<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        >;
         async fn create_playlist(
             &self,
             request: tonic::Request<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_tracks(
             &self,
             request: tonic::Request<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        >;
         async fn insert_directory(
             &self,
             request: tonic::Request<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn insert_playlist(
             &self,
             request: tonic::Request<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_album(
             &self,
             request: tonic::Request<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        >;
         async fn insert_artist_tracks(
             &self,
             request: tonic::Request<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn shuffle_playlist(
             &self,
             request: tonic::Request<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaylistServiceServer<T> {
@@ -4554,7 +5376,10 @@ pub mod playlist_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4609,11 +5434,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetCurrentRequest>
-                        for GetCurrentSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetCurrentRequest>
+                    for GetCurrentSvc<T> {
                         type Response = super::GetCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCurrentRequest>,
@@ -4650,19 +5479,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetResumeInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetResumeInfoRequest>
-                        for GetResumeInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetResumeInfoRequest>
+                    for GetResumeInfoSvc<T> {
                         type Response = super::GetResumeInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetResumeInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_resume_info(&inner, request).await
+                                <T as PlaylistService>::get_resume_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4692,18 +5525,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetTrackInfoRequest>
-                        for GetTrackInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetTrackInfoRequest>
+                    for GetTrackInfoSvc<T> {
                         type Response = super::GetTrackInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_track_info(&inner, request).await
+                                <T as PlaylistService>::get_track_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4733,19 +5571,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetFirstIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetFirstIndexRequest>
-                        for GetFirstIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetFirstIndexRequest>
+                    for GetFirstIndexSvc<T> {
                         type Response = super::GetFirstIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFirstIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_first_index(&inner, request).await
+                                <T as PlaylistService>::get_first_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4775,19 +5617,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetDisplayIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetDisplayIndexRequest>
-                        for GetDisplayIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetDisplayIndexRequest>
+                    for GetDisplayIndexSvc<T> {
                         type Response = super::GetDisplayIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetDisplayIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_display_index(&inner, request).await
+                                <T as PlaylistService>::get_display_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4817,9 +5663,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Amount" => {
                     #[allow(non_camel_case_types)]
                     struct AmountSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::AmountRequest> for AmountSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::AmountRequest>
+                    for AmountSvc<T> {
                         type Response = super::AmountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AmountRequest>,
@@ -4856,19 +5708,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume" => {
                     #[allow(non_camel_case_types)]
                     struct PlaylistResumeSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::PlaylistResumeRequest>
-                        for PlaylistResumeSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::PlaylistResumeRequest>
+                    for PlaylistResumeSvc<T> {
                         type Response = super::PlaylistResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlaylistResumeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::playlist_resume(&inner, request).await
+                                <T as PlaylistService>::playlist_resume(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4898,11 +5754,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeTrackSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::ResumeTrackRequest>
-                        for ResumeTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ResumeTrackRequest>
+                    for ResumeTrackSvc<T> {
                         type Response = super::ResumeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeTrackRequest>,
@@ -4939,11 +5799,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/SetModified" => {
                     #[allow(non_camel_case_types)]
                     struct SetModifiedSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SetModifiedRequest>
-                        for SetModifiedSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SetModifiedRequest>
+                    for SetModifiedSvc<T> {
                         type Response = super::SetModifiedResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetModifiedRequest>,
@@ -4980,16 +5844,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Start" => {
                     #[allow(non_camel_case_types)]
                     struct StartSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
                         type Response = super::StartResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StartRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::start(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::start(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5018,16 +5888,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
                         type Response = super::SyncResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::sync(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::sync(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5056,19 +5932,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveAllTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::RemoveAllTracksRequest>
-                        for RemoveAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveAllTracksRequest>
+                    for RemoveAllTracksSvc<T> {
                         type Response = super::RemoveAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::remove_all_tracks(&inner, request).await
+                                <T as PlaylistService>::remove_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5098,11 +5978,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::RemoveTracksRequest>
-                        for RemoveTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveTracksRequest>
+                    for RemoveTracksSvc<T> {
                         type Response = super::RemoveTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveTracksRequest>,
@@ -5139,19 +6023,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct CreatePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::CreatePlaylistRequest>
-                        for CreatePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::CreatePlaylistRequest>
+                    for CreatePlaylistSvc<T> {
                         type Response = super::CreatePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreatePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::create_playlist(&inner, request).await
+                                <T as PlaylistService>::create_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5181,11 +6069,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertTracksRequest>
-                        for InsertTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertTracksRequest>
+                    for InsertTracksSvc<T> {
                         type Response = super::InsertTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertTracksRequest>,
@@ -5222,19 +6114,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct InsertDirectorySvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertDirectoryRequest>
-                        for InsertDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertDirectoryRequest>
+                    for InsertDirectorySvc<T> {
                         type Response = super::InsertDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_directory(&inner, request).await
+                                <T as PlaylistService>::insert_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5264,19 +6160,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct InsertPlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertPlaylistRequest>
-                        for InsertPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertPlaylistRequest>
+                    for InsertPlaylistSvc<T> {
                         type Response = super::InsertPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_playlist(&inner, request).await
+                                <T as PlaylistService>::insert_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5306,11 +6206,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct InsertAlbumSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertAlbumRequest>
-                        for InsertAlbumSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertAlbumRequest>
+                    for InsertAlbumSvc<T> {
                         type Response = super::InsertAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertAlbumRequest>,
@@ -5347,19 +6251,26 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertArtistTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertArtistTracksRequest>
-                        for InsertArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertArtistTracksRequest>
+                    for InsertArtistTracksSvc<T> {
                         type Response = super::InsertArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_artist_tracks(&inner, request).await
+                                <T as PlaylistService>::insert_artist_tracks(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5389,19 +6300,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct ShufflePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::ShufflePlaylistRequest>
-                        for ShufflePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ShufflePlaylistRequest>
+                    for ShufflePlaylistSvc<T> {
                         type Response = super::ShufflePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ShufflePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::shuffle_playlist(&inner, request).await
+                                <T as PlaylistService>::shuffle_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5428,19 +6343,23 @@ pub mod playlist_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -5950,10 +6869,10 @@ pub mod settings_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SettingsServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -5997,8 +6916,9 @@ pub mod settings_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SettingsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6036,58 +6956,85 @@ pub mod settings_service_client {
         pub async fn get_settings_list(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetSettingsList",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetSettingsList",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetGlobalSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetGlobalSettings",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn save_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/SaveSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "SaveSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SettingsService", "SaveSettings"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6099,7 +7046,7 @@ pub mod settings_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SettingsServiceServer.
@@ -6108,15 +7055,24 @@ pub mod settings_service_server {
         async fn get_settings_list(
             &self,
             request: tonic::Request<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        >;
         async fn get_global_settings(
             &self,
             request: tonic::Request<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        >;
         async fn save_settings(
             &self,
             request: tonic::Request<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SettingsServiceServer<T> {
@@ -6139,7 +7095,10 @@ pub mod settings_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6194,19 +7153,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList" => {
                     #[allow(non_camel_case_types)]
                     struct GetSettingsListSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetSettingsListRequest>
-                        for GetSettingsListSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetSettingsListRequest>
+                    for GetSettingsListSvc<T> {
                         type Response = super::GetSettingsListResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSettingsListRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_settings_list(&inner, request).await
+                                <T as SettingsService>::get_settings_list(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6236,19 +7199,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetGlobalSettingsRequest>
-                        for GetGlobalSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetGlobalSettingsRequest>
+                    for GetGlobalSettingsSvc<T> {
                         type Response = super::GetGlobalSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalSettingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_global_settings(&inner, request).await
+                                <T as SettingsService>::get_global_settings(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6278,11 +7245,15 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/SaveSettings" => {
                     #[allow(non_camel_case_types)]
                     struct SaveSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService> tonic::server::UnaryService<super::SaveSettingsRequest>
-                        for SaveSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::SaveSettingsRequest>
+                    for SaveSettingsSvc<T> {
                         type Response = super::SaveSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SaveSettingsRequest>,
@@ -6316,19 +7287,23 @@ pub mod settings_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6486,10 +7461,10 @@ pub mod sound_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SoundServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6533,8 +7508,9 @@ pub mod sound_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SoundServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6572,31 +7548,48 @@ pub mod sound_service_client {
         pub async fn adjust_volume(
             &mut self,
             request: impl tonic::IntoRequest<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/AdjustVolume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/AdjustVolume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "AdjustVolume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "AdjustVolume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_set(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundSet");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundSet",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundSet"));
@@ -6605,49 +7598,74 @@ pub mod sound_service_client {
         pub async fn sound_current(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundCurrent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundCurrent",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_default(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundDefault");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundDefault",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundDefault",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundDefault"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_min(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMin");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMin",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMin"));
@@ -6656,13 +7674,22 @@ pub mod sound_service_client {
         pub async fn sound_max(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMax");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMax",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMax"));
@@ -6671,49 +7698,72 @@ pub mod sound_service_client {
         pub async fn sound_unit(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundUnit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundUnit",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundUnit",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundUnit"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_val2_phys(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundVal2Phys",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundVal2Phys"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/GetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/GetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "GetPitch"));
@@ -6722,13 +7772,22 @@ pub mod sound_service_client {
         pub async fn set_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SetPitch"));
@@ -6737,13 +7796,22 @@ pub mod sound_service_client {
         pub async fn beep_play(
             &mut self,
             request: impl tonic::IntoRequest<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/BeepPlay");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/BeepPlay",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "BeepPlay"));
@@ -6752,76 +7820,106 @@ pub mod sound_service_client {
         pub async fn pcmbuf_fade(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/PcmbufFade");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/PcmbufFade",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufFade",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "PcmbufFade"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn pcmbuf_set_low_latency(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufSetLowLatency",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SoundService",
+                        "PcmbufSetLowLatency",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn system_sound_play(
             &mut self,
             request: impl tonic::IntoRequest<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SystemSoundPlay",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SystemSoundPlay"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn keyclick_click(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/KeyclickClick",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "KeyclickClick",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "KeyclickClick"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6833,7 +7931,7 @@ pub mod sound_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SoundServiceServer.
@@ -6842,63 +7940,108 @@ pub mod sound_service_server {
         async fn adjust_volume(
             &self,
             request: tonic::Request<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        >;
         async fn sound_set(
             &self,
             request: tonic::Request<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        >;
         async fn sound_current(
             &self,
             request: tonic::Request<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        >;
         async fn sound_default(
             &self,
             request: tonic::Request<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        >;
         async fn sound_min(
             &self,
             request: tonic::Request<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        >;
         async fn sound_max(
             &self,
             request: tonic::Request<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        >;
         async fn sound_unit(
             &self,
             request: tonic::Request<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        >;
         async fn sound_val2_phys(
             &self,
             request: tonic::Request<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        >;
         async fn get_pitch(
             &self,
             request: tonic::Request<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        >;
         async fn set_pitch(
             &self,
             request: tonic::Request<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        >;
         async fn beep_play(
             &self,
             request: tonic::Request<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_fade(
             &self,
             request: tonic::Request<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_set_low_latency(
             &self,
             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        >;
         async fn system_sound_play(
             &self,
             request: tonic::Request<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        >;
         async fn keyclick_click(
             &self,
             request: tonic::Request<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SoundServiceServer<T> {
@@ -6921,7 +8064,10 @@ pub mod sound_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6976,11 +8122,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/AdjustVolume" => {
                     #[allow(non_camel_case_types)]
                     struct AdjustVolumeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::AdjustVolumeRequest>
-                        for AdjustVolumeSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::AdjustVolumeRequest>
+                    for AdjustVolumeSvc<T> {
                         type Response = super::AdjustVolumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AdjustVolumeRequest>,
@@ -7017,9 +8167,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundSet" => {
                     #[allow(non_camel_case_types)]
                     struct SoundSetSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundSetRequest> for SoundSetSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundSetRequest>
+                    for SoundSetSvc<T> {
                         type Response = super::SoundSetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundSetRequest>,
@@ -7056,11 +8212,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct SoundCurrentSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundCurrentRequest>
-                        for SoundCurrentSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundCurrentRequest>
+                    for SoundCurrentSvc<T> {
                         type Response = super::SoundCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundCurrentRequest>,
@@ -7097,11 +8257,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundDefault" => {
                     #[allow(non_camel_case_types)]
                     struct SoundDefaultSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundDefaultRequest>
-                        for SoundDefaultSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundDefaultRequest>
+                    for SoundDefaultSvc<T> {
                         type Response = super::SoundDefaultResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundDefaultRequest>,
@@ -7138,9 +8302,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMin" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMinSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMinRequest> for SoundMinSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMinRequest>
+                    for SoundMinSvc<T> {
                         type Response = super::SoundMinResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMinRequest>,
@@ -7177,9 +8347,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMax" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMaxSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMaxRequest> for SoundMaxSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMaxRequest>
+                    for SoundMaxSvc<T> {
                         type Response = super::SoundMaxResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMaxRequest>,
@@ -7216,9 +8392,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundUnit" => {
                     #[allow(non_camel_case_types)]
                     struct SoundUnitSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundUnitRequest> for SoundUnitSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundUnitRequest>
+                    for SoundUnitSvc<T> {
                         type Response = super::SoundUnitResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundUnitRequest>,
@@ -7255,11 +8437,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys" => {
                     #[allow(non_camel_case_types)]
                     struct SoundVal2PhysSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundVal2PhysRequest>
-                        for SoundVal2PhysSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundVal2PhysRequest>
+                    for SoundVal2PhysSvc<T> {
                         type Response = super::SoundVal2PhysResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundVal2PhysRequest>,
@@ -7296,9 +8482,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/GetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct GetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::GetPitchRequest> for GetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::GetPitchRequest>
+                    for GetPitchSvc<T> {
                         type Response = super::GetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPitchRequest>,
@@ -7335,9 +8527,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct SetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SetPitchRequest> for SetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SetPitchRequest>
+                    for SetPitchSvc<T> {
                         type Response = super::SetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPitchRequest>,
@@ -7374,9 +8572,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/BeepPlay" => {
                     #[allow(non_camel_case_types)]
                     struct BeepPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::BeepPlayRequest> for BeepPlaySvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::BeepPlayRequest>
+                    for BeepPlaySvc<T> {
                         type Response = super::BeepPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BeepPlayRequest>,
@@ -7413,9 +8617,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufFade" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufFadeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::PcmbufFadeRequest> for PcmbufFadeSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufFadeRequest>
+                    for PcmbufFadeSvc<T> {
                         type Response = super::PcmbufFadeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufFadeRequest>,
@@ -7452,19 +8662,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufSetLowLatencySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService>
-                        tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
-                        for PcmbufSetLowLatencySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
+                    for PcmbufSetLowLatencySvc<T> {
                         type Response = super::PcmbufSetLowLatencyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request).await
+                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7494,18 +8708,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay" => {
                     #[allow(non_camel_case_types)]
                     struct SystemSoundPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SystemSoundPlayRequest>
-                        for SystemSoundPlaySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SystemSoundPlayRequest>
+                    for SystemSoundPlaySvc<T> {
                         type Response = super::SystemSoundPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SystemSoundPlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::system_sound_play(&inner, request).await
+                                <T as SoundService>::system_sound_play(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7535,11 +8754,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/KeyclickClick" => {
                     #[allow(non_camel_case_types)]
                     struct KeyclickClickSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::KeyclickClickRequest>
-                        for KeyclickClickSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::KeyclickClickRequest>
+                    for KeyclickClickSvc<T> {
                         type Response = super::KeyclickClickResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::KeyclickClickRequest>,
@@ -7573,19 +8796,23 @@ pub mod sound_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -7646,10 +8873,10 @@ pub mod system_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SystemServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7693,8 +8920,9 @@ pub mod system_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SystemServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7732,39 +8960,56 @@ pub mod system_service_client {
         pub async fn get_rockbox_version(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetRockboxVersion",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SystemService",
+                        "GetRockboxVersion",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetGlobalStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SystemService", "GetGlobalStatus"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7776,7 +9021,7 @@ pub mod system_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SystemServiceServer.
@@ -7785,11 +9030,17 @@ pub mod system_service_server {
         async fn get_rockbox_version(
             &self,
             request: tonic::Request<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        >;
         async fn get_global_status(
             &self,
             request: tonic::Request<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SystemServiceServer<T> {
@@ -7812,7 +9063,10 @@ pub mod system_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7867,19 +9121,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion" => {
                     #[allow(non_camel_case_types)]
                     struct GetRockboxVersionSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetRockboxVersionRequest>
-                        for GetRockboxVersionSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetRockboxVersionRequest>
+                    for GetRockboxVersionSvc<T> {
                         type Response = super::GetRockboxVersionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRockboxVersionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_rockbox_version(&inner, request).await
+                                <T as SystemService>::get_rockbox_version(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7909,19 +9167,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalStatusSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetGlobalStatusRequest>
-                        for GetGlobalStatusSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetGlobalStatusRequest>
+                    for GetGlobalStatusSvc<T> {
                         type Response = super::GetGlobalStatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_global_status(&inner, request).await
+                                <T as SystemService>::get_global_status(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7948,19 +9210,23 @@ pub mod system_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -931,6 +931,8 @@ pub mod api {
                     }),
                     audio_output: None,
                     fifo_path: None,
+                    airplay_host: None,
+                    airplay_port: None,
                 }
             }
         }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1,5 +1,4 @@
 use anyhow::Error;
-use owo_colors::OwoColorize;
 use rockbox_library::entity::track::Track;
 use rockbox_sys::{
     self as rb,

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -33,6 +33,12 @@ pub fn load_settings(new_settings: Option<NewGlobalSettings>) -> Result<(), Erro
             let path = settings.fifo_path.as_deref().unwrap_or("/tmp/rockbox.fifo");
             pcm::fifo_set_path(path);
             pcm::switch_sink(pcm::PCM_SINK_FIFO);
+        } else if output == "airplay" {
+            if let Some(ref host) = settings.airplay_host {
+                let port = settings.airplay_port.unwrap_or(5000);
+                pcm::airplay_set_host(host, port);
+                pcm::switch_sink(pcm::PCM_SINK_AIRPLAY);
+            }
         }
     }
 

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_ushort, c_void};
 
 pub mod browse;
 pub mod dir;
@@ -1148,6 +1148,7 @@ extern "C" {
     fn pcm_play_unlock();
     fn pcm_switch_sink(sink: c_int) -> c_uchar;
     fn pcm_fifo_set_path(path: *const c_char);
+    fn pcm_airplay_set_host(host: *const c_char, port: c_ushort);
     fn beep_play(frequency: c_uint, duration: c_uint, amplitude: c_uint);
     fn dsp_set_crossfeed_type(r#type: c_int);
     fn dsp_eq_enable(enable: c_uchar);

--- a/crates/sys/src/sound/pcm.rs
+++ b/crates/sys/src/sound/pcm.rs
@@ -4,6 +4,7 @@ use crate::{PcmPlayCallbackType, PcmStatusCallbackType};
 
 pub const PCM_SINK_BUILTIN: i32 = 0;
 pub const PCM_SINK_FIFO: i32 = 1;
+pub const PCM_SINK_AIRPLAY: i32 = 2;
 
 pub fn apply_settings() {
     unsafe {
@@ -49,6 +50,13 @@ pub fn play_unlock() {
 
 pub fn switch_sink(sink: i32) -> bool {
     unsafe { crate::pcm_switch_sink(sink) != 0 }
+}
+
+pub fn airplay_set_host(host: &str, port: u16) {
+    use std::ffi::CString;
+    let chost = CString::new(host).expect("host must not contain null bytes");
+    unsafe { crate::pcm_airplay_set_host(chost.as_ptr(), port) }
+    std::mem::forget(chost);
 }
 
 pub fn fifo_set_path(path: &str) {

--- a/crates/sys/src/types/user_settings.rs
+++ b/crates/sys/src/types/user_settings.rs
@@ -677,10 +677,14 @@ pub struct NewGlobalSettings {
     pub eq_band_settings: Option<Vec<EqBandSetting>>,
     pub replaygain_settings: Option<ReplaygainSettings>,
     pub compressor_settings: Option<CompressorSettings>,
-    /// Audio output sink: "builtin" (default) or "fifo"
+    /// Audio output sink: "builtin" (default), "fifo", or "airplay"
     pub audio_output: Option<String>,
     /// Path for the FIFO sink, e.g. "/tmp/rockbox.fifo" or "-" for stdout
     pub fifo_path: Option<String>,
+    /// IP address or hostname of the AirPlay (RAOP) receiver
+    pub airplay_host: Option<String>,
+    /// RAOP port on the receiver (default: 5000)
+    pub airplay_port: Option<u16>,
 }
 
 impl From<UserSettings> for NewGlobalSettings {
@@ -716,6 +720,8 @@ impl From<UserSettings> for NewGlobalSettings {
             compressor_settings: Some(settings.compressor_settings),
             audio_output: None,
             fifo_path: None,
+            airplay_host: None,
+            airplay_port: None,
         }
     }
 }

--- a/firmware/SOURCES
+++ b/firmware/SOURCES
@@ -537,6 +537,7 @@ pcm.c
 pcm_mixer.c
 #if (CONFIG_PLATFORM & PLATFORM_HOSTED)
 target/hosted/pcm-fifo.c
+target/hosted/pcm-airplay.c
 #endif
 #ifdef HAVE_SW_VOLUME_CONTROL
 pcm_sw_volume.c

--- a/firmware/export/pcm_sink.h
+++ b/firmware/export/pcm_sink.h
@@ -54,6 +54,7 @@ enum pcm_sink_ids {
     PCM_SINK_BUILTIN = 0,
 #if (CONFIG_PLATFORM & PLATFORM_HOSTED)
     PCM_SINK_FIFO,
+    PCM_SINK_AIRPLAY,
 #endif
     PCM_SINK_NUM
 };
@@ -65,4 +66,7 @@ extern struct pcm_sink builtin_pcm_sink;
 /* FIFO/pipe sink — writes raw S16LE stereo PCM to a named FIFO or stdout */
 extern struct pcm_sink fifo_pcm_sink;
 void pcm_fifo_set_path(const char *path);
+
+/* AirPlay (RAOP) sink — streams ALAC-encoded audio over RTP */
+extern struct pcm_sink airplay_pcm_sink;
 #endif

--- a/firmware/pcm.c
+++ b/firmware/pcm.c
@@ -79,9 +79,10 @@
  */
 
 static struct pcm_sink* sinks[PCM_SINK_NUM] = {
-    [PCM_SINK_BUILTIN] = &builtin_pcm_sink,
+    [PCM_SINK_BUILTIN]  = &builtin_pcm_sink,
 #if (CONFIG_PLATFORM & PLATFORM_HOSTED)
-    [PCM_SINK_FIFO]    = &fifo_pcm_sink,
+    [PCM_SINK_FIFO]     = &fifo_pcm_sink,
+    [PCM_SINK_AIRPLAY]  = &airplay_pcm_sink,
 #endif
 };
 static enum pcm_sink_ids cur_sink = PCM_SINK_BUILTIN;

--- a/firmware/target/hosted/pcm-airplay.c
+++ b/firmware/target/hosted/pcm-airplay.c
@@ -1,0 +1,177 @@
+/***************************************************************************
+ * PCM sink that encodes S16LE stereo PCM as ALAC escape frames and streams
+ * them over RAOP (AirPlay 1) via UDP/RTP to a compatible receiver.
+ *
+ * Usage:
+ *   pcm_airplay_set_host("192.168.1.x", 5000);
+ *   pcm_switch_sink(PCM_SINK_AIRPLAY);
+ *
+ * Copyright (C) 2026 Rockbox contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ****************************************************************************/
+
+#include "autoconf.h"
+#include "config.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "pcm.h"
+#include "pcm-internal.h"
+#include "pcm_mixer.h"
+#include "pcm_sampr.h"
+#include "pcm_sink.h"
+
+#define LOGF_ENABLE
+#include "logf.h"
+
+/* Rust C API — symbols are provided by the rockbox-airplay crate via
+ * librockbox_cli.a. */
+extern void    pcm_airplay_set_host(const char *host, uint16_t port);
+extern int     pcm_airplay_connect(void);
+extern int     pcm_airplay_write(const uint8_t *data, size_t len);
+extern void    pcm_airplay_stop(void);
+extern void    pcm_airplay_close(void);
+
+static const void *pcm_data = NULL;
+static size_t      pcm_size = 0;
+
+static pthread_mutex_t airplay_mtx;
+static pthread_t       airplay_tid;
+static volatile bool   airplay_running = false;
+static volatile bool   airplay_stop    = false;
+
+static void *airplay_thread(void *arg)
+{
+    (void)arg;
+
+    while (!airplay_stop) {
+        pthread_mutex_lock(&airplay_mtx);
+        const void *data = pcm_data;
+        size_t      size = pcm_size;
+        pcm_data = NULL;
+        pcm_size = 0;
+        pthread_mutex_unlock(&airplay_mtx);
+
+        if (data && size > 0) {
+            if (pcm_airplay_write((const uint8_t *)data, size) < 0) {
+                logf("pcm-airplay: write error");
+                airplay_stop = true;
+                break;
+            }
+        }
+
+        if (airplay_stop)
+            break;
+
+        pthread_mutex_lock(&airplay_mtx);
+        bool got_more = pcm_play_dma_complete_callback(PCM_DMAST_OK,
+                                                        &pcm_data, &pcm_size);
+        pthread_mutex_unlock(&airplay_mtx);
+
+        if (!got_more) {
+            logf("pcm-airplay: no more PCM data");
+            break;
+        }
+
+        pcm_play_dma_status_callback(PCM_DMAST_STARTED);
+    }
+
+    airplay_running = false;
+    return NULL;
+}
+
+static void sink_dma_init(void)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&airplay_mtx, &attr);
+    pthread_mutexattr_destroy(&attr);
+}
+
+static void sink_dma_postinit(void)
+{
+}
+
+static void sink_set_freq(uint16_t freq)
+{
+    (void)freq;
+}
+
+static void sink_lock(void)
+{
+    pthread_mutex_lock(&airplay_mtx);
+}
+
+static void sink_unlock(void)
+{
+    pthread_mutex_unlock(&airplay_mtx);
+}
+
+static void sink_dma_start(const void *addr, size_t size)
+{
+    logf("pcm-airplay: start (%p, %zu)", addr, size);
+
+    /* Connect if not already connected */
+    if (pcm_airplay_connect() < 0) {
+        logf("pcm-airplay: connect failed");
+        return;
+    }
+
+    pthread_mutex_lock(&airplay_mtx);
+    pcm_data = addr;
+    pcm_size = size;
+    pthread_mutex_unlock(&airplay_mtx);
+
+    airplay_stop    = false;
+    airplay_running = true;
+    pthread_create(&airplay_tid, NULL, airplay_thread, NULL);
+}
+
+static void sink_dma_stop(void)
+{
+    logf("pcm-airplay: stop");
+
+    airplay_stop = true;
+
+    if (airplay_running) {
+        pthread_join(airplay_tid, NULL);
+        airplay_running = false;
+    }
+
+    pthread_mutex_lock(&airplay_mtx);
+    pcm_data = NULL;
+    pcm_size = 0;
+    pthread_mutex_unlock(&airplay_mtx);
+
+    pcm_airplay_stop();
+}
+
+struct pcm_sink airplay_pcm_sink = {
+    .caps = {
+        .samprs       = hw_freq_sampr,
+        .num_samprs   = HW_NUM_FREQ,
+        .default_freq = HW_FREQ_DEFAULT,
+    },
+    .ops = {
+        .init     = sink_dma_init,
+        .postinit = sink_dma_postinit,
+        .set_freq = sink_set_freq,
+        .lock     = sink_lock,
+        .unlock   = sink_unlock,
+        .play     = sink_dma_start,
+        .stop     = sink_dma_stop,
+    },
+};


### PR DESCRIPTION
Implement AirPlay (RAOP) output: add rockbox-airplay Rust crate with ALAC
encoder, RTSP/RTP sender and AirPlay 2 pairing (PAIR-SETUP/VERIFY), add hosted pcm-airplay.c sink, wire C bindings into the CLI staticlib, update
settings/types/sys to support airplay host/port, and add docs (CLAUDE.md)