### PR TITLE
Add multi-room AirPlay support with receiver management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and Squeezelite.
 
 ### Audio output
 - [x] Built-in SDL audio
-- [x] AirPlay (RAOP) — stream to Apple TV, HomePod, Airport Express, shairport-sync
+- [x] AirPlay (RAOP) — single or multi-room fan-out to Apple TV, HomePod, Airport Express, shairport-sync
 - [x] Snapcast (FIFO/pipe) — synchronised multi-room via snapserver
 - [x] Squeezelite (Slim Protocol + HTTP broadcast) — synchronised multi-room
 - [x] Chromecast
@@ -228,7 +228,9 @@ Pipe to any PCM consumer with `fifo_path = "-"`:
 rockboxd | ffplay -f s16le -ar 44100 -ac 2 -
 ```
 
-### AirPlay (RAOP)
+### AirPlay (RAOP) — single or multi-room
+
+Single receiver:
 
 ```toml
 music_dir    = "/path/to/Music"
@@ -237,9 +239,26 @@ airplay_host = "192.168.1.50"   # IP of the AirPlay receiver
 airplay_port = 5000             # optional, default 5000
 ```
 
+Multi-room (fan-out to N receivers simultaneously):
+
+```toml
+music_dir    = "/path/to/Music"
+audio_output = "airplay"
+
+[[airplay_receivers]]
+host = "192.168.1.50"   # living room
+port = 5000             # optional, default 5000
+
+[[airplay_receivers]]
+host = "192.168.1.51"   # bedroom
+# port defaults to 5000
+```
+
 Streams ALAC-encoded audio over RTP to any RAOP-compatible receiver — Apple
 TV, HomePod, Airport Express, or
-[shairport-sync](https://github.com/mikebrady/shairport-sync).
+[shairport-sync](https://github.com/mikebrady/shairport-sync). All receivers
+share the same `initial_rtptime`, so RTP-level playback synchronisation is
+within one frame (~8 ms) across the LAN.
 
 ### Squeezelite (Slim Protocol — multi-room)
 

--- a/crates/airplay/README.md
+++ b/crates/airplay/README.md
@@ -1,7 +1,8 @@
 # rockbox-airplay — AirPlay PCM Sink
 
 This document traces every hop an audio frame takes from the Rockbox C firmware
-through the `rockbox-airplay` Rust crate to an AirPlay (RAOP) receiver.
+through the `rockbox-airplay` Rust crate to one or more AirPlay (RAOP)
+receivers.
 
 ---
 
@@ -18,10 +19,11 @@ through the `rockbox-airplay` Rust crate to an AirPlay (RAOP) receiver.
 9. [RTP audio stream (`rtp.rs`)](#rtp-audio-stream-rtprs)
 10. [RTCP synchronisation](#rtcp-synchronisation)
 11. [NTP timing responder](#ntp-timing-responder)
-12. [Track transitions](#track-transitions)
-13. [Configuration](#configuration)
-14. [AirPlay 2 probe](#airplay-2-probe)
-15. [Gotchas and known limits](#gotchas-and-known-limits)
+12. [Multi-room fan-out](#multi-room-fan-out)
+13. [Track transitions](#track-transitions)
+14. [Configuration](#configuration)
+15. [AirPlay 2 probe](#airplay-2-probe)
+16. [Gotchas and known limits](#gotchas-and-known-limits)
 
 ---
 
@@ -29,16 +31,20 @@ through the `rockbox-airplay` Rust crate to an AirPlay (RAOP) receiver.
 
 The AirPlay sink lets Rockbox stream audio to any RAOP-compatible receiver —
 Apple TV, HomePod, Airport Express, or third-party software such as
-[shairport-sync](https://github.com/mikebrady/shairport-sync). It implements
-**AirPlay 1 (RAOP)** entirely in pure Rust with no external C libraries.
+[shairport-sync](https://github.com/mikebrady/shairport-sync). Multiple
+receivers can be configured simultaneously for multi-room playback.
+
+The implementation is **AirPlay 1 (RAOP)** in pure Rust with no external C
+libraries. AirPlay 2 pairing (HAP SRP6a + x25519 ECDH) is attempted as a
+non-fatal probe before falling through to the AirPlay 1 path.
 
 The protocol stack looks like:
 
 ```
-RTSP/TCP  ──  session negotiation (ANNOUNCE, SETUP, RECORD, TEARDOWN)
-RTP/UDP   ──  ALAC-encoded audio frames
-RTCP/UDP  ──  synchronisation (NTP send-report) every ~350 ms
-UDP       ──  NTP timing response service
+RTSP/TCP  ──  session negotiation per receiver (ANNOUNCE, SETUP, RECORD, TEARDOWN)
+RTP/UDP   ──  ALAC-encoded audio frames (same frame broadcast to all receivers)
+RTCP/UDP  ──  synchronisation (NTP send-report) every ~350 ms per receiver
+UDP       ──  shared NTP timing response service (one port, all receivers)
 ```
 
 ---
@@ -46,46 +52,55 @@ UDP       ──  NTP timing response service
 ## Layer map
 
 ```
-┌────────────────────────────────────────────────────────┐
-│  Rockbox C firmware  (pcm.c, audio thread)             │
-│    pcm_play_data() → sink.ops.play()                   │
-│    pcm_play_dma_complete_callback() per chunk          │
-└───────────────────┬────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  Rockbox C firmware  (pcm.c, audio thread)                  │
+│    pcm_play_data() → sink.ops.play()                        │
+│    pcm_play_dma_complete_callback() per chunk               │
+└───────────────────┬─────────────────────────────────────────┘
                     │ raw S16LE stereo PCM chunks
-┌───────────────────▼────────────────────────────────────┐
-│  firmware/target/hosted/pcm-airplay.c                  │
-│    sink_dma_start()  → pcm_airplay_connect()           │
-│    airplay_thread()  → pcm_airplay_write()             │
-│    sink_dma_stop()   → pcm_airplay_stop()              │
-└───────────────────┬────────────────────────────────────┘
+┌───────────────────▼─────────────────────────────────────────┐
+│  firmware/target/hosted/pcm-airplay.c                       │
+│    sink_dma_start()  → pcm_airplay_connect()                │
+│    airplay_thread()  → pcm_airplay_write()                  │
+│    sink_dma_stop()   → pcm_airplay_stop()                   │
+└───────────────────┬─────────────────────────────────────────┘
                     │  extern "C" FFI
-┌───────────────────▼────────────────────────────────────┐
-│  crates/airplay/src/lib.rs                             │
-│    AirPlaySession { sender, rtsp, buf, first_frame }   │
-│    pcm_airplay_connect() — RTSP handshake              │
-│    pcm_airplay_write()   — ALAC frame dispatch         │
-│    pcm_airplay_stop()    — TEARDOWN + session clear    │
-└───────┬───────────────────────┬────────────────────────┘
-        │ RTSP/TCP              │ ALAC frames
-┌───────▼────────────┐  ┌───────▼──────────────────────┐
-│  rtsp.rs           │  │  alac.rs                     │
-│  RtspClient        │  │  encode_frame()              │
-│  ANNOUNCE / SETUP  │  │  BitWriter                   │
-│  RECORD / TEARDOWN │  │  352 S16LE → 1411-byte frame │
-└────────────────────┘  └───────┬──────────────────────┘
-                                │ encoded frames
-                        ┌───────▼──────────────────────┐
-                        │  rtp.rs                      │
-                        │  RtpSender                   │
-                        │  send_audio() — RTP/UDP      │
-                        │  send_sync()  — RTCP         │
-                        │  timing_responder() — NTP    │
-                        └──────────────────────────────┘
-                                │ UDP packets
-                        ┌───────▼──────────────────────┐
-                        │  AirPlay receiver            │
-                        │  (Apple TV, shairport-sync…) │
-                        └──────────────────────────────┘
+┌───────────────────▼─────────────────────────────────────────┐
+│  crates/airplay/src/lib.rs                                  │
+│    AirPlaySession {                                         │
+│      receivers:    Vec<ReceiverHandle>,                     │
+│      rtsp_clients: Vec<RtspClient>,                         │
+│      timing:       TimingSocket,   ← shared, one port       │
+│      pacing:       PacingClock,    ← shared clock           │
+│      buf, first_frame,                                      │
+│    }                                                        │
+│    pcm_airplay_connect()  — handshake per receiver          │
+│    pcm_airplay_write()    — encode once, fan out            │
+│    pcm_airplay_stop()     — TEARDOWN all + session clear    │
+└───┬───────────────────────┬─────────────────────────────────┘
+    │ RTSP/TCP (per rx)     │ ALAC frames
+┌───▼────────────┐  ┌───────▼─────────────────────────────────┐
+│  rtsp.rs       │  │  alac.rs                                │
+│  RtspClient    │  │  encode_frame()  — called once/frame    │
+│  ANNOUNCE      │  │  BitWriter                              │
+│  SETUP         │  │  352 S16LE → 1411-byte verbatim frame   │
+│  RECORD        │  └───────┬─────────────────────────────────┘
+│  SET_PARAMETER │          │ encoded frame (shared reference)
+│  TEARDOWN      │  ┌───────▼─────────────────────────────────┐
+└────────────────┘  │  rtp.rs                                 │
+                    │  ReceiverHandle  (per receiver)         │
+                    │    send_audio_packet() — RTP/UDP        │
+                    │    send_sync()         — RTCP           │
+                    │  TimingSocket (shared, one port)        │
+                    │    timing_responder()  — NTP thread     │
+                    │  PacingClock (shared)                   │
+                    │    pace()  — one sleep for all rooms    │
+                    └───────┬─────────────────────────────────┘
+                            │ UDP packets (fan-out)
+              ┌─────────────┼─────────────┐
+       ┌──────▼──────┐ ┌────▼──────┐ ┌───▼──────┐
+       │  Receiver 1 │ │ Receiver 2│ │    …     │
+       └─────────────┘ └───────────┘ └──────────┘
 ```
 
 ---
@@ -99,9 +114,9 @@ following vtable:
 |-------------------|---------------------------------------------------------------------|
 | `init`            | `pthread_mutex_init` (recursive)                                    |
 | `postinit`        | no-op                                                               |
-| `set_freq`        | records `current_sample_rate` from `hw_freq_sampr[freq]`            |
+| `set_freq`        | no-op (sample rate is fixed at 44100 Hz)                            |
 | `lock` / `unlock` | `pthread_mutex_lock/unlock`                                         |
-| `play`            | `sink_dma_start` — connects, spawns `airplay_thread`                |
+| `play`            | `sink_dma_start` — connects all receivers, spawns `airplay_thread` |
 | `stop`            | `sink_dma_stop` — signals thread, joins, calls `pcm_airplay_stop()` |
 
 `airplay_pcm_sink` is registered at index `PCM_SINK_AIRPLAY = 2` in the
@@ -124,26 +139,27 @@ while not stopped:
     5. pcm_play_dma_status_callback(STARTED)   ← tells audio engine chunk consumed
 ```
 
-Unlike the FIFO sink, there is **no explicit real-time pacing** in C. Pacing is
-handled inside `rtp.rs` — the RTP sender sleeps to maintain the correct
-wall-clock transmission rate based on the RTP timestamp increment.
+Real-time pacing is handled inside `PacingClock` in `rtp.rs` — the shared
+clock sleeps once per frame after fanning out to all receivers.
 
 ---
 
 ## FFI boundary
 
-`crates/airplay/src/lib.rs` exports three `#[no_mangle] extern "C"` functions:
+`crates/airplay/src/lib.rs` exports these `#[no_mangle] extern "C"` functions:
 
-| C symbol               | Rust function          | Purpose                              |
-|------------------------|------------------------|--------------------------------------|
-| `pcm_airplay_set_host` | `pcm_airplay_set_host` | Store `HOST` + `PORT` atomics/mutex  |
-| `pcm_airplay_connect`  | `pcm_airplay_connect`  | Open RTSP + RTP session (idempotent) |
-| `pcm_airplay_write`    | `pcm_airplay_write`    | Buffer PCM, encode ALAC, send RTP    |
-| `pcm_airplay_stop`     | `pcm_airplay_stop`     | Send TEARDOWN, clear session         |
+| C symbol                    | Purpose                                                  |
+|-----------------------------|----------------------------------------------------------|
+| `pcm_airplay_set_host`      | Set a single receiver (clears any previous list)         |
+| `pcm_airplay_add_receiver`  | Append one receiver to the multi-room list               |
+| `pcm_airplay_clear_receivers` | Clear the receiver list before re-configuring          |
+| `pcm_airplay_connect`       | Open RTSP + RTP sessions for all configured receivers    |
+| `pcm_airplay_write`         | Buffer PCM, encode ALAC once, fan out to every receiver  |
+| `pcm_airplay_stop`          | Send TEARDOWN to all, clear session                      |
+| `pcm_airplay_close`         | Same as stop (called on sink switch)                     |
 
-`HOST` is a `Mutex<Option<String>>` and `PORT` is an `AtomicU16` (default
-5000). `SESSION` is a `Mutex<Option<AirPlaySession>>` — the session is
-created once and reused across `write` calls for the lifetime of a track.
+`SESSION` is a `Mutex<Option<AirPlaySession>>`. `CONFIG` is a
+`Mutex<AirPlayConfig>` holding `receivers: Vec<(String, u16)>`.
 
 ### Force-link shim
 
@@ -155,8 +171,7 @@ contains:
 use rockbox_airplay::_link_airplay as _;
 ```
 
-where `_link_airplay` is a public no-op function in `lib.rs`. This is enough
-to pull the entire crate into the link graph.
+where `_link_airplay` is a public no-op function in `lib.rs`.
 
 ---
 
@@ -168,35 +183,52 @@ every track. It is guarded by `SESSION`:
 ```
 if SESSION is already Some → return OK immediately (idempotent)
 
-1. Probe AirPlay 2 (non-fatal — logs and falls through on failure)
-2. RtpSender::bind(host, ports)     ← binds three UDP sockets
-3. RtspClient::new(host, port)      ← opens TCP connection to receiver
-4. rtsp.announce(sdp)               ← sends SDP describing the ALAC stream
-5. rtsp.setup(transport)            ← negotiates UDP port numbers
-6. rtsp.record()                    ← starts the session
-7. sender.send_initial_sync()       ← sends first RTCP sync packet
-8. SESSION = Some(AirPlaySession { sender, rtsp, buf: [], first_frame: true })
+1. Read receiver list from CONFIG
+2. TimingSocket::bind()          ← one shared NTP timing port + responder thread
+3. Choose shared initial_rtptime ← same value for ALL receivers (sync anchor)
+4. For each configured receiver:
+     a. connect_one(host, port, initial_rtptime, timing_port)
+        ├── Probe AirPlay 2 (non-fatal)
+        ├── ReceiverHandle::bind()      ← audio_sock + ctrl_sock
+        ├── RtspClient::connect()       ← TCP to receiver
+        ├── rtsp.announce(sdp)          ← SDP with ALAC params
+        ├── rtsp.setup(ctrl, timing)    ← get server UDP ports
+        ├── rx.connect(audio, ctrl)     ← connect audio_sock
+        ├── rtsp.record(seq=0, ts)      ← start stream
+        └── rtsp.set_parameter_volume(0.0)
+     b. On failure: log warning, continue (partial success OK)
+5. Abort only if ZERO receivers connected
+6. session.send_initial_sync()    ← RTCP sync to all receivers
+7. SESSION = Some(AirPlaySession { receivers, rtsp_clients, timing, pacing, … })
 ```
 
-`pcm_airplay_write(data, len)` appends the incoming PCM bytes to `buf`, then
-drains complete 352-sample (1408-byte) frames in a loop:
+`pcm_airplay_write(data, len)` accumulates PCM in `buf`, then for each
+complete 352-sample frame:
 
 ```rust
-while buf.len() >= FRAME_SIZE:
-    frame_pcm = buf.drain(..FRAME_SIZE)
-    alac_frame = alac::encode_frame(&frame_pcm)
-    sender.send_audio(&alac_frame, first_frame)
-    first_frame = false
+alac = encode_frame(&frame_bytes)          // encode ONCE
+
+for rx in &mut receivers:
+    rx.send_audio_packet(&alac, rtptime, …) // send to EACH receiver
+
+pacing.advance()                            // increment rtptime + frames_sent
+if frames_sent % 44 == 0:
+    for rx: rx.send_sync(current_ts, next_ts, false)
+
+pacing.pace()                               // sleep ONCE for all rooms
 ```
 
-`pcm_airplay_stop()` sends RTSP TEARDOWN and sets `SESSION = None`.
+`pcm_airplay_stop()` sends RTSP TEARDOWN to every receiver, then sets
+`SESSION = None`.
 
 ---
 
 ## RTSP handshake (`rtsp.rs`)
 
-`RtspClient` speaks synchronous RTSP over a single TCP connection. The full
-exchange for one session is:
+`RtspClient` speaks synchronous RTSP over a single TCP connection **per
+receiver**. The TCP connection is kept alive in `AirPlaySession.rtsp_clients`
+for the duration of the track — dropping it would cause the receiver to detect
+EOF and tear down its audio socket.
 
 ### 1. ANNOUNCE
 
@@ -211,160 +243,219 @@ t=0 0
 m=audio 0 RTP/AVP 96
 a=rtpmap:96 AppleLossless
 a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+a=min-latency:3528
 ```
 
-The `fmtp` parameters encode:
-`<frames_per_packet> <version> <bit_depth> <rice_history_mult>
+The `fmtp` parameters: `<frames/pkt> <version> <bit_depth> <rice_history_mult>
 <rice_initial_history> <rice_limit> <channels> <max_run> <max_frame_bytes>
-<avg_bit_rate> <sample_rate>`
+<avg_bit_rate> <sample_rate>`.
+
+No `a=rsaaeskey` line — encryption is disabled. The receiver sets
+`stream.encrypted = 0` and passes frames straight to the ALAC decoder.
 
 ### 2. SETUP
 
-Sends a `Transport` header requesting UDP:
+Requests UDP transport, advertising our local ctrl and timing ports:
 
 ```
-Transport: RTP/AVP/UDP;unicast;interleaved=0-1;
-           client_port=<audio_port>-<ctrl_port>
+Transport: RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;
+           control_port=<local_ctrl>;timing_port=<shared_timing>
 ```
 
-`interleaved=0-1` is required by many receivers even though the transport is
-UDP (not RTSP interleaved). The response carries the server's UDP port pair,
-extracted by `parse_port()`.
+All receivers are advertised the **same** `timing_port` (the shared
+`TimingSocket`). The response carries the server's audio, ctrl, and timing
+ports, extracted by `parse_port()`.
 
 ### 3. RECORD
 
-Starts the stream. Sends `RTP-Info` with sequence number and RTP timestamp.
+Starts the stream. Sends `RTP-Info` with sequence number 0 and the shared
+`initial_rtptime`.
 
 ### 4. SET_PARAMETER (volume)
 
-Sets playback volume. Sent as a float string in a `text/parameters` body:
-`volume: -20.0` (range −144 to 0; 0 is full volume).
+Sets playback volume to maximum (0.0 in RAOP's −144…0 range).
 
 ### 5. TEARDOWN
 
-Gracefully terminates the session. Called from `pcm_airplay_stop()`.
+Gracefully terminates the session. Called per-receiver from
+`pcm_airplay_stop()`.
 
 ---
 
 ## ALAC encoding (`alac.rs`)
 
-`encode_frame(samples: &[i16])` encodes exactly **352 stereo S16LE samples**
+`encode_frame(pcm: &[u8])` encodes exactly **352 stereo S16LE samples**
 (1408 bytes of PCM) into an ALAC verbatim ("uncompressed escape") frame.
 
 ### Frame format
 
-The Hammerton ALAC decoder expects this exact bit layout:
+The Hammerton ALAC decoder (used by shairport-sync) expects this exact bit
+layout — note there is **no** 4-bit element-instance tag after the channel
+field:
 
 ```
-Bits  Width  Field
-0–2     3    channels − 1  (= 1 for stereo)
-3–6     4    discarded (0)
-7–18   12    discarded (0)
-19      1    hassize = 0
-20–23   4    uncompressed_bytes = 0
-24      1    isNotCompressed = 1   ← verbatim frame flag
-25+    32    each sample as big-endian signed 16-bit, left then right
+Bits   Width  Field
+0–2      3    channels − 1  (= 1 for stereo)
+3–6      4    output_waiting — read and discarded
+7–18    12    unknown        — read and discarded
+19       1    hassize = 0
+20–21    2    uncompressed_bytes = 0
+22       1    isNotCompressed = 1   ← verbatim frame flag
+23+     32    each sample as big-endian signed 16-bit, left then right
+             (352 × L + R pairs = 22,528 bits)
 ```
 
-Output size = 4 bytes header + 352 × 2 channels × 2 bytes/sample
-            = **1412 bytes** (rounded up to byte boundary).
+Total: 23 header bits + 352 × 32 sample bits = 11,287 bits → **1411 bytes**
+(padded to byte boundary with no END tag).
 
 ### BitWriter
 
-`BitWriter` accumulates bits MSB-first into a `Vec<u8>`:
+`BitWriter` accumulates bits MSB-first into a `[u8; 1411]` buffer:
 
 ```rust
-fn write(&mut self, value: u64, nbits: u32)
+fn write(&mut self, value: u32, nbits: usize)
 fn align(&mut self)   // zero-pad to next byte boundary
 ```
-
-The encoder calls `write` for the 25-bit header fields and then for each
-sample (16 bits per channel, interleaved L/R), then `align()` to flush the
-final byte.
 
 ---
 
 ## RTP audio stream (`rtp.rs`)
 
-`RtpSender` opens **three UDP sockets** at construction time:
+Three types in `rtp.rs` handle the per-receiver and shared concerns:
 
-| Socket        | Direction               | Purpose             |
-|---------------|-------------------------|---------------------|
-| `audio_sock`  | → receiver audio port   | RTP audio frames    |
-| `ctrl_sock`   | ↔ receiver control port | RTCP sync packets   |
-| `timing_sock` | ↔ receiver timing port  | NTP timing exchange |
+### `ReceiverHandle` — per receiver
 
-### `send_audio(frame, marker)`
+Owns the two UDP sockets for one AirPlay endpoint:
 
-Builds a 12-byte RTP header:
+| Socket       | Direction               | Purpose             |
+|--------------|-------------------------|---------------------|
+| `audio_sock` | → receiver audio port   | RTP audio frames    |
+| `ctrl_sock`  | ↔ receiver control port | RTCP sync packets   |
+
+Also holds `ssrc` (random per receiver) and `seqnum` (wrapping u16).
+
+`send_audio_packet(alac_frame, rtptime, frame_index, first)` builds and sends
+one 12-byte RTP packet:
 
 ```
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 ├─┤─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┤
-│V=2│P│X│  CC   │M│    PT=96    │       Sequence Number       │
-├───────────────────────────────┼─────────────────────────────┤
-│                  Timestamp (RTP clock units)                │
-├─────────────────────────────────────────────────────────────┤
-│                          SSRC                               │
-└─────────────────────────────────────────────────────────────┘
+│V=2│P│X│  CC   │M│    PT=96    │       Sequence Number         │
+├───────────────────────────────┼───────────────────────────────┤
+│            Timestamp (shared rtptime — same for all receivers) │
+├────────────────────────────────────────────────────────────────┤
+│                  SSRC (per-receiver random u32)                │
+└────────────────────────────────────────────────────────────────┘
 ```
 
-- `M` (marker) = 1 on the first frame of a session, 0 thereafter.
-- Timestamp increments by **352** per frame (one ALAC frame = 352 samples).
-- SSRC is a random 32-bit value chosen at sender creation.
+- `M` (marker) = 1 on the first frame of a session only.
+- Timestamp is **shared** across all receivers — all rooms decode the same
+  logical frame position.
 
-**Real-time pacing**: `send_audio` tracks the expected transmission instant
-using `Instant` and `frame_count × Duration_per_frame` and calls
-`thread::sleep` when the sender is running ahead.
+### `TimingSocket` — shared
+
+One UDP socket bound to a random port. All receivers are told this single
+port in SETUP. `timing_responder` (a background thread) answers any PT=0xD2
+timing request from any source with a PT=0xD3 response containing the current
+NTP time.
+
+### `PacingClock` — shared
+
+Tracks `stream_start` (an `Instant`), `frames_sent`, and the current `rtptime`.
+After all receivers have been sent a frame, `pace()` sleeps until the frame's
+wall-clock deadline:
+
+```rust
+let expected = stream_start + frames_sent × FRAME_DURATION_US;
+if expected > Instant::now() { thread::sleep(expected - now); }
+```
+
+`FRAME_DURATION_US = 352 × 1_000_000 / 44100 ≈ 7982 µs`.
 
 ---
 
 ## RTCP synchronisation
 
-`send_sync(first)` sends a 20-byte RTCP NTP Send Report to the control socket
-every **44 frames** (~350 ms at 44100 Hz):
+`ReceiverHandle::send_sync(current_ts, next_ts, first)` sends a 20-byte RTCP
+packet on the ctrl socket every **44 frames** (~350 ms at 44100 Hz):
 
 ```
-Byte  Field
-0     V=2, P=0, RC=0
-1     PT=200 (SR) or 0xD4 (first sync)
-2–3   length = 4 (words after fixed header)
-4–7   SSRC
-8–11  NTP timestamp seconds (since 1900-01-01)
-12–15 NTP timestamp fraction (2^32 units)
-16–19 RTP timestamp (matching the next audio frame's timestamp)
+Byte   Field
+0      0x80 (normal) or 0x90 (first sync, extension bit set)
+1      0xD4  (PT=212, Apple proprietary sync)
+2–3    0x0007  (length field)
+4–7    current RTP timestamp (frame just sent)
+8–11   NTP seconds (since 1900-01-01, = UNIX_time + 0x83AA7E80)
+12–15  NTP fraction (2^32 units per second)
+16–19  next RTP timestamp (next frame to be sent)
 ```
 
-`NTP_EPOCH_DELTA = 0x83AA_7E80` converts UNIX time (seconds since 1970) to NTP
-time (seconds since 1900).
-
-The first sync packet (`first=true`) uses PT=`0xD4` (not standard SR) — some
-receivers require this to accept the initial synchronisation.
+`current_ts` and `next_ts` are derived from the shared `PacingClock.rtptime`,
+so all receivers receive consistent timestamps.
 
 ---
 
 ## NTP timing responder
 
-A background thread (`timing_responder`) listens on `timing_sock` and answers
-NTP timing requests from the receiver:
+A single background thread (`timing_responder`) listens on the shared
+`TimingSocket` and answers NTP timing requests from **all** receivers:
 
 ```
-Request  PT = 0xD2  (timing request)
+Request  PT = 0xD2  (timing request, from any receiver)
 Response PT = 0xD3  (timing response)
 
-Response body (32 bytes):
-  [0–3]   SSRC
-  [4–7]   0 (reference seconds)
-  [8–11]  0 (reference fraction)
-  [12–15] received seconds  (echoed from request)
-  [16–19] received fraction (echoed from request)
-  [20–23] send seconds      (current NTP time)
-  [24–27] send fraction     (current NTP time)
+Response layout (32 bytes):
+  [0]    0x80
+  [1]    0xD3
+  [2–3]  sequence number (copied from request)
+  [4–7]  padding (zero)
+  [8–15] reference NTP (zero)
+  [16–23] originate NTP (copied from request bytes [16–23])
+  [24–31] receive/transmit NTP (current system time)
 ```
 
-Many receivers stall playback if timing responses stop arriving. The thread
-runs for the entire duration of the session.
+Using one socket for all receivers works because the responder uses
+`send_to(src)` to reply to the exact source address of each request.
+
+---
+
+## Multi-room fan-out
+
+The complete per-frame processing path in `AirPlaySession::send_frame()`:
+
+```
+1. encode_frame(&pcm)               → alac: [u8; 1411]   (once, ~5 µs)
+2. for rx in receivers:
+     rx.send_audio_packet(&alac, …) → UDP send            (per receiver, ~1 µs each)
+3. pacing.advance()                 → increment rtptime, frames_sent
+4. if frames_sent % 44 == 0:
+     for rx in receivers:
+       rx.send_sync(…)              → RTCP UDP send       (per receiver)
+5. pacing.pace()                    → thread::sleep       (once, ~7982 µs avg)
+```
+
+With N receivers, steps 2 and 4 take O(N) sequential UDP sends (~1–2 µs each).
+Even with 10 receivers the added latency (~20 µs) is negligible compared to
+the 7982 µs frame budget.
+
+### Sync accuracy
+
+All receivers share the same `initial_rtptime` and receive each frame within
+the same loop iteration (a few microseconds apart). Their playout timestamps
+are identical. Actual synchronisation accuracy is bounded by:
+- Receiver buffer depth (typically 1–3 s for shairport-sync)
+- NTP timing exchange accuracy (usually < 5 ms on LAN)
+
+This gives **AirPlay 1-level sync** — adequate for multi-room on a LAN.
+Sample-accurate sync across rooms requires AirPlay 2's clock-anchoring, which
+is a different protocol.
+
+### Partial failure
+
+If one receiver fails to connect during `pcm_airplay_connect()`, the error is
+logged at `warn` level and the session continues with the remaining receivers.
+The session is only aborted when **zero** receivers connect successfully.
 
 ---
 
@@ -372,55 +463,74 @@ runs for the entire duration of the session.
 
 When Rockbox moves to the next track:
 
-1. `sink_dma_stop()` is called → `pcm_airplay_stop()` → RTSP TEARDOWN →
-   `SESSION = None`.
-2. `sink_dma_start()` is called for the new track → `pcm_airplay_connect()` →
-   new RTSP session with fresh RTP sequence/timestamp counters.
+1. `sink_dma_stop()` → `pcm_airplay_stop()` → RTSP TEARDOWN on every receiver
+   → `SESSION = None`.
+2. `sink_dma_start()` → `pcm_airplay_connect()` → new RTSP sessions with
+   fresh RTP sequence/timestamp counters and a new random `initial_rtptime`.
 
 There is a brief gap (TEARDOWN round-trip + new ANNOUNCE/SETUP/RECORD) between
-tracks. This is inherent to RAOP and is typically inaudible (<100 ms).
+tracks, inherent to RAOP and typically inaudible (< 100 ms).
 
 ---
 
 ## Configuration
 
-In `~/.config/rockbox.org/settings.toml`:
+### Single receiver (backward-compatible)
 
 ```toml
 audio_output = "airplay"
-airplay_host = "192.168.1.x"   # IP of the AirPlay receiver
+airplay_host = "192.168.1.50"   # IP of the AirPlay receiver
 airplay_port = 5000             # optional, default 5000
 ```
 
-`crates/settings/src/lib.rs:load_settings()` reads these values and calls:
+### Multi-room
 
-```rust
-pcm::airplay_set_host(&host, port);
-pcm::switch_sink(PCM_SINK_AIRPLAY);
+```toml
+audio_output = "airplay"
+
+[[airplay_receivers]]
+host = "192.168.1.50"
+port = 5000              # optional, default 5000
+
+[[airplay_receivers]]
+host = "192.168.1.51"
+
+[[airplay_receivers]]
+host = "192.168.1.52"
+port = 5001
 ```
 
-`airplay_set_host` stores the host in `HOST: Mutex<Option<String>>` and the
-port in `PORT: AtomicU16`. These are read by `pcm_airplay_connect()` at the
-start of each track.
+`airplay_receivers` takes precedence over `airplay_host`/`airplay_port` when
+both are present. `crates/settings/src/lib.rs` calls
+`pcm_airplay_clear_receivers()` then `pcm_airplay_add_receiver()` for each
+entry.
+
+### Runtime control
+
+The Rust FFI also exposes:
+
+```rust
+pcm::airplay_set_host("192.168.1.50", 5000);     // replace list with one receiver
+pcm::airplay_add_receiver("192.168.1.51", 5000); // append to list
+pcm::airplay_clear_receivers();                   // clear before re-configuring
+```
 
 ---
 
 ## AirPlay 2 probe
 
-`pcm_airplay_connect()` first attempts an AirPlay 2 handshake (PTP-based). If
-it fails (connection refused, or the receiver does not support AirPlay 2) the
-error is logged at `tracing::debug!` level and the function falls through to the
-AirPlay 1 / RAOP path. This makes the probe transparent to the user.
+`connect_one()` first attempts an AirPlay 2 handshake (HAP-based). If it
+fails the error is logged at `tracing::debug!` and the function falls through
+to the AirPlay 1 / RAOP path. This makes the probe transparent to the user.
 
-The AirPlay 2 path uses the cryptographic dependencies declared in
-`Cargo.toml`:
+The AirPlay 2 path uses:
 
 ```toml
-x25519-dalek        # key exchange
-ed25519-dalek       # signature
-chacha20poly1305    # AEAD encryption
+x25519-dalek        # ephemeral key exchange (PAIR-VERIFY)
+ed25519-dalek       # long-term identity signature
+chacha20poly1305    # AEAD encryption of the identity payload
 sha2, hkdf, hmac    # key derivation
-num-bigint          # SRP big-integer arithmetic
+num-bigint          # SRP 3072-bit big-integer arithmetic (PAIR-SETUP)
 ```
 
 None of these are needed for the AirPlay 1 code path.
@@ -429,45 +539,42 @@ None of these are needed for the AirPlay 1 code path.
 
 ## Gotchas and known limits
 
-### 1. Only one simultaneous receiver
+### 1. Receiver must be reachable via UDP
 
-The `SESSION` mutex holds a single `AirPlaySession`. Sending to multiple
-AirPlay devices simultaneously is not supported. For multi-room output use
-the Squeezelite sink with multiple clients, or run multiple rockboxd instances.
+RAOP uses UDP with no NAT traversal. Every configured receiver must be
+directly reachable at its IP from the machine running rockboxd. Multicast
+discovery (mDNS/Bonjour) is not implemented — supply the IP manually.
 
-### 2. Receiver must be on the local network
-
-RAOP uses UDP with no NAT traversal. The receiver must be directly reachable
-at the configured IP. Multicast discovery (mDNS/Bonjour) is not implemented —
-you must supply the IP manually.
-
-### 3. `interleaved=0-1` in Transport header
+### 2. `interleaved=0-1` in Transport header
 
 Even though the transport is plain UDP, most receivers require the
-`interleaved=0-1` parameter in the SETUP `Transport` header. Omitting it causes
-the receiver to ignore the `RECORD` command silently.
+`interleaved=0-1` parameter in the SETUP `Transport` header. Omitting it
+causes the receiver to silently ignore the `RECORD` command.
 
-### 4. Verbatim ALAC only (no compression)
+### 3. Verbatim ALAC only (no compression)
 
 `alac.rs` only implements the verbatim escape frame (`isNotCompressed=1`).
 Bitrate is fixed at `sample_rate × 4 bytes/s = 176,400 bytes/s` at 44.1 kHz.
-This is fine for LAN streaming but wasteful compared to the compressed ALAC
-path.
+Fine for LAN streaming but higher than compressed ALAC.
 
-### 5. Fixed 44100 Hz sample rate
+### 4. Fixed 44100 Hz sample rate
 
-The RTSP SDP and ALAC frame size constants are hard-coded for 44100 Hz.
-Playback of 48 kHz or 96 kHz tracks is not tested and may produce incorrect
-pitch or receiver errors.
+The SDP and ALAC frame size constants are hard-coded for 44100 Hz. Playback
+of 48 kHz or 96 kHz tracks is not tested.
+
+### 5. Multi-room sync is LAN-quality, not sample-accurate
+
+See [Sync accuracy](#sync-accuracy). AirPlay 2-level clock anchoring is not
+implemented.
 
 ### 6. Logging uses `tracing`, never `println!`
 
-All diagnostic output is routed through the `tracing` crate. To see the full
-AirPlay negotiation:
+All diagnostic output is routed through the `tracing` crate:
 
 ```sh
-RUST_LOG=rockbox_airplay=debug rockboxd
+RUST_LOG=rockbox_airplay=debug rockboxd   # full protocol trace
+RUST_LOG=info rockboxd                    # lifecycle events only
 ```
 
-Never add `println!` or `eprintln!` — those bypass the log filter and pollute
-stdout, breaking FIFO/pipe mode.
+Never add `println!` or `eprintln!` — those bypass the log filter and can
+corrupt the stdout PCM stream in FIFO mode.

--- a/crates/airplay/src/lib.rs
+++ b/crates/airplay/src/lib.rs
@@ -7,36 +7,89 @@ mod rtsp;
 #[doc(hidden)]
 pub fn _link_airplay() {}
 
-use alac::{encode_frame, PCM_BYTES_PER_FRAME};
-use rtp::RtpSender;
+use alac::{encode_frame, FRAME_SAMPLES, PCM_BYTES_PER_FRAME};
+use rtp::{PacingClock, ReceiverHandle, TimingSocket};
 use rtsp::RtspClient;
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_ushort};
 use std::sync::Mutex;
 
+// ---------------------------------------------------------------------------
+// Global state
+// ---------------------------------------------------------------------------
+
 static SESSION: Mutex<Option<AirPlaySession>> = Mutex::new(None);
 
 struct AirPlaySession {
-    sender: RtpSender,
-    rtsp: RtspClient,
+    receivers: Vec<ReceiverHandle>,
+    timing: TimingSocket,
+    rtsp_clients: Vec<RtspClient>,
     buf: Vec<u8>,
     first_frame: bool,
+    pacing: PacingClock,
 }
 
+impl AirPlaySession {
+    /// Encode one ALAC frame and fan it out to every connected receiver.
+    fn send_frame(&mut self, frame_bytes: &[u8; PCM_BYTES_PER_FRAME], first: bool) {
+        let alac = encode_frame(frame_bytes);
+        let rtptime = self.pacing.rtptime;
+        let frame_index = self.pacing.frames_sent;
+
+        for rx in &mut self.receivers {
+            rx.send_audio_packet(&alac, rtptime, frame_index, first);
+        }
+
+        self.pacing.advance();
+
+        // RTCP NTP sync every ~44 frames (~0.35 s)
+        if self.pacing.frames_sent % 44 == 0 {
+            let current_ts = self.pacing.rtptime.wrapping_sub(FRAME_SAMPLES as u32);
+            let next_ts = self.pacing.rtptime;
+            for rx in &self.receivers {
+                rx.send_sync(current_ts, next_ts, false);
+            }
+        }
+
+        // Pace once for all receivers
+        self.pacing.pace();
+    }
+
+    fn send_initial_sync(&self) {
+        let ts = self.pacing.initial_rtptime;
+        for rx in &self.receivers {
+            rx.send_sync(ts, ts, true);
+        }
+        tracing::debug!(
+            "sent initial sync ts={} to {} receiver(s)",
+            ts,
+            self.receivers.len()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
 static CONFIG: Mutex<AirPlayConfig> = Mutex::new(AirPlayConfig {
-    host: None,
-    port: 5000,
+    receivers: Vec::new(),
 });
 
 struct AirPlayConfig {
-    host: Option<String>,
-    port: u16,
+    receivers: Vec<(String, u16)>,
 }
 
-// Safety: the raw pointer in host is only touched inside the mutex
+// Safety: Vec<(String, u16)> is Send
 unsafe impl Send for AirPlayConfig {}
 
+// ---------------------------------------------------------------------------
+// FFI — configuration
+// ---------------------------------------------------------------------------
+
+/// Set a single AirPlay receiver, replacing any previously configured list.
+/// Kept for backward compatibility with existing C callers and settings.
 #[no_mangle]
 pub extern "C" fn pcm_airplay_set_host(host: *const c_char, port: c_ushort) {
     if host.is_null() {
@@ -46,109 +99,152 @@ pub extern "C" fn pcm_airplay_set_host(host: *const c_char, port: c_ushort) {
         .to_string_lossy()
         .into_owned();
     let mut cfg = CONFIG.lock().unwrap();
-    cfg.host = Some(s);
-    cfg.port = port;
+    cfg.receivers.clear();
+    cfg.receivers.push((s, port));
 }
+
+/// Append one receiver to the multi-room list.
+#[no_mangle]
+pub extern "C" fn pcm_airplay_add_receiver(host: *const c_char, port: c_ushort) {
+    if host.is_null() {
+        return;
+    }
+    let s = unsafe { CStr::from_ptr(host) }
+        .to_string_lossy()
+        .into_owned();
+    let mut cfg = CONFIG.lock().unwrap();
+    cfg.receivers.push((s, port));
+}
+
+/// Clear the receiver list (call before re-configuring).
+#[no_mangle]
+pub extern "C" fn pcm_airplay_clear_receivers() {
+    CONFIG.lock().unwrap().receivers.clear();
+}
+
+// ---------------------------------------------------------------------------
+// FFI — session lifecycle
+// ---------------------------------------------------------------------------
 
 #[no_mangle]
 pub extern "C" fn pcm_airplay_connect() -> c_int {
-    // Already connected — don't redo the RTSP handshake for every DMA chunk.
     if SESSION.lock().unwrap().is_some() {
-        return 0;
+        return 0; // idempotent
     }
 
-    let cfg = CONFIG.lock().unwrap();
-    let host = match cfg.host.clone() {
-        Some(h) => h,
-        None => {
-            tracing::error!("pcm_airplay_connect: no host configured");
+    let targets = {
+        let cfg = CONFIG.lock().unwrap();
+        if cfg.receivers.is_empty() {
+            tracing::error!("pcm_airplay_connect: no receivers configured");
             return -1;
         }
+        cfg.receivers.clone()
     };
-    let port = cfg.port;
-    drop(cfg);
 
-    let local_ip = local_ip_for(&host).unwrap_or_else(|| "127.0.0.1".to_string());
-    tracing::info!("connecting to {}:{} (local_ip={})", host, port, local_ip);
-
-    // Attempt AirPlay 2 pairing (PAIR-VERIFY / PAIR-SETUP).
-    // Failure here is non-fatal — many AirPlay 1 receivers don't have the endpoint.
-    match airplay2::connect(&host, port, None) {
-        Ok(()) => tracing::info!("AirPlay 2 handshake complete"),
-        Err(e) => tracing::debug!("AirPlay 2 handshake skipped ({}), using AirPlay 1", e),
-    }
-
-    let session_token: u64 = rand::random();
-    let ssrc: u32 = rand::random();
+    // All receivers share the same initial_rtptime for RTP-level synchronisation.
     let initial_rtptime: u32 = rand::random();
 
-    // Bind all UDP sockets first so we know the local ports before SETUP.
-    let mut sender = match RtpSender::bind(ssrc, initial_rtptime) {
-        Ok(s) => s,
+    // Bind the shared timing socket first; every receiver advertises the same port.
+    let timing = match TimingSocket::bind() {
+        Ok(t) => t,
         Err(e) => {
-            tracing::error!("bind failed: {}", e);
+            tracing::error!("timing socket bind failed: {}", e);
             return -1;
         }
     };
-    let local_ctrl_port = sender.local_ctrl_port;
-    let local_timing_port = sender.local_timing_port;
+    let local_timing_port = timing.local_port;
 
-    let mut rtsp = match RtspClient::connect(&host, port, session_token) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("RTSP TCP connect failed: {}", e);
-            return -1;
-        }
-    };
+    let mut receivers: Vec<ReceiverHandle> = Vec::new();
+    let mut rtsp_clients: Vec<RtspClient> = Vec::new();
+    let mut connected = 0usize;
 
-    if let Err(e) = rtsp.announce(&local_ip, &host) {
-        tracing::error!("ANNOUNCE failed: {}", e);
-        return -1;
-    }
-
-    let (server_audio, server_ctrl, _server_timing) =
-        match rtsp.setup(local_ctrl_port, local_timing_port) {
-            Ok(ports) => ports,
-            Err(e) => {
-                tracing::error!("SETUP failed: {}", e);
-                return -1;
+    for (host, port) in &targets {
+        match connect_one(host, *port, initial_rtptime, local_timing_port) {
+            Ok((rx, rtsp)) => {
+                tracing::info!("connected to {}:{}", host, port);
+                receivers.push(rx);
+                rtsp_clients.push(rtsp);
+                connected += 1;
             }
-        };
+            Err(e) => tracing::warn!("failed to connect to {}:{}: {}", host, port, e),
+        }
+    }
 
-    if let Err(e) = sender.connect_server(&host, server_audio, server_ctrl) {
-        tracing::error!("connect_server failed: {}", e);
+    if connected == 0 {
+        tracing::error!("could not connect to any AirPlay receiver");
         return -1;
     }
 
-    if let Err(e) = rtsp.record(0, initial_rtptime) {
-        tracing::error!("RECORD failed: {}", e);
-        return -1;
-    }
-
-    // Set volume to maximum; RAOP range: -144.0 (mute) to 0.0 (full).
-    if let Err(e) = rtsp.set_parameter_volume(0.0) {
-        tracing::warn!("SET_PARAMETER volume failed (non-fatal): {}", e);
-    }
-
-    sender.send_initial_sync();
-    tracing::info!(
-        "session established — sending audio to {}:{}",
-        host,
-        server_audio
-    );
-
-    let mut guard = SESSION.lock().unwrap();
-    *guard = Some(AirPlaySession {
-        sender,
-        rtsp,
+    let pacing = PacingClock::new(initial_rtptime);
+    let session = AirPlaySession {
+        receivers,
+        timing,
+        rtsp_clients,
         buf: Vec::with_capacity(PCM_BYTES_PER_FRAME * 4),
         first_frame: true,
-    });
+        pacing,
+    };
 
+    session.send_initial_sync();
+    tracing::info!(
+        "session established: {}/{} receiver(s) connected",
+        connected,
+        targets.len()
+    );
+
+    *SESSION.lock().unwrap() = Some(session);
     0
 }
 
-/// Write raw S16LE stereo PCM. Buffers into 352-sample frames, encodes ALAC, sends RTP.
+/// Connect to a single AirPlay receiver. Returns `(ReceiverHandle, RtspClient)` on success.
+fn connect_one(
+    host: &str,
+    port: u16,
+    initial_rtptime: u32,
+    local_timing_port: u16,
+) -> std::io::Result<(ReceiverHandle, RtspClient)> {
+    let local_ip = local_ip_for(host).unwrap_or_else(|| "127.0.0.1".to_string());
+
+    // Attempt AirPlay 2 pairing (non-fatal fallback to AirPlay 1).
+    match airplay2::connect(host, port, None) {
+        Ok(()) => tracing::info!("AirPlay 2 handshake complete for {}:{}", host, port),
+        Err(e) => tracing::debug!(
+            "AirPlay 2 skipped for {}:{} ({}), using AirPlay 1",
+            host,
+            port,
+            e
+        ),
+    }
+
+    let session_token: u64 = rand::random();
+
+    let mut rx = ReceiverHandle::bind()?;
+    let local_ctrl_port = rx.local_ctrl_port;
+
+    let mut rtsp = RtspClient::connect(host, port, session_token)?;
+    rtsp.announce(&local_ip, host)?;
+
+    let (server_audio, server_ctrl, _server_timing) =
+        rtsp.setup(local_ctrl_port, local_timing_port)?;
+
+    rx.connect(host, server_audio, server_ctrl)?;
+    rtsp.record(0, initial_rtptime)?;
+
+    // Set volume to maximum; RAOP range: -144.0 (mute) to 0.0 (full).
+    if let Err(e) = rtsp.set_parameter_volume(0.0) {
+        tracing::warn!(
+            "SET_PARAMETER volume failed for {}:{} (non-fatal): {}",
+            host,
+            port,
+            e
+        );
+    }
+
+    Ok((rx, rtsp))
+}
+
+/// Write raw S16LE stereo PCM. Buffers into 352-sample frames, encodes ALAC,
+/// fans out to every connected receiver, then paces once.
 #[no_mangle]
 pub extern "C" fn pcm_airplay_write(data: *const u8, len: usize) -> c_int {
     if data.is_null() || len == 0 {
@@ -166,7 +262,11 @@ pub extern "C" fn pcm_airplay_write(data: *const u8, len: usize) -> c_int {
     };
 
     if session.first_frame {
-        tracing::debug!("first write: {} bytes", len);
+        tracing::debug!(
+            "first write: {} bytes, {} receiver(s)",
+            len,
+            session.receivers.len()
+        );
     }
 
     session.buf.extend_from_slice(input);
@@ -176,10 +276,9 @@ pub extern "C" fn pcm_airplay_write(data: *const u8, len: usize) -> c_int {
             session.buf[..PCM_BYTES_PER_FRAME].try_into().unwrap();
         session.buf.drain(..PCM_BYTES_PER_FRAME);
 
-        let alac = encode_frame(&frame_bytes);
         let first = session.first_frame;
         session.first_frame = false;
-        session.sender.send_audio(&alac, first);
+        session.send_frame(&frame_bytes, first);
     }
 
     0
@@ -189,7 +288,9 @@ pub extern "C" fn pcm_airplay_write(data: *const u8, len: usize) -> c_int {
 pub extern "C" fn pcm_airplay_stop() {
     let mut guard = SESSION.lock().unwrap();
     if let Some(ref mut session) = *guard {
-        let _ = session.rtsp.teardown();
+        for rtsp in &mut session.rtsp_clients {
+            let _ = rtsp.teardown();
+        }
     }
     *guard = None;
 }
@@ -198,10 +299,16 @@ pub extern "C" fn pcm_airplay_stop() {
 pub extern "C" fn pcm_airplay_close() {
     let mut guard = SESSION.lock().unwrap();
     if let Some(ref mut session) = *guard {
-        let _ = session.rtsp.teardown();
+        for rtsp in &mut session.rtsp_clients {
+            let _ = rtsp.teardown();
+        }
     }
     *guard = None;
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 fn local_ip_for(remote: &str) -> Option<String> {
     use std::net::UdpSocket;

--- a/crates/airplay/src/rtp.rs
+++ b/crates/airplay/src/rtp.rs
@@ -11,70 +11,38 @@ pub const RTP_PACKET_BYTES: usize = RTP_HEADER_BYTES + ALAC_FRAME_BYTES;
 const NTP_EPOCH_DELTA: u32 = 0x83AA_7E80;
 
 // Duration of one ALAC frame at 44100 Hz
-const FRAME_DURATION_US: u64 = FRAME_SAMPLES as u64 * 1_000_000 / 44100; // ~7982 µs
+pub const FRAME_DURATION_US: u64 = FRAME_SAMPLES as u64 * 1_000_000 / 44100; // ~7982 µs
 
-pub struct RtpSender {
+/// Per-receiver UDP state. One of these per AirPlay endpoint.
+pub struct ReceiverHandle {
     audio_sock: UdpSocket,
     ctrl_sock: UdpSocket,
     server_ctrl_addr: std::net::SocketAddr,
-    ssrc: u32,
-    seqnum: u16,
-    rtptime: u32,
-    initial_rtptime: u32,
-    frames_sent: u64,
     pub local_ctrl_port: u16,
-    pub local_timing_port: u16,
-    stream_start: Option<Instant>,
-    // kept alive so the OS port stays open; responder thread holds the other Arc
-    _timing_sock: Arc<UdpSocket>,
+    pub ssrc: u32,
+    pub seqnum: u16,
 }
 
-impl RtpSender {
-    /// Bind all local UDP sockets. `connect_server()` must be called after SETUP
-    /// once the server's ports are known.
-    pub fn bind(ssrc: u32, initial_rtptime: u32) -> std::io::Result<Self> {
+impl ReceiverHandle {
+    /// Bind local audio and ctrl sockets. Call `connect()` after SETUP.
+    pub fn bind() -> std::io::Result<Self> {
         let audio_sock = UdpSocket::bind("0.0.0.0:0")?;
         let ctrl_sock = UdpSocket::bind("0.0.0.0:0")?;
         let local_ctrl_port = ctrl_sock.local_addr()?.port();
-        let timing_sock = Arc::new(UdpSocket::bind("0.0.0.0:0")?);
-        let local_timing_port = timing_sock.local_addr()?.port();
-
-        // Respond to NTP timing requests from the receiver so it can synchronise
-        // and actually start playing. Without this, the timing port gets ICMP
-        // unreachable replies and many receivers stall indefinitely.
-        let timing_thread = Arc::clone(&timing_sock);
-        thread::spawn(move || timing_responder(timing_thread));
-
+        let ssrc: u32 = rand::random();
         let server_ctrl_addr = "0.0.0.0:0".parse().unwrap();
-        tracing::debug!(
-            "local ctrl_port={} timing_port={}",
-            local_ctrl_port,
-            local_timing_port
-        );
-
         Ok(Self {
             audio_sock,
             ctrl_sock,
             server_ctrl_addr,
+            local_ctrl_port,
             ssrc,
             seqnum: 0,
-            rtptime: initial_rtptime,
-            initial_rtptime,
-            frames_sent: 0,
-            local_ctrl_port,
-            local_timing_port,
-            stream_start: None,
-            _timing_sock: timing_sock,
         })
     }
 
     /// Connect the audio socket to the server's RTP port and record the ctrl addr.
-    pub fn connect_server(
-        &mut self,
-        host: &str,
-        audio_port: u16,
-        ctrl_port: u16,
-    ) -> std::io::Result<()> {
+    pub fn connect(&mut self, host: &str, audio_port: u16, ctrl_port: u16) -> std::io::Result<()> {
         tracing::debug!("connecting audio → {}:{}", host, audio_port);
         self.audio_sock
             .connect(format!("{}:{}", host, audio_port))?;
@@ -84,18 +52,23 @@ impl RtpSender {
         Ok(())
     }
 
-    pub fn send_audio(&mut self, alac_frame: &[u8; ALAC_FRAME_BYTES], first: bool) {
-        let start = *self.stream_start.get_or_insert_with(Instant::now);
-
+    /// Build and send one RTP audio packet. Increments seqnum.
+    pub fn send_audio_packet(
+        &mut self,
+        alac_frame: &[u8; ALAC_FRAME_BYTES],
+        rtptime: u32,
+        frame_index: u64,
+        first: bool,
+    ) {
         let mut pkt = [0u8; RTP_PACKET_BYTES];
         pkt[0] = 0x80;
         pkt[1] = if first { 0x60 | 0x80 } else { 0x60 }; // M=1 on first, PT=96
         pkt[2] = (self.seqnum >> 8) as u8;
         pkt[3] = self.seqnum as u8;
-        pkt[4] = (self.rtptime >> 24) as u8;
-        pkt[5] = (self.rtptime >> 16) as u8;
-        pkt[6] = (self.rtptime >> 8) as u8;
-        pkt[7] = self.rtptime as u8;
+        pkt[4] = (rtptime >> 24) as u8;
+        pkt[5] = (rtptime >> 16) as u8;
+        pkt[6] = (rtptime >> 8) as u8;
+        pkt[7] = rtptime as u8;
         pkt[8] = (self.ssrc >> 24) as u8;
         pkt[9] = (self.ssrc >> 16) as u8;
         pkt[10] = (self.ssrc >> 8) as u8;
@@ -104,47 +77,28 @@ impl RtpSender {
 
         match self.audio_sock.send(&pkt) {
             Ok(_) => {
-                if self.frames_sent < 5 {
+                if frame_index < 5 {
                     tracing::debug!(
                         "sent frame {} ts={} seq={} first={}",
-                        self.frames_sent,
-                        self.rtptime,
+                        frame_index,
+                        rtptime,
                         self.seqnum,
                         first
                     );
                 }
             }
-            Err(e) => tracing::warn!("send error on frame {}: {}", self.frames_sent, e),
+            Err(e) => tracing::warn!("send error on frame {}: {}", frame_index, e),
         }
-
         self.seqnum = self.seqnum.wrapping_add(1);
-        self.rtptime = self.rtptime.wrapping_add(FRAME_SAMPLES as u32);
-        self.frames_sent += 1;
-
-        // RTCP NTP sync every ~44 frames (~0.35 s)
-        if self.frames_sent % 44 == 0 {
-            self.send_sync(false);
-        }
-
-        // Real-time pacing — sleep until the frame's playout deadline.
-        let expected = start + Duration::from_micros(self.frames_sent * FRAME_DURATION_US);
-        let now = Instant::now();
-        if expected > now {
-            std::thread::sleep(expected - now);
-        }
     }
 
-    fn send_sync(&self, first: bool) {
+    /// Send an RTCP NTP sync packet on the ctrl socket.
+    pub fn send_sync(&self, current_ts: u32, next_ts: u32, first: bool) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default();
         let ntp_sec = now.as_secs() as u32 + NTP_EPOCH_DELTA;
         let ntp_frac = ((now.subsec_nanos() as u64 * (1u64 << 32)) / 1_000_000_000) as u32;
-
-        // "current" timestamp = frame we just sent (rtptime was already incremented)
-        let current_ts = self.rtptime.wrapping_sub(FRAME_SAMPLES as u32);
-        // "next" timestamp = self.rtptime (next frame to be sent)
-        let next_ts = self.rtptime;
 
         let mut pkt = [0u8; 20];
         pkt[0] = if first { 0x90 } else { 0x80 };
@@ -170,46 +124,68 @@ impl RtpSender {
 
         let _ = self.ctrl_sock.send_to(&pkt, self.server_ctrl_addr);
     }
+}
 
-    pub fn send_initial_sync(&self) {
-        // At startup no frames have been sent yet; use initial_rtptime for both
-        // "current" and "next" so we don't send a backwards-wrapped timestamp.
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        let ntp_sec = now.as_secs() as u32 + NTP_EPOCH_DELTA;
-        let ntp_frac = ((now.subsec_nanos() as u64 * (1u64 << 32)) / 1_000_000_000) as u32;
-        let ts = self.initial_rtptime;
+/// Shared NTP timing socket. One instance serves all receivers — the responder
+/// doesn't care which receiver the request came from, it just replies in place.
+pub struct TimingSocket {
+    pub local_port: u16,
+    // kept alive so the OS port stays open; responder thread holds the other Arc
+    _sock: Arc<UdpSocket>,
+}
 
-        let mut pkt = [0u8; 20];
-        pkt[0] = 0x90; // first sync: extension bit set
-        pkt[1] = 0xd4;
-        pkt[2] = 0x00;
-        pkt[3] = 0x07;
-        pkt[4] = (ts >> 24) as u8;
-        pkt[5] = (ts >> 16) as u8;
-        pkt[6] = (ts >> 8) as u8;
-        pkt[7] = ts as u8;
-        pkt[8] = (ntp_sec >> 24) as u8;
-        pkt[9] = (ntp_sec >> 16) as u8;
-        pkt[10] = (ntp_sec >> 8) as u8;
-        pkt[11] = ntp_sec as u8;
-        pkt[12] = (ntp_frac >> 24) as u8;
-        pkt[13] = (ntp_frac >> 16) as u8;
-        pkt[14] = (ntp_frac >> 8) as u8;
-        pkt[15] = ntp_frac as u8;
-        pkt[16] = (ts >> 24) as u8;
-        pkt[17] = (ts >> 16) as u8;
-        pkt[18] = (ts >> 8) as u8;
-        pkt[19] = ts as u8;
+impl TimingSocket {
+    pub fn bind() -> std::io::Result<Self> {
+        let sock = Arc::new(UdpSocket::bind("0.0.0.0:0")?);
+        let local_port = sock.local_addr()?.port();
+        let thread_sock = Arc::clone(&sock);
+        thread::spawn(move || timing_responder(thread_sock));
+        tracing::debug!("timing responder bound on port {}", local_port);
+        Ok(Self {
+            local_port,
+            _sock: sock,
+        })
+    }
+}
 
-        let _ = self.ctrl_sock.send_to(&pkt, self.server_ctrl_addr);
-        tracing::debug!("sent initial sync ts={}", ts);
+/// Pacing state shared across all receivers.
+pub struct PacingClock {
+    pub stream_start: Option<Instant>,
+    pub frames_sent: u64,
+    pub rtptime: u32,
+    pub initial_rtptime: u32,
+}
+
+impl PacingClock {
+    pub fn new(initial_rtptime: u32) -> Self {
+        Self {
+            stream_start: None,
+            frames_sent: 0,
+            rtptime: initial_rtptime,
+            initial_rtptime,
+        }
     }
 
-    pub fn reset_clock(&mut self) {
+    /// Advance after sending one frame to all receivers.
+    pub fn advance(&mut self) {
+        self.rtptime = self.rtptime.wrapping_add(FRAME_SAMPLES as u32);
+        self.frames_sent += 1;
+    }
+
+    /// Sleep until the current frame's real-time deadline.
+    pub fn pace(&mut self) {
+        let start = *self.stream_start.get_or_insert_with(Instant::now);
+        let expected = start + Duration::from_micros(self.frames_sent * FRAME_DURATION_US);
+        let now = Instant::now();
+        if expected > now {
+            std::thread::sleep(expected - now);
+        }
+    }
+
+    pub fn reset(&mut self) {
         self.stream_start = None;
         self.frames_sent = 0;
+        self.rtptime = self.initial_rtptime;
     }
 }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -933,6 +933,7 @@ pub mod api {
                     fifo_path: None,
                     airplay_host: None,
                     airplay_port: None,
+                    airplay_receivers: None,
                     squeezelite_http_port: None,
                     squeezelite_port: None,
                 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -36,13 +36,25 @@ pub fn load_settings(new_settings: Option<NewGlobalSettings>) -> Result<(), Erro
             tracing::info!("audio output: fifo ({})", path);
         }
         Some("airplay") => {
-            if let Some(ref host) = settings.airplay_host {
+            pcm::airplay_clear_receivers();
+            // Multi-room list takes precedence over the legacy single-host fields.
+            if let Some(ref receivers) = settings.airplay_receivers {
+                if receivers.is_empty() {
+                    tracing::warn!("audio output: airplay_receivers is empty");
+                }
+                for r in receivers {
+                    let port = r.port.unwrap_or(5000);
+                    pcm::airplay_add_receiver(&r.host, port);
+                    tracing::info!("audio output: airplay receiver {}:{}", r.host, port);
+                }
+                pcm::switch_sink(pcm::PCM_SINK_AIRPLAY);
+            } else if let Some(ref host) = settings.airplay_host {
                 let port = settings.airplay_port.unwrap_or(5000);
                 pcm::airplay_set_host(host, port);
                 pcm::switch_sink(pcm::PCM_SINK_AIRPLAY);
-                tracing::info!("audio output: airplay ({}:{})", host, port);
+                tracing::info!("audio output: airplay {}:{}", host, port);
             } else {
-                tracing::warn!("audio output: airplay selected but airplay_host is not set");
+                tracing::warn!("audio output: airplay selected but no receiver configured");
             }
         }
         Some("squeezelite") => {

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -1149,6 +1149,8 @@ extern "C" {
     fn pcm_switch_sink(sink: c_int) -> c_uchar;
     fn pcm_fifo_set_path(path: *const c_char);
     fn pcm_airplay_set_host(host: *const c_char, port: c_ushort);
+    fn pcm_airplay_add_receiver(host: *const c_char, port: c_ushort);
+    fn pcm_airplay_clear_receivers();
     fn pcm_squeezelite_set_slim_port(port: c_ushort);
     fn pcm_squeezelite_set_http_port(port: c_ushort);
     fn beep_play(frequency: c_uint, duration: c_uint, amplitude: c_uint);

--- a/crates/sys/src/sound/pcm.rs
+++ b/crates/sys/src/sound/pcm.rs
@@ -54,10 +54,19 @@ pub fn switch_sink(sink: i32) -> bool {
 }
 
 pub fn airplay_set_host(host: &str, port: u16) {
-    use std::ffi::CString;
     let chost = CString::new(host).expect("host must not contain null bytes");
     unsafe { crate::pcm_airplay_set_host(chost.as_ptr(), port) }
     std::mem::forget(chost);
+}
+
+pub fn airplay_add_receiver(host: &str, port: u16) {
+    let chost = CString::new(host).expect("host must not contain null bytes");
+    unsafe { crate::pcm_airplay_add_receiver(chost.as_ptr(), port) }
+    std::mem::forget(chost);
+}
+
+pub fn airplay_clear_receivers() {
+    unsafe { crate::pcm_airplay_clear_receivers() }
 }
 
 pub fn fifo_set_path(path: &str) {

--- a/crates/sys/src/types/user_settings.rs
+++ b/crates/sys/src/types/user_settings.rs
@@ -647,6 +647,14 @@ impl From<crate::UserSettings> for UserSettings {
     }
 }
 
+/// One entry in the `airplay_receivers` list in settings.toml.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct AirPlayReceiverConfig {
+    pub host: String,
+    /// RAOP port (default: 5000)
+    pub port: Option<u16>,
+}
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct NewGlobalSettings {
     pub music_dir: Option<String>,
@@ -681,10 +689,13 @@ pub struct NewGlobalSettings {
     pub audio_output: Option<String>,
     /// Path for the FIFO sink, e.g. "/tmp/rockbox.fifo" or "-" for stdout
     pub fifo_path: Option<String>,
-    /// IP address or hostname of the AirPlay (RAOP) receiver
+    /// Single AirPlay (RAOP) receiver — kept for backward compatibility.
+    /// Prefer `airplay_receivers` for multi-room setups.
     pub airplay_host: Option<String>,
-    /// RAOP port on the receiver (default: 5000)
+    /// RAOP port for the single receiver (default: 5000)
     pub airplay_port: Option<u16>,
+    /// Multi-room AirPlay receiver list. Takes precedence over `airplay_host`/`airplay_port`.
+    pub airplay_receivers: Option<Vec<AirPlayReceiverConfig>>,
     /// Slim Protocol control port for the squeezelite sink (default: 3483)
     pub squeezelite_port: Option<u16>,
     /// HTTP audio stream port for the squeezelite sink (default: 9999)
@@ -726,6 +737,7 @@ impl From<UserSettings> for NewGlobalSettings {
             fifo_path: None,
             airplay_host: None,
             airplay_port: None,
+            airplay_receivers: None,
             squeezelite_port: None,
             squeezelite_http_port: None,
         }

--- a/firmware/target/hosted/pcm-airplay.c
+++ b/firmware/target/hosted/pcm-airplay.c
@@ -39,6 +39,8 @@
 /* Rust C API — symbols are provided by the rockbox-airplay crate via
  * librockbox_cli.a. */
 extern void    pcm_airplay_set_host(const char *host, uint16_t port);
+extern void    pcm_airplay_add_receiver(const char *host, uint16_t port);
+extern void    pcm_airplay_clear_receivers(void);
 extern int     pcm_airplay_connect(void);
 extern int     pcm_airplay_write(const uint8_t *data, size_t len);
 extern void    pcm_airplay_stop(void);


### PR DESCRIPTION
Add list-based AirPlay receiver support and fan-out in the airplay crate. Introduce pcm_airplay_add_receiver and
pcm_airplay_clear_receivers
FFI bindings and a new airplay_receivers settings field (takes precedence
over the legacy airplay_host). Refactor RTP/RTSP to use per-receiver UDP state with shared pacing and per-receiver sync packets.