### PR TITLE
Add Snapcast TCP PCM sink and stream metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9503,6 +9503,7 @@ dependencies = [
  "reqwest",
  "rockbox-sys",
  "serde",
+ "serde_json",
  "socket2 0.5.7",
  "sqlx",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and Squeezelite.
 ### Audio output
 - [x] Built-in SDL audio
 - [x] AirPlay (RAOP) — single or multi-room fan-out to Apple TV, HomePod, Airport Express, shairport-sync
-- [x] Snapcast (FIFO/pipe) — synchronised multi-room via snapserver
+- [x] Snapcast — synchronised multi-room via snapserver (FIFO/pipe **and** direct TCP with mDNS auto-discovery)
 - [x] Squeezelite (Slim Protocol + HTTP broadcast) — synchronised multi-room
 - [x] Chromecast
 - [x] Gapless playback and crossfading
@@ -204,7 +204,39 @@ audio_output = "builtin"
 
 Uses SDL2 audio — plays through the OS default device. No extra setup needed.
 
-### Snapcast (FIFO / pipe)
+### Snapcast
+
+Rockbox supports two ways to feed [Snapcast](https://github.com/badaix/snapcast)
+for synchronised multi-room playback. Both write raw **S16LE stereo 44100 Hz**
+PCM to snapserver.
+
+#### TCP (recommended — auto-discovery)
+
+```toml
+music_dir         = "/path/to/Music"
+audio_output      = "snapcast_tcp"
+snapcast_tcp_host = "192.168.1.x"   # IP of the machine running snapserver
+snapcast_tcp_port = 4953            # default snapserver TCP source port
+```
+
+Connects directly to snapserver's TCP source port. No named FIFO or filesystem
+dependency needed.
+
+```ini
+# /etc/snapserver.conf  (or /usr/local/etc/snapserver.conf on macOS)
+[stream]
+source = tcp://0.0.0.0:4953?name=default&sampleformat=44100:16:2
+```
+
+> **Startup order**: start `snapserver` first so it is already listening when
+> rockboxd begins playback. If the connection drops (e.g. snapserver restarts),
+> it is re-established automatically on the next play call.
+
+> **Auto-discovery**: rockboxd scans for `_snapcast._tcp.local.` via mDNS at
+> startup. Discovered servers appear in the web UI and desktop app device
+> picker — just click to connect, no config file editing needed.
+
+#### FIFO / pipe
 
 ```toml
 music_dir    = "/path/to/Music"
@@ -212,9 +244,8 @@ audio_output = "fifo"
 fifo_path    = "/tmp/snapfifo"   # named FIFO for snapserver; use "-" for stdout
 ```
 
-Writes raw **S16LE stereo 44100 Hz** PCM to a named FIFO. Feed it into
-[Snapcast](https://github.com/badaix/snapcast) for synchronised multi-room
-playback:
+Writes to a named FIFO. Use this when you need stdout piping or prefer the
+traditional pipe model.
 
 ```ini
 # /etc/snapserver.conf  (or /usr/local/etc/snapserver.conf on macOS)
@@ -231,6 +262,9 @@ Pipe to any PCM consumer with `fifo_path = "-"`:
 ```sh
 rockboxd | ffplay -f s16le -ar 44100 -ac 2 -
 ```
+
+See [SNAPCAST.md](./SNAPCAST.md) for a detailed comparison of both modes,
+connection lifecycle, reconnect behaviour, and macOS quirks.
 
 ### AirPlay (RAOP) — single or multi-room
 

--- a/SNAPCAST.md
+++ b/SNAPCAST.md
@@ -1,43 +1,79 @@
-# Snapcast / FIFO PCM Sink
+# Snapcast — FIFO & TCP PCM Sinks
 
 This document traces every hop an audio frame takes from the Rockbox C firmware
-through the FIFO PCM sink to a Snapcast server (or any other pipe consumer).
+through the Snapcast PCM sinks to a Snapcast server.
+
+Two complementary sinks are available:
+
+| Sink | Setting value | Transport | Snapserver source type |
+|------|--------------|-----------|------------------------|
+| FIFO / pipe | `audio_output = "fifo"` | Named FIFO or stdout | `pipe://` |
+| TCP (direct) | `audio_output = "snapcast_tcp"` | TCP socket | `tcp://` |
+
+The **FIFO sink** is the traditional approach: rockboxd writes to a named pipe
+that snapserver reads. The **TCP sink** connects directly to snapserver's TCP
+source port — no FIFO, no filesystem dependency, auto-discoverable via mDNS.
 
 ---
 
 ## Table of contents
 
 1. [Overview](#overview)
-2. [Layer map](#layer-map)
-3. [PCM sink vtable (`pcm-fifo.c`)](#pcm-sink-vtable-pcm-fifoc)
-4. [The DMA thread](#the-dma-thread)
-5. [FIFO pre-open strategy](#fifo-pre-open-strategy)
-6. [stdout mode](#stdout-mode)
-7. [Track transitions and EOF prevention](#track-transitions-and-eof-prevention)
-8. [FFI boundary (`crates/sys`)](#ffi-boundary-cratessys)
-9. [Settings and startup (`crates/settings`)](#settings-and-startup-cratessettings)
-10. [Snapcast integration](#snapcast-integration)
-11. [Startup order](#startup-order)
-12. [Snapserver configuration (macOS)](#snapserver-configuration-macos)
-13. [Other pipe consumers](#other-pipe-consumers)
-14. [Gotchas and known limits](#gotchas-and-known-limits)
+2. [Choosing FIFO vs TCP](#choosing-fifo-vs-tcp)
+3. [FIFO sink](#fifo-sink)
+   - [Layer map](#fifo-layer-map)
+   - [PCM sink vtable](#pcm-sink-vtable-pcm-fifoc)
+   - [The DMA thread](#the-dma-thread)
+   - [FIFO pre-open strategy](#fifo-pre-open-strategy)
+   - [stdout mode](#stdout-mode)
+   - [Track transitions and EOF prevention](#track-transitions-and-eof-prevention)
+   - [Startup order](#startup-order-fifo)
+   - [Snapserver configuration](#snapserver-configuration-fifo)
+4. [TCP sink](#tcp-sink)
+   - [Layer map](#tcp-layer-map)
+   - [PCM sink vtable](#pcm-sink-vtable-pcm-tcpc)
+   - [Connection lifecycle](#connection-lifecycle)
+   - [Reconnect on error](#reconnect-on-error)
+   - [Startup order](#startup-order-tcp)
+   - [Snapserver configuration](#snapserver-configuration-tcp)
+5. [Auto-discovery via mDNS](#auto-discovery-via-mdns)
+6. [FFI boundary (`crates/sys`)](#ffi-boundary-cratessys)
+7. [Settings and startup (`crates/settings`)](#settings-and-startup-cratessettings)
+8. [Other pipe consumers](#other-pipe-consumers)
+9. [Gotchas and known limits](#gotchas-and-known-limits)
 
 ---
 
 ## Overview
 
-The FIFO sink writes raw **S16LE stereo PCM at 44100 Hz** to either a named
-FIFO (pipe) or stdout. Its primary use case is feeding
-[Snapcast](https://github.com/badaix/snapcast) for synchronized multi-room
-playback, but any consumer that reads a raw PCM stream works — `ffplay`,
-`aplay`, `sox`, custom scripts, etc.
-
-There is no Rust crate involved. This is a pure-C PCM sink with a thin Rust
-FFI wrapper for configuration.
+Both sinks write raw **S16LE stereo PCM at 44100 Hz** — the same byte stream
+snapserver expects regardless of source type. There is no Rust crate involved;
+both are pure-C PCM sinks with a thin Rust FFI wrapper for configuration.
 
 ---
 
-## Layer map
+## Choosing FIFO vs TCP
+
+| | FIFO sink | TCP sink |
+|---|---|---|
+| Filesystem entry required | Yes (`/tmp/snapfifo`) | No |
+| Snapserver source type | `pipe://` | `tcp://` |
+| Startup order sensitive | Yes — rockboxd first | Yes — snapserver first |
+| Reconnect on snapserver restart | No (FIFO stays open) | Yes (auto on next play) |
+| Auto-discovered in UI | No (static virtual device) | Yes (mDNS `_snapcast._tcp.local.`) |
+| stdout pipe support | Yes (`fifo_path = "-"`) | No |
+| Config | `fifo_path` | `snapcast_tcp_host` + `snapcast_tcp_port` |
+
+**Use FIFO** when you want stdout piping or prefer the traditional pipe model.
+
+**Use TCP** when you want UI-based auto-discovery, multiple snapservers, or
+don't want a filesystem dependency.
+
+---
+
+## FIFO sink
+
+### FIFO layer map
 
 ```
 ┌────────────────────────────────────────────────────────┐
@@ -65,12 +101,9 @@ FFI wrapper for configuration.
 └────────────────────────────────────────────────────────┘
 ```
 
----
+### PCM sink vtable (`pcm-fifo.c`)
 
-## PCM sink vtable (`pcm-fifo.c`)
-
-`firmware/target/hosted/pcm-fifo.c` implements `struct pcm_sink` with the
-following vtable:
+`firmware/target/hosted/pcm-fifo.c` implements `struct pcm_sink`:
 
 | Op                | Implementation                                              |
 |-------------------|-------------------------------------------------------------|
@@ -81,12 +114,9 @@ following vtable:
 | `play`            | `sink_dma_start` — opens fd if needed, spawns `fifo_thread` |
 | `stop`            | `sink_dma_stop` — signals thread, joins; keeps fd open      |
 
-`fifo_pcm_sink` is registered at index `PCM_SINK_FIFO = 1` in the `sinks[]`
-array in `firmware/pcm.c`.
+`fifo_pcm_sink` is registered at index `PCM_SINK_FIFO = 1` in `firmware/pcm.c`.
 
----
-
-## The DMA thread
+### The DMA thread
 
 `sink_dma_start(addr, size)` stores the initial PCM pointer/length under the
 mutex, then spawns `fifo_thread`. The thread mimics a hardware DMA interrupt
@@ -95,264 +125,295 @@ loop:
 ```
 while not stopped:
     1. lock → grab (data, size) → clear pcm_data/pcm_size → unlock
-    2. if data:
-           while size > 0 and not stopped:
-               n = write(fifo_fd, data, size)
-               handle EINTR/EAGAIN (retry)
-               advance data pointer, decrement size
+    2. while size > 0 and not stopped:
+           n = write(fifo_fd, data, size)
+           handle EINTR/EAGAIN (retry)
+           advance data pointer, decrement size
     3. lock → pcm_play_dma_complete_callback(OK, &pcm_data, &pcm_size) → unlock
     4. if no more data: break
-    5. pcm_play_dma_status_callback(STARTED)   ← tells audio engine chunk consumed
+    5. pcm_play_dma_status_callback(STARTED)
 ```
 
-The inner write loop handles partial writes and `EINTR`/`EAGAIN` correctly,
-advancing the pointer on each successful `write()` call. Pacing comes
-naturally from the blocking FIFO write — the kernel suspends the thread until
-the reader drains data, keeping throughput locked to the consumer's read rate.
+Pacing comes naturally from the blocking FIFO write — the kernel suspends the
+thread until the reader drains data, locking throughput to the consumer's rate.
 
----
+### FIFO pre-open strategy
 
-## FIFO pre-open strategy
+`pcm_fifo_set_path(path)` is called once at startup:
 
-`pcm_fifo_set_path(path)` is called once at startup from Rust settings code.
-It does two things:
-
-### 1. Create the FIFO
+#### 1. Create the FIFO
 
 ```c
 mkfifo(path, 0666);   // EEXIST is ignored
 ```
 
-This ensures the filesystem entry exists before snapserver starts, so
-snapserver's `open()` can succeed immediately.
-
-### 2. Open with a permanent writer reference
+#### 2. Open with a permanent writer reference
 
 ```c
 fd = open(path, O_RDWR | O_NONBLOCK);
 // then clear O_NONBLOCK:
-flags = fcntl(fd, F_GETFL);
 fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
 ```
 
-**Why `O_RDWR`?** On Linux and macOS, opening a FIFO `O_WRONLY` blocks until
-a reader is present. `O_RDWR` succeeds immediately even with no reader, and
-critically it keeps the FIFO's open-writer-count at ≥1 for the entire lifetime
-of the process. This means:
+**Why `O_RDWR`?** Opening `O_WRONLY` blocks until a reader is present. `O_RDWR`
+succeeds immediately and keeps the open-writer-count at ≥1 for the process
+lifetime — snapserver never sees premature EOF between tracks.
 
-- A reader that comes and goes (snapserver restart, client reconnect) never
-  causes the FIFO writer to receive `EPIPE` or the reader to see premature EOF.
-- Between tracks, when `fifo_thread` exits and `fifo_fd` is not closed,
-  snapserver's reader stays connected and continues to block-read cleanly.
+**Why clear `O_NONBLOCK`?** Writes must block when the kernel buffer is full to
+provide natural back-pressure. Leaving `O_NONBLOCK` set would produce `EAGAIN`
+and corrupt the stream.
 
-**Why clear `O_NONBLOCK`?** After pre-opening, writes must block when the
-kernel pipe buffer is full, providing natural back-pressure / pacing. If
-`O_NONBLOCK` were left set, writes would return `EAGAIN` when the consumer is
-slow, corrupting the stream.
+### stdout mode
 
----
-
-## stdout mode
-
-When `fifo_path = "-"`, the sink writes to stdout. This enables piping:
+When `fifo_path = "-"`, the sink writes to stdout:
 
 ```sh
 rockboxd | ffplay -f s16le -ar 44100 -ac 2 -
 ```
 
-Because Rockbox C code internally uses `printf()`/`puts()` on fd 1, stdout
-mode redirects fd 1 to stderr before any PCM is written:
+`pcm_fifo_set_path("-")` redirects fd 1 to stderr before any PCM is written so
+internal `printf()` output never pollutes the PCM stream.
 
-```c
-static void redirect_stdout_to_stderr(void)
-{
-    stdout_pcm_fd = dup(STDOUT_FILENO);   // save real stdout
-    dup2(STDERR_FILENO, STDOUT_FILENO);   // fd 1 → stderr
-}
+### Track transitions and EOF prevention
+
+`sink_dma_stop()` does **not** close `fifo_fd`. On POSIX, a named FIFO's read
+end sees EOF only when all write-side fds are closed. By keeping `fifo_fd` open
+across track boundaries, snapserver sees a continuous stream with no gaps.
+
+### Startup order (FIFO)
+
+**rockboxd must start before snapserver.**
+
+```
+1. rockboxd starts  → pcm_fifo_set_path() → FIFO created, O_RDWR fd held
+2. snapserver starts → opens FIFO O_RDONLY → blocks until data flows
+3. Playback begins  → fifo_thread writes → snapserver distributes to clients
 ```
 
-All subsequent `printf()` output goes to stderr (visible in the terminal but
-not in the pipe), while PCM writes go to `stdout_pcm_fd` — the saved copy of
-the original stdout. The PCM stream is never polluted by log output.
+### Snapserver configuration (FIFO)
 
-This works only if `redirect_stdout_to_stderr()` is called before any C code
-writes to fd 1. `pcm_fifo_set_path("-")` calls it at startup, which is before
-any audio decoding begins.
+```ini
+# /etc/snapserver.conf  (or /usr/local/etc/snapserver.conf on macOS)
+[stream]
+source = pipe:///tmp/snapfifo?name=default&sampleformat=44100:16:2
+```
+
+> On macOS, snapserver ≥ v0.35.0 ignores the `-s` CLI flag. Use the config
+> file.
 
 ---
 
-## Track transitions and EOF prevention
+## TCP sink
 
-`sink_dma_stop()` **does not close `fifo_fd`**:
+### TCP layer map
+
+```
+┌────────────────────────────────────────────────────────┐
+│  Rockbox C firmware  (pcm.c, audio thread)             │
+│    pcm_play_data() → sink.ops.play()                   │
+│    pcm_play_dma_complete_callback() per chunk          │
+└───────────────────┬────────────────────────────────────┘
+                    │ raw S16LE stereo PCM chunks
+┌───────────────────▼────────────────────────────────────┐
+│  firmware/target/hosted/pcm-tcp.c                      │
+│    pcm_tcp_set_host() / pcm_tcp_set_port()             │
+│    sink_dma_start()  — connects if needed, spawns thread│
+│    tcp_thread()      — blocking write() loop           │
+│    sink_dma_stop()   — signals thread, keeps socket    │
+└───────────────────┬────────────────────────────────────┘
+                    │ blocking write() over TCP
+┌───────────────────▼────────────────────────────────────┐
+│  TCP socket  (snapserver host:port)                    │
+└───────────────────┬────────────────────────────────────┘
+                    │ recv()
+┌───────────────────▼────────────────────────────────────┐
+│  snapserver  (tcp:// source, server mode)              │
+│      │                                                 │
+│  ┌───┴──────┬──────────┐                              │
+│  ▼          ▼          ▼                              │
+│ snapclient snapclient snapclient                       │
+└────────────────────────────────────────────────────────┘
+```
+
+### PCM sink vtable (`pcm-tcp.c`)
+
+`firmware/target/hosted/pcm-tcp.c` implements `struct pcm_sink`:
+
+| Op                | Implementation                                              |
+|-------------------|-------------------------------------------------------------|
+| `init`            | `pthread_mutex_init` (recursive)                            |
+| `postinit`        | no-op                                                       |
+| `set_freq`        | no-op (output is always 44100 Hz; snapserver must match)    |
+| `lock` / `unlock` | `pthread_mutex_lock/unlock`                                 |
+| `play`            | `sink_dma_start` — connects if needed, spawns `tcp_thread`  |
+| `stop`            | `sink_dma_stop` — signals thread, joins; keeps socket open  |
+
+`tcp_pcm_sink` is registered at index `PCM_SINK_SNAPCAST_TCP = 6` in
+`firmware/pcm.c`.
+
+### Connection lifecycle
+
+`sink_dma_start()` calls `tcp_connect_once()` if `tcp_fd < 0`:
 
 ```c
-static void sink_dma_stop(void)
+static int tcp_connect_once(void)
 {
-    fifo_stop = true;
-    if (fifo_running) {
-        pthread_join(fifo_tid, NULL);
-        fifo_running = false;
-    }
-    // fifo_fd intentionally left open
+    // getaddrinfo(tcp_host, port) → socket() → connect()
+    // returns fd on success, -1 on failure (logs error, drops audio)
 }
 ```
 
-On POSIX, a named FIFO's read end sees EOF only when all write-side file
-descriptors are closed. By keeping `fifo_fd` open across track boundaries,
-the consumer (snapserver) sees a continuous stream with no gaps. It never has
-to reconnect or re-open the pipe.
+The socket is kept open across `stop()` → `play()` transitions, just as the
+FIFO fd is. snapserver's reader sees a continuous stream between tracks.
 
-The only time `fifo_fd` is closed is if `pcm_fifo_set_path()` is called again
-with a new path — an operation that doesn't happen at runtime.
+### Reconnect on error
+
+If `write()` returns a hard error (`EPIPE`, `ECONNRESET`, etc.), `tcp_thread`
+closes the socket (`tcp_fd = -1`) and sets `tcp_stop = true`. The next call to
+`sink_dma_start()` finds `tcp_fd < 0` and attempts a fresh `connect()`. This
+handles snapserver restarts gracefully — the connection is re-established
+automatically on the next track or resume.
+
+### Startup order (TCP)
+
+**snapserver must be running and listening before playback starts.**
+
+```
+1. snapserver starts  → listens on tcp://0.0.0.0:4953
+2. rockboxd starts    → pcm_tcp_set_host/port() stores config
+3. Playback begins    → sink_dma_start() → tcp_connect_once() → connects
+4. tcp_thread writes  → snapserver receives → distributes to clients
+```
+
+Unlike the FIFO sink there is no permanent pre-connection at startup. The
+socket is opened on the first `play()` call.
+
+### Snapserver configuration (TCP)
+
+```ini
+# /etc/snapserver.conf  (or /usr/local/etc/snapserver.conf on macOS)
+[stream]
+source = tcp://0.0.0.0:4953?name=default&sampleformat=44100:16:2
+```
+
+`settings.toml` (manual config, not needed when selecting from the UI):
+
+```toml
+audio_output      = "snapcast_tcp"
+snapcast_tcp_host = "192.168.1.x"   # IP of the machine running snapserver
+snapcast_tcp_port = 4953            # default snapserver TCP source port
+```
+
+---
+
+## Auto-discovery via mDNS
+
+snapserver advertises itself via mDNS as `_snapcast._tcp.local.`. rockboxd
+scans for this service at startup via `scan_snapcast_servers()` in
+`crates/server/src/scan.rs`, which browses `_snapcast._tcp.local.` using the
+`mdns-sd` crate and adds discovered servers to the shared devices list.
+
+Discovered servers appear immediately in:
+
+- **Web UI** — the device picker in the control bar (lime-green radio icon)
+- **Desktop app (GPUI)** — the device picker popup
+
+Clicking a discovered server calls `PUT /devices/:id/connect`, which:
+
+1. Calls `pcm_tcp_set_host(device.ip)` and `pcm_tcp_set_port(device.port)`.
+2. Calls `pcm_switch_sink(PCM_SINK_SNAPCAST_TCP)`.
+3. Persists `audio_output = "snapcast_tcp"`, `snapcast_tcp_host`, and
+   `snapcast_tcp_port` to `settings.toml` so the selection survives restart.
+
+No manual `settings.toml` editing is needed when using the UI.
 
 ---
 
 ## FFI boundary (`crates/sys`)
 
-`crates/sys/src/lib.rs` declares the C function:
+### FIFO
 
 ```rust
-extern "C" {
-    pub fn pcm_fifo_set_path(path: *const c_char);
-}
-```
+// crates/sys/src/lib.rs
+extern "C" { fn pcm_fifo_set_path(path: *const c_char); }
 
-`crates/sys/src/sound/pcm.rs` wraps it safely:
-
-```rust
+// crates/sys/src/sound/pcm.rs
 pub fn fifo_set_path(path: &str) {
     let cpath = CString::new(path).expect("path must not contain null bytes");
     unsafe { crate::pcm_fifo_set_path(cpath.as_ptr()) }
-    std::mem::forget(cpath);  // C code only reads during init — leaking is fine
+    std::mem::forget(cpath);  // C code stores and re-reads pointer at runtime
 }
 ```
 
-`std::mem::forget` is used because `pcm_fifo_set_path` stores a raw pointer to
-the string and reads it later (e.g. in `sink_dma_start`'s fallback path).
-Dropping the `CString` would free the memory while C still holds a dangling
-pointer. Since this is a one-time startup call, leaking is acceptable.
+### TCP
 
-`pcm_switch_sink(PCM_SINK_FIFO)` switches the active sink. This is also an
-`extern "C"` call wrapped in `pcm::switch_sink(sink: i32) -> bool`.
+```rust
+// crates/sys/src/lib.rs
+extern "C" {
+    fn pcm_tcp_set_host(host: *const c_char);
+    fn pcm_tcp_set_port(port: c_ushort);
+}
+
+// crates/sys/src/sound/pcm.rs
+pub fn tcp_set_host(host: &str) {
+    let chost = CString::new(host).expect("host must not contain null bytes");
+    unsafe { crate::pcm_tcp_set_host(chost.as_ptr()) }
+    std::mem::forget(chost);
+}
+
+pub fn tcp_set_port(port: u16) {
+    unsafe { crate::pcm_tcp_set_port(port) }
+}
+```
+
+`std::mem::forget` is used in both cases because the C code stores the raw
+pointer and reads it later (in `sink_dma_start`'s connect / fallback path).
+Dropping the `CString` would free the memory while C holds a dangling pointer.
+Since these are startup-time config calls, leaking is acceptable.
 
 ---
 
 ## Settings and startup (`crates/settings`)
 
-`crates/settings/src/lib.rs:load_settings()` reads
-`~/.config/rockbox.org/settings.toml` and handles the FIFO case:
+`crates/settings/src/lib.rs:load_settings()` handles both sinks:
 
 ```rust
 Some("fifo") => {
     let path = settings.fifo_path.as_deref().unwrap_or("/tmp/rockbox.fifo");
     pcm::fifo_set_path(path);
     pcm::switch_sink(pcm::PCM_SINK_FIFO);
-    tracing::info!("audio output: fifo ({})", path);
+}
+Some("snapcast_tcp") => {
+    if let Some(ref host) = settings.snapcast_tcp_host {
+        let port = settings.snapcast_tcp_port.unwrap_or(4953);
+        pcm::tcp_set_host(host);
+        pcm::tcp_set_port(port);
+        pcm::switch_sink(pcm::PCM_SINK_SNAPCAST_TCP);
+    }
 }
 ```
 
-Relevant `settings.toml` keys:
+### All Snapcast settings keys
 
-| Key            | Type   | Default               | Description                           |
-|----------------|--------|-----------------------|---------------------------------------|
-| `audio_output` | string | `"builtin"`           | Set to `"fifo"` to activate this sink |
-| `fifo_path`    | string | `"/tmp/rockbox.fifo"` | FIFO path, or `"-"` for stdout        |
-
----
-
-## Snapcast integration
-
-[Snapcast](https://github.com/badaix/snapcast) is a synchronised multi-room
-audio system. snapserver reads a PCM source and distributes it to one or more
-snapclient instances with sub-millisecond synchronisation.
-
-The FIFO sink is designed to feed snapserver's `pipe://` source type. Once
-configured, the stream looks like:
-
-```
-rockboxd ──write()──▶ /tmp/snapfifo ──read()──▶ snapserver
-                                                     │
-                                          ┌──────────┴──────────┐
-                                          ▼                      ▼
-                                    snapclient              snapclient
-                                  (living room)             (kitchen)
-```
-
-### snapserver configuration
-
-Add a stream source to `/etc/snapserver.conf` (or
-`/usr/local/etc/snapserver.conf` on macOS):
-
-```ini
-[stream]
-source = pipe:///tmp/snapfifo?name=default&sampleformat=44100:16:2
-```
-
-The `sampleformat=44100:16:2` parameter is required on snapserver v0.35+.
-The `-s` CLI flag is **ignored** on macOS; it must be set in the config file.
-
-Start snapserver after rockboxd is running (see startup order below):
-
-```sh
-snapserver
-```
-
-Connect clients:
-
-```sh
-snapclient --host localhost --player default
-```
-
----
-
-## Startup order
-
-**rockboxd must start before snapserver.**
-
-If snapserver opens the FIFO first (before rockboxd calls `pcm_fifo_set_path`
-which does the `O_RDWR` open), it gets the sole writer reference. When
-snapserver later closes its end, the FIFO appears to have no writers and
-subsequent readers see immediate EOF.
-
-Correct order:
-
-```
-1. rockboxd starts  → pcm_fifo_set_path() → FIFO created, O_RDWR fd held
-2. snapserver starts → opens FIFO O_RDONLY → blocks until data flows
-3. Playback begins  → fifo_thread writes → snapserver reads → clients play
-```
-
----
-
-## Snapserver configuration (macOS)
-
-On macOS, snapserver's `-s` (stream source) command-line flag is silently
-ignored. The only way to configure the source is via the config file:
-
-```ini
-# /usr/local/etc/snapserver.conf
-[stream]
-source = pipe:///tmp/snapfifo?name=default&sampleformat=44100:16:2
-```
-
-Verify snapserver is reading it:
-
-```sh
-snapserver --config /usr/local/etc/snapserver.conf
-```
+| Key                  | Type   | Default               | Sink  | Description                              |
+|----------------------|--------|-----------------------|-------|------------------------------------------|
+| `audio_output`       | string | `"builtin"`           | both  | `"fifo"` or `"snapcast_tcp"`             |
+| `fifo_path`          | string | `"/tmp/rockbox.fifo"` | FIFO  | FIFO path, or `"-"` for stdout           |
+| `snapcast_tcp_host`  | string | —                     | TCP   | IP / hostname of the snapserver machine  |
+| `snapcast_tcp_port`  | u16    | `4953`                | TCP   | snapserver TCP source port               |
 
 ---
 
 ## Other pipe consumers
 
-Since the FIFO carries raw S16LE stereo 44100 Hz PCM, it works with any tool
-that accepts that format:
+Since both sinks carry raw S16LE stereo 44100 Hz PCM, the FIFO sink works with
+any tool that accepts that format:
 
 ```sh
-# Play directly with ffplay
+# Play directly with ffplay (stdout mode)
 rockboxd | ffplay -f s16le -ar 44100 -ac 2 -
 
-# Encode on the fly with ffmpeg
+# Encode on the fly
 rockboxd | ffmpeg -f s16le -ar 44100 -ac 2 -i - output.mp3
 
 # Play with sox
@@ -362,47 +423,54 @@ rockboxd | play -t raw -r 44100 -e signed -b 16 -c 2 -
 rockboxd | aplay -f S16_LE -r 44100 -c 2
 ```
 
-All of these require `fifo_path = "-"` in `settings.toml` so rockboxd writes
-to stdout.
+All of these require `fifo_path = "-"` and are only available with the FIFO
+sink. The TCP sink does not support stdout mode.
 
 ---
 
 ## Gotchas and known limits
 
-### 1. Startup order is critical
+### 1. Startup order is critical for both sinks
 
-As described above, rockboxd must open the FIFO before snapserver. If
-snapserver opens it first and later closes its write end, snapclient may see
-EOF and stop buffering. Restart snapserver after rockboxd in that case.
+- **FIFO**: rockboxd must open the FIFO before snapserver. Reverse order causes
+  snapserver to hold the only writer reference; when it closes, readers see EOF.
+  Restart snapserver if this happens.
+- **TCP**: snapserver must be listening before playback starts. If snapserver
+  is not yet running, `sink_dma_start` logs a warning and drops audio for that
+  buffer. It reconnects automatically on the next play call.
 
 ### 2. Fixed 44100 Hz, S16LE stereo
 
-The FIFO sink does not resample. The `set_freq` op is a no-op. If Rockbox
-decodes a 48 kHz or 96 kHz track, the firmware resamples it internally to
-the codec's sample rate, but the PCM output is always delivered to the sink
-at 44100 Hz. Configure snapserver and any other consumer to match.
+Neither sink resamples. `set_freq` is a no-op. The firmware resamples tracks
+internally before they reach the sink, but the output is always 44100 Hz.
+Configure `sampleformat=44100:16:2` on the snapserver side.
 
 ### 3. No volume control through the sink
 
 Volume is applied by the Rockbox DSP pipeline before PCM reaches the sink.
-The FIFO sink itself has no volume knob. Adjust volume through the Rockbox
-API or client applications.
+Adjust volume through the Rockbox API or client applications.
 
 ### 4. Consumer back-pressure controls playback speed
 
-Because `fifo_fd` is in blocking mode, a slow or stalled consumer will cause
-`write()` to block, which stalls `fifo_thread`, which eventually stalls the
-DMA callback loop, which pauses decoding. This is correct behavior for
-synchronized output, but it means a crashed or frozen snapserver will freeze
+Both sinks use blocking `write()`. A slow or stalled consumer stalls
+`write()`, which stalls the DMA callback loop, which pauses decoding. This
+is correct for synchronized output but means a crashed consumer freezes
 playback. Restart snapserver to recover.
 
 ### 5. macOS `snapserver.conf` vs CLI flag
 
-The `-s` flag to snapserver is silently ignored on macOS (at least v0.35.0).
-Always use the config file. See [Snapserver configuration (macOS)](#snapserver-configuration-macos).
+The `-s` flag to snapserver is silently ignored on macOS (≥ v0.35.0).
+Always use the config file for both `pipe://` and `tcp://` sources.
 
-### 6. Logging uses `tracing`, never `println!`
+### 6. TCP reconnect drops in-flight buffer
+
+When the write loop detects `EPIPE` it closes the socket immediately. The
+current audio buffer is discarded. Reconnection happens on the next
+`sink_dma_start()` call, so there will be a brief audio gap when snapserver
+restarts.
+
+### 7. Logging uses `tracing`, never `println!`
 
 All Rust-side diagnostic output must go through `tracing`. `println!` and
-`eprintln!` bypass the log filter and — in stdout mode — corrupt the PCM
-stream. Use `RUST_LOG=debug rockboxd` to see debug output on stderr.
+`eprintln!` bypass the log filter and — in stdout/FIFO mode — can corrupt the
+PCM stream. Use `RUST_LOG=debug rockboxd` to see debug output on stderr.

--- a/crates/library/src/audio_scan.rs
+++ b/crates/library/src/audio_scan.rs
@@ -253,6 +253,104 @@ pub async fn save_audio_metadata(pool: Pool<Sqlite>, path: &str) -> Result<(), E
     Ok(())
 }
 
+/// Save metadata for a streaming URL directly to the DB without probing the stream.
+/// Called by the UPnP renderer which already has title/artist/album/duration from DIDL-Lite.
+pub async fn save_stream_metadata(
+    pool: Pool<Sqlite>,
+    url: &str,
+    title: &str,
+    artist: &str,
+    album: &str,
+    duration_ms: u32,
+) -> Result<(), Error> {
+    let track_md5 = format!("{:x}", md5::compute(url.as_bytes()));
+    let length_secs = duration_ms / 1000;
+
+    if repo::track::find_by_md5(pool.clone(), &track_md5)
+        .await?
+        .is_some()
+    {
+        repo::track::update_stream_metadata(pool, &track_md5, title, artist, album, length_secs)
+            .await?;
+        return Ok(());
+    }
+
+    let artist_id = repo::artist::save(
+        pool.clone(),
+        Artist {
+            id: cuid::cuid1()?,
+            name: artist.to_string(),
+            bio: None,
+            image: None,
+            genres: None,
+        },
+    )
+    .await?;
+
+    let album_md5 = format!(
+        "{:x}",
+        md5::compute(format!("{}{}", artist, album).as_bytes())
+    );
+    let album_id = repo::album::save(
+        pool.clone(),
+        Album {
+            id: cuid::cuid1()?,
+            title: album.to_string(),
+            artist: artist.to_string(),
+            year: 0,
+            year_string: String::new(),
+            album_art: None,
+            md5: album_md5,
+            artist_id: artist_id.clone(),
+            label: None,
+            copyright_message: None,
+        },
+    )
+    .await?;
+
+    let track_id = repo::track::save(
+        pool.clone(),
+        Track {
+            id: cuid::cuid1()?,
+            path: url.to_string(),
+            title: title.to_string(),
+            artist: artist.to_string(),
+            album: album.to_string(),
+            album_artist: artist.to_string(),
+            length: length_secs,
+            md5: track_md5,
+            artist_id: artist_id.clone(),
+            album_id: album_id.clone(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    repo::album_tracks::save(
+        pool.clone(),
+        AlbumTracks {
+            id: cuid::cuid1()?,
+            album_id,
+            track_id: track_id.clone(),
+        },
+    )
+    .await?;
+
+    repo::artist_tracks::save(
+        pool.clone(),
+        ArtistTracks {
+            id: cuid::cuid1()?,
+            artist_id,
+            track_id,
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
 fn is_remote_path(path: &str) -> bool {
     path.starts_with("http://") || path.starts_with("https://")
 }

--- a/crates/library/src/repo/track.rs
+++ b/crates/library/src/repo/track.rs
@@ -155,6 +155,28 @@ pub async fn find_by_filename(pool: Pool<Sqlite>, filename: &str) -> Result<Vec<
     Ok(result)
 }
 
+pub async fn update_stream_metadata(
+    pool: Pool<Sqlite>,
+    md5: &str,
+    title: &str,
+    artist: &str,
+    album: &str,
+    length: u32,
+) -> Result<(), Error> {
+    sqlx::query(
+        "UPDATE track SET title = $2, artist = $3, album = $4, length = $5, updated_at = $6 WHERE md5 = $1",
+    )
+    .bind(md5)
+    .bind(title)
+    .bind(artist)
+    .bind(album)
+    .bind(length)
+    .bind(chrono::Utc::now())
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
 pub async fn find_by_artist_album_date(
     pool: Pool<Sqlite>,
     artist: &str,

--- a/crates/netstream/src/lib.rs
+++ b/crates/netstream/src/lib.rs
@@ -332,10 +332,26 @@ pub extern "C" fn rb_net_lseek(h: i32, off: i64, whence: libc::c_int) -> i64 {
         _ => return -1,
     };
 
-    // Guard: never issue a Range request past EOF — the server would return 416
-    // and seek_to would leave response=None, permanently breaking the stream.
-    // This can happen when the C MP4 parser has a uint32_t underflow in its
-    // atom-size arithmetic and tries to seek gigabytes forward.
+    // Guard 1: never seek gigabytes forward regardless of content_length.
+    // A seek >256 MB past current position is always a codec arithmetic bug
+    // (e.g. WAV trying to skip a 0xFFFFFFFF-byte data chunk, or MP4 with
+    // uint32_t underflow).  Issue a Range request for such an offset and the
+    // server either returns 416 or streams from the beginning — either way
+    // skip_bytes would block for hours reading a live stream.
+    const MAX_SKIP: u64 = 256 * 1024 * 1024; // 256 MB
+    if new_pos > state.pos && new_pos - state.pos > MAX_SKIP {
+        warn!(
+            "[netstream] rb_net_lseek: h={} off={} whence={} huge skip ({} bytes) clamped",
+            h,
+            off,
+            whence,
+            new_pos - state.pos
+        );
+        return -1;
+    }
+
+    // Guard 2: never issue a Range request past EOF — the server would return
+    // 416 and leave response=None, permanently breaking the stream.
     if let Some(cl) = state.content_length {
         if new_pos >= cl {
             warn!(

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -948,6 +948,8 @@ pub mod api {
                     chromecast_host: None,
                     chromecast_http_port: None,
                     chromecast_port: None,
+                    snapcast_tcp_host: None,
+                    snapcast_tcp_port: None,
                 }
             }
         }
@@ -1021,7 +1023,7 @@ macro_rules! check_and_load_player {
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        if !player.host.is_empty() && player.port != 0 {
+        if player.is_cast_device {
             let client = reqwest::Client::new();
             let body = serde_json::json!({
                 "tracks": $tracks,

--- a/crates/server/src/handlers/devices.rs
+++ b/crates/server/src/handlers/devices.rs
@@ -87,6 +87,11 @@ pub async fn connect(ctx: &Context, req: &Request, res: &mut Response) -> Result
                 pcm::upnp_set_renderer_url(url);
             }
             pcm::upnp_set_http_port(http_port);
+            // Reset renderer state so the very next sink_dma_start always fires
+            // SetAVTransportURI + Play — without this, switching back to UPnP after
+            // using another output would leave RENDERER_PLAYING=true and send no
+            // play command, silently producing no audio until daemon restart.
+            pcm::upnp_reset_renderer();
             pcm::switch_sink(pcm::PCM_SINK_UPNP);
             *GLOBAL_MUTEX.lock().unwrap() = 0;
         }
@@ -99,6 +104,15 @@ pub async fn connect(ctx: &Context, req: &Request, res: &mut Response) -> Result
             pcm::chromecast_set_device_host(&device.ip);
             pcm::chromecast_set_device_port(device.port);
             pcm::switch_sink(pcm::PCM_SINK_CHROMECAST);
+            *GLOBAL_MUTEX.lock().unwrap() = 0;
+        }
+        "snapcast" => {
+            settings.audio_output = Some("snapcast_tcp".to_string());
+            settings.snapcast_tcp_host = Some(device.ip.clone());
+            settings.snapcast_tcp_port = Some(device.port);
+            pcm::tcp_set_host(&device.ip);
+            pcm::tcp_set_port(device.port);
+            pcm::switch_sink(pcm::PCM_SINK_SNAPCAST_TCP);
             *GLOBAL_MUTEX.lock().unwrap() = 0;
         }
         other => {

--- a/crates/server/src/handlers/mod.rs
+++ b/crates/server/src/handlers/mod.rs
@@ -77,6 +77,7 @@ async_handler!(saved_playlists, create_playlist_folder);
 async_handler!(saved_playlists, delete_playlist_folder);
 async_handler!(tracks, get_tracks);
 async_handler!(tracks, get_track);
+async_handler!(tracks, save_stream_track_metadata);
 async_handler!(system, get_rockbox_version);
 async_handler!(system, get_status);
 async_handler!(system, scan_library);

--- a/crates/server/src/handlers/playlists.rs
+++ b/crates/server/src/handlers/playlists.rs
@@ -45,6 +45,21 @@ pub async fn create_playlist(
 
     let player_mutex = PLAYER_MUTEX.lock().unwrap();
 
+    // For HTTP streams: flush the audio thread's message queue before replacing
+    // the playlist.  Stale Q_AUDIO_FILL_BUFFER messages from a previous HTTP
+    // session (e.g. auto-resume) would otherwise act on the new playlist's
+    // handle with the old stream context, causing the new play to be silently
+    // ignored.  For local files the queue is always drained by the time the
+    // user starts a new playlist, so hard_stop is a no-op cost there.
+    let current_is_http = rb::playback::current_track()
+        .map(|t| t.path.starts_with("http://") || t.path.starts_with("https://"))
+        .unwrap_or(false);
+    let new_is_http = new_playlist.tracks[0].starts_with("http://")
+        || new_playlist.tracks[0].starts_with("https://");
+    if current_is_http || new_is_http {
+        rb::playback::hard_stop();
+    }
+
     // Always create a fresh playlist so the currently-playing track is
     // fully replaced rather than appended to.
     // Local paths: use the track's parent directory (required by Rockbox).
@@ -308,6 +323,14 @@ pub async fn insert_tracks(ctx: &Context, req: &Request, res: &mut Response) -> 
 async fn persist_remote_track_metadata(ctx: &Context, tracks: &[String]) -> Result<(), Error> {
     for track in tracks {
         if track.starts_with("http://") || track.starts_with("https://") {
+            // Raw PCM streams served at /stream.wav have no embedded metadata and
+            // probing them would block for ~47 s (8 MB at audio bitrate) then time out.
+            if reqwest::Url::parse(track)
+                .map(|u| u.path() == "/stream.wav")
+                .unwrap_or(false)
+            {
+                continue;
+            }
             if find_internal_track_by_url(ctx, track).await?.is_some() {
                 continue;
             }

--- a/crates/server/src/handlers/tracks.rs
+++ b/crates/server/src/handlers/tracks.rs
@@ -1,5 +1,6 @@
 use anyhow::Error;
-use rockbox_library::repo;
+use rockbox_library::{audio_scan, repo};
+use serde::Deserialize;
 
 use crate::http::{Context, Request, Response};
 
@@ -12,5 +13,40 @@ pub async fn get_tracks(ctx: &Context, _req: &Request, res: &mut Response) -> Re
 pub async fn get_track(ctx: &Context, req: &Request, res: &mut Response) -> Result<(), Error> {
     let track = repo::track::find(ctx.pool.clone(), &req.params[0]).await?;
     res.json(&track);
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct StreamMetadataBody {
+    url: String,
+    title: String,
+    artist: String,
+    album: String,
+    duration_ms: u32,
+}
+
+pub async fn save_stream_track_metadata(
+    ctx: &Context,
+    req: &Request,
+    res: &mut Response,
+) -> Result<(), Error> {
+    let body = match req.body.as_ref() {
+        Some(b) => b,
+        None => {
+            res.set_status(400);
+            return Ok(());
+        }
+    };
+    let params: StreamMetadataBody = serde_json::from_str(body)?;
+    audio_scan::save_stream_metadata(
+        ctx.pool.clone(),
+        &params.url,
+        &params.title,
+        &params.artist,
+        &params.album,
+        params.duration_ms,
+    )
+    .await?;
+    res.set_status(204);
     Ok(())
 }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -25,8 +25,8 @@ use crate::{
     kv::{build_tracks_kv, KV},
     player_events::listen_for_playback_changes,
     scan::{
-        scan_airplay_devices, scan_chromecast_devices, scan_squeezelite_clients, scan_upnp_devices,
-        virtual_devices,
+        scan_airplay_devices, scan_chromecast_devices, scan_snapcast_servers,
+        scan_squeezelite_clients, scan_upnp_devices, virtual_devices,
     },
 };
 
@@ -324,6 +324,24 @@ impl RockboxHttpServer {
                             ..Default::default()
                         })
                     }
+                    "snapcast_tcp" => {
+                        let host = s.snapcast_tcp_host.clone().unwrap_or_default();
+                        Some(Device {
+                            id: format!("snapcast-{}", host),
+                            name: if host.is_empty() {
+                                "Snapcast".to_string()
+                            } else {
+                                format!("Snapcast ({})", host)
+                            },
+                            host: host.clone(),
+                            ip: host,
+                            port: s.snapcast_tcp_port.unwrap_or(4953),
+                            service: "snapcast".to_string(),
+                            app: "Snapcast".to_string(),
+                            is_cast_device: true,
+                            ..Default::default()
+                        })
+                    }
                     _ => virtual_devices()
                         .into_iter()
                         .find(|d| d.service == "builtin"),
@@ -347,6 +365,7 @@ impl RockboxHttpServer {
         scan_chromecast_devices(devices.clone());
         scan_upnp_devices(devices.clone());
         scan_airplay_devices(devices.clone());
+        scan_snapcast_servers(devices.clone());
         scan_squeezelite_clients(devices.clone());
         listen_for_playback_changes(player.clone(), db_pool.clone());
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -153,6 +153,7 @@ pub extern "C" fn start_server() {
 
     app.get("/tracks", get_tracks);
     app.get("/tracks/:id", get_track);
+    app.put("/tracks/stream-metadata", save_stream_track_metadata);
 
     app.get("/version", get_rockbox_version);
     app.get("/status", get_status);

--- a/crates/server/src/scan.rs
+++ b/crates/server/src/scan.rs
@@ -1,7 +1,9 @@
 use futures_util::StreamExt;
 use rockbox_discovery::{discover, CHROMECAST_SERVICE_NAME};
 use rockbox_graphql::simplebroker::SimpleBroker;
-use rockbox_types::device::{Device, AIRPLAY_DEVICE, AIRPLAY_SERVICE_NAME, UPNP_DLNA_DEVICE};
+use rockbox_types::device::{
+    Device, AIRPLAY_DEVICE, AIRPLAY_SERVICE_NAME, SNAPCAST_SERVICE_NAME, UPNP_DLNA_DEVICE,
+};
 use std::{
     sync::{Arc, Mutex},
     thread,
@@ -117,6 +119,33 @@ pub fn scan_airplay_devices(devices: Arc<Mutex<Vec<Device>>>) {
                 device.is_cast_device = true;
                 devices.push(device.clone());
                 SimpleBroker::<Device>::publish(device);
+            }
+        });
+    });
+}
+
+/// Discover Snapcast servers on the local network via mDNS (`_snapcast._tcp.local.`).
+/// Runs in a background thread; newly found servers are added to the shared device list.
+pub fn scan_snapcast_servers(devices: Arc<Mutex<Vec<Device>>>) {
+    thread::spawn(move || {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let services = discover(SNAPCAST_SERVICE_NAME);
+            tokio::pin!(services);
+            while let Some(info) = services.next().await {
+                let device = Device::from(info.clone());
+
+                let mut devs = devices.lock().unwrap();
+                if devs.iter().any(|d| d.id == device.id) {
+                    continue;
+                }
+                tracing::info!(
+                    "snapcast: discovered server {} ({}:{})",
+                    device.name,
+                    device.ip,
+                    device.port
+                );
+                SimpleBroker::<Device>::publish(device.clone());
+                devs.push(device);
             }
         });
     });

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -17,13 +17,24 @@ pub fn load_settings(new_settings: Option<NewGlobalSettings>) -> Result<(), Erro
         rb::system::set_sleeptimer_duration(0);
     }
 
+    let home = std::env::var("HOME")?;
+    let default_music_dir = format!("{}/Music", home);
+    // Ensure the default music directory always exists.
+    if let Err(e) = std::fs::create_dir_all(&default_music_dir) {
+        tracing::warn!("could not create default music dir {default_music_dir}: {e}");
+    }
+
     if let Some(music_dir) = settings.clone().music_dir {
-        if let Ok(_) = std::fs::metadata(&music_dir) {
-            std::env::set_var(
-                "ROCKBOX_LIBRARY",
-                music_dir.replace("$HOME", &std::env::var("HOME")?),
-            );
+        let resolved = music_dir.replace("$HOME", &home);
+        if std::fs::metadata(&resolved).is_ok() {
+            std::env::set_var("ROCKBOX_LIBRARY", &resolved);
+        } else {
+            // Configured dir doesn't exist yet; fall back to the default so
+            // the library scanner has somewhere to point.
+            std::env::set_var("ROCKBOX_LIBRARY", &default_music_dir);
         }
+    } else {
+        std::env::set_var("ROCKBOX_LIBRARY", &default_music_dir);
     }
 
     rb::settings::save_settings(settings.clone(), new_settings.is_none());
@@ -98,6 +109,19 @@ pub fn load_settings(new_settings: Option<NewGlobalSettings>) -> Result<(), Erro
             }
             pcm::switch_sink(pcm::PCM_SINK_CHROMECAST);
         }
+        Some("snapcast_tcp") => {
+            if let Some(ref host) = settings.snapcast_tcp_host {
+                let port = settings.snapcast_tcp_port.unwrap_or(4953);
+                pcm::tcp_set_host(host);
+                pcm::tcp_set_port(port);
+                pcm::switch_sink(pcm::PCM_SINK_SNAPCAST_TCP);
+                tracing::info!("audio output: snapcast_tcp ({}:{})", host, port);
+            } else {
+                tracing::warn!(
+                    "audio output: snapcast_tcp selected but no snapcast_tcp_host configured"
+                );
+            }
+        }
         Some("builtin") | None => {
             tracing::info!("audio output: builtin (SDL)");
         }
@@ -134,15 +158,49 @@ pub fn load_settings(new_settings: Option<NewGlobalSettings>) -> Result<(), Erro
 }
 
 pub fn write_settings() -> Result<(), Error> {
-    let settings = rb::settings::get_global_settings();
-    let mut settings: NewGlobalSettings = settings.into();
+    let from_c: NewGlobalSettings = rb::settings::get_global_settings().into();
     let home = std::env::var("HOME")?;
 
-    settings.music_dir =
-        Some(std::env::var("ROCKBOX_LIBRARY").unwrap_or(format!("{}/Music", home)));
+    // Start from whatever is already on disk so Rust-only fields
+    // (audio_output, upnp_*, airplay_*, fifo_path, etc.) are never lost
+    // when writing back only the C-firmware-owned settings.
+    let mut settings = read_settings().unwrap_or_default();
+
+    // Only update music_dir when ROCKBOX_LIBRARY was explicitly set at runtime.
+    // If it was never set (e.g. the directory didn't exist at startup), keep
+    // whatever the TOML already has to avoid resetting to the default ~/Music.
+    if let Ok(library) = std::env::var("ROCKBOX_LIBRARY") {
+        settings.music_dir = Some(library);
+    }
+    settings.playlist_shuffle = from_c.playlist_shuffle;
+    settings.repeat_mode = from_c.repeat_mode;
+    settings.bass = from_c.bass;
+    settings.treble = from_c.treble;
+    settings.bass_cutoff = from_c.bass_cutoff;
+    settings.treble_cutoff = from_c.treble_cutoff;
+    settings.crossfade = from_c.crossfade;
+    settings.fade_on_stop = from_c.fade_on_stop;
+    settings.fade_in_delay = from_c.fade_in_delay;
+    settings.fade_in_duration = from_c.fade_in_duration;
+    settings.fade_out_delay = from_c.fade_out_delay;
+    settings.fade_out_duration = from_c.fade_out_duration;
+    settings.fade_out_mixmode = from_c.fade_out_mixmode;
+    settings.balance = from_c.balance;
+    settings.stereo_width = from_c.stereo_width;
+    settings.stereosw_mode = from_c.stereosw_mode;
+    settings.surround_enabled = from_c.surround_enabled;
+    settings.surround_balance = from_c.surround_balance;
+    settings.surround_fx1 = from_c.surround_fx1;
+    settings.surround_fx2 = from_c.surround_fx2;
+    settings.party_mode = from_c.party_mode;
+    settings.channel_config = from_c.channel_config;
+    settings.player_name = from_c.player_name;
+    settings.eq_enabled = from_c.eq_enabled;
+    settings.eq_band_settings = from_c.eq_band_settings;
+    settings.replaygain_settings = from_c.replaygain_settings;
+    settings.compressor_settings = from_c.compressor_settings;
 
     let content = toml::to_string(&settings)?;
-
     let path = format!("{}/.config/rockbox.org/settings.toml", home);
     std::fs::write(&path, content)?;
     Ok(())

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -1156,10 +1156,13 @@ extern "C" {
     fn pcm_upnp_set_http_port(port: c_ushort);
     fn pcm_upnp_set_renderer_url(url: *const c_char);
     fn pcm_upnp_set_sample_rate(rate: c_uint);
+    fn pcm_upnp_reset_renderer();
     fn pcm_chromecast_set_http_port(port: c_ushort);
     fn pcm_chromecast_set_device_host(host: *const c_char);
     fn pcm_chromecast_set_device_port(port: c_ushort);
     fn pcm_chromecast_teardown();
+    fn pcm_tcp_set_host(host: *const c_char);
+    fn pcm_tcp_set_port(port: c_ushort);
     fn beep_play(frequency: c_uint, duration: c_uint, amplitude: c_uint);
     fn dsp_set_crossfeed_type(r#type: c_int);
     fn dsp_eq_enable(enable: c_uchar);

--- a/crates/sys/src/playback.rs
+++ b/crates/sys/src/playback.rs
@@ -1,4 +1,51 @@
 use crate::types::{audio_status::AudioStatus, file_position::FilePosition, mp3_entry::Mp3Entry};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+struct MetadataOverride {
+    title: String,
+    artist: String,
+    album: String,
+    /// Milliseconds; 0 means "don't override".
+    length_ms: u64,
+    /// Remote URL of the album art image, empty means "no override".
+    album_art_url: String,
+}
+
+static METADATA_OVERRIDES: OnceLock<Mutex<HashMap<String, MetadataOverride>>> = OnceLock::new();
+
+fn overrides() -> &'static Mutex<HashMap<String, MetadataOverride>> {
+    METADATA_OVERRIDES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Store metadata that will be overlaid on top of whatever the C codec parsed
+/// whenever `current_track()` returns a track whose path matches `url`.
+/// Call this before or just after starting playback so all callers (HTTP API,
+/// gRPC, GraphQL, MPD) immediately see meaningful values.
+pub fn set_metadata_override(
+    url: &str,
+    title: &str,
+    artist: &str,
+    album: &str,
+    length_ms: u64,
+    album_art_url: &str,
+) {
+    overrides().lock().unwrap().insert(
+        url.to_string(),
+        MetadataOverride {
+            title: title.to_string(),
+            artist: artist.to_string(),
+            album: album.to_string(),
+            length_ms,
+            album_art_url: album_art_url.to_string(),
+        },
+    );
+}
+
+/// Remove a previously-registered override (e.g. when the stream stops).
+pub fn clear_metadata_override(url: &str) {
+    overrides().lock().unwrap().remove(url);
+}
 
 pub fn pause() {
     unsafe {
@@ -66,7 +113,29 @@ pub fn current_track() -> Option<Mp3Entry> {
     let track = unsafe { track.as_ref() };
 
     match track {
-        Some(track) => Some((*track).into()),
+        Some(track) => {
+            let mut entry: Mp3Entry = (*track).into();
+            if let Ok(map) = overrides().lock() {
+                if let Some(ov) = map.get(&entry.path) {
+                    if !ov.title.is_empty() {
+                        entry.title = ov.title.clone();
+                    }
+                    if !ov.artist.is_empty() {
+                        entry.artist = ov.artist.clone();
+                    }
+                    if !ov.album.is_empty() {
+                        entry.album = ov.album.clone();
+                    }
+                    if ov.length_ms > 0 {
+                        entry.length = ov.length_ms;
+                    }
+                    if !ov.album_art_url.is_empty() {
+                        entry.album_art = Some(ov.album_art_url.clone());
+                    }
+                }
+            }
+            Some(entry)
+        }
         None => None,
     }
 }

--- a/crates/sys/src/sound/pcm.rs
+++ b/crates/sys/src/sound/pcm.rs
@@ -8,6 +8,7 @@ pub const PCM_SINK_AIRPLAY: i32 = 2;
 pub const PCM_SINK_SQUEEZELITE: i32 = 3;
 pub const PCM_SINK_UPNP: i32 = 4;
 pub const PCM_SINK_CHROMECAST: i32 = 5;
+pub const PCM_SINK_SNAPCAST_TCP: i32 = 6;
 
 pub fn apply_settings() {
     unsafe {
@@ -101,6 +102,12 @@ pub fn upnp_clear_renderer_url() {
     unsafe { crate::pcm_upnp_set_renderer_url(std::ptr::null()) }
 }
 
+/// Reset renderer-side state so the next play always sends SetAVTransportURI+Play.
+/// Call this before switch_sink(PCM_SINK_UPNP) so output switching works live.
+pub fn upnp_reset_renderer() {
+    unsafe { crate::pcm_upnp_reset_renderer() }
+}
+
 pub fn chromecast_set_http_port(port: u16) {
     unsafe { crate::pcm_chromecast_set_http_port(port) }
 }
@@ -117,4 +124,14 @@ pub fn chromecast_set_device_port(port: u16) {
 
 pub fn chromecast_teardown() {
     unsafe { crate::pcm_chromecast_teardown() }
+}
+
+pub fn tcp_set_host(host: &str) {
+    let chost = CString::new(host).expect("host must not contain null bytes");
+    unsafe { crate::pcm_tcp_set_host(chost.as_ptr()) }
+    std::mem::forget(chost);
+}
+
+pub fn tcp_set_port(port: u16) {
+    unsafe { crate::pcm_tcp_set_port(port) }
 }

--- a/crates/sys/src/types/user_settings.rs
+++ b/crates/sys/src/types/user_settings.rs
@@ -721,6 +721,10 @@ pub struct NewGlobalSettings {
     pub chromecast_port: Option<u16>,
     /// HTTP port for the Chromecast WAV stream (default: 7881)
     pub chromecast_http_port: Option<u16>,
+    /// Host address of the Snapcast TCP source (required for snapcast_tcp output)
+    pub snapcast_tcp_host: Option<String>,
+    /// TCP port for the Snapcast source (default: 4953)
+    pub snapcast_tcp_port: Option<u16>,
 }
 
 impl From<UserSettings> for NewGlobalSettings {
@@ -771,6 +775,8 @@ impl From<UserSettings> for NewGlobalSettings {
             chromecast_host: None,
             chromecast_port: None,
             chromecast_http_port: None,
+            snapcast_tcp_host: None,
+            snapcast_tcp_port: None,
         }
     }
 }

--- a/crates/types/src/device.rs
+++ b/crates/types/src/device.rs
@@ -6,13 +6,18 @@ pub const CHROMECAST_SERVICE_NAME: &str = "_googlecast._tcp.local.";
 pub const AIRPLAY_SERVICE_NAME: &str = "_raop._tcp.local.";
 pub const ROCKBOX_SERVICE_NAME: &str = "_rockbox._tcp.local.";
 pub const XBMC_SERVICE_NAME: &str = "_xbmc-jsonrpc-h._tcp.local.";
+pub const SNAPCAST_SERVICE_NAME: &str = "_snapcast._tcp.local.";
 
 pub const AIRPLAY_DEVICE: &str = "AirPlay";
 pub const CHROMECAST_DEVICE: &str = "Chromecast";
 pub const XBMC_DEVICE: &str = "XBMC";
 pub const MUSIC_PLAYER_DEVICE: &str = "MusicPlayer";
 pub const UPNP_DLNA_DEVICE: &str = "UPnP/DLNA";
+
+// Port for Snapcast TCP source input (not the client streaming port 1704 advertised via mDNS).
+pub const SNAPCAST_TCP_SOURCE_PORT: u16 = 4953;
 pub const ROCKBOX_DEVICE: &str = "Rockbox";
+pub const SNAPCAST_DEVICE: &str = "Snapcast";
 
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Device {
@@ -120,6 +125,43 @@ impl From<ServiceInfo> for Device {
                 port: srv.get_port(),
                 service: srv.get_fullname().to_owned(),
                 app: "chromecast".to_owned(),
+                is_connected: false,
+                base_url: None,
+                is_cast_device: true,
+                is_source_device: false,
+                is_current_device: false,
+            };
+        }
+
+        if srv.get_fullname().contains(SNAPCAST_SERVICE_NAME) {
+            let ip = srv
+                .get_addresses()
+                .iter()
+                .next()
+                .map(|a| a.to_string())
+                .unwrap_or_default();
+            let name = srv
+                .get_fullname()
+                .replace(SNAPCAST_SERVICE_NAME, "")
+                .trim_matches('.')
+                .to_owned();
+            let name = if name.is_empty() {
+                SNAPCAST_DEVICE.to_owned()
+            } else {
+                name
+            };
+            return Self {
+                id: format!("snapcast-{}", ip),
+                name,
+                host: srv
+                    .get_hostname()
+                    .split_at(srv.get_hostname().len() - 1)
+                    .0
+                    .to_owned(),
+                ip,
+                port: SNAPCAST_TCP_SOURCE_PORT,
+                service: "snapcast".to_owned(),
+                app: SNAPCAST_DEVICE.to_owned(),
                 is_connected: false,
                 base_url: None,
                 is_cast_device: true,

--- a/crates/upnp/Cargo.toml
+++ b/crates/upnp/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 socket2 = { workspace = true }
 sqlx = { version = "0.8.2", features = ["runtime-tokio", "sqlite"] }
 bytes = { workspace = true }

--- a/crates/upnp/src/api/rockbox.v1alpha1.rs
+++ b/crates/upnp/src/api/rockbox.v1alpha1.rs
@@ -43,10 +43,10 @@ pub mod browse_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BrowseServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -90,8 +90,9 @@ pub mod browse_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BrowseServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -129,20 +130,27 @@ pub mod browse_service_client {
         pub async fn tree_get_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.BrowseService",
-                "TreeGetEntries",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.BrowseService", "TreeGetEntries"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -154,7 +162,7 @@ pub mod browse_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BrowseServiceServer.
@@ -163,7 +171,10 @@ pub mod browse_service_server {
         async fn tree_get_entries(
             &self,
             request: tonic::Request<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct BrowseServiceServer<T> {
@@ -186,7 +197,10 @@ pub mod browse_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -241,18 +255,23 @@ pub mod browse_service_server {
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries" => {
                     #[allow(non_camel_case_types)]
                     struct TreeGetEntriesSvc<T: BrowseService>(pub Arc<T>);
-                    impl<T: BrowseService> tonic::server::UnaryService<super::TreeGetEntriesRequest>
-                        for TreeGetEntriesSvc<T>
-                    {
+                    impl<
+                        T: BrowseService,
+                    > tonic::server::UnaryService<super::TreeGetEntriesRequest>
+                    for TreeGetEntriesSvc<T> {
                         type Response = super::TreeGetEntriesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TreeGetEntriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BrowseService>::tree_get_entries(&inner, request).await
+                                <T as BrowseService>::tree_get_entries(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -279,19 +298,23 @@ pub mod browse_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -548,10 +571,10 @@ pub mod library_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct LibraryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -595,8 +618,9 @@ pub mod library_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LibraryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -634,233 +658,325 @@ pub mod library_service_client {
         pub async fn get_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbums");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbums",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbums",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbums"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtists");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtists",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtists",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtists"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTracks");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTracks",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTracks",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTracks"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_album(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artist(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtist");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtist",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtist",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtist"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_track(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_track(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_album(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_album(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedAlbums",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedAlbums"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn scan_library(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "ScanLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "ScanLibrary"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_library(
@@ -870,30 +986,41 @@ pub mod library_service_client {
             tonic::Response<tonic::codec::Streaming<super::StreamLibraryResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "StreamLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "StreamLibrary"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/Search");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/Search",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "Search"));
@@ -908,7 +1035,7 @@ pub mod library_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LibraryServiceServer.
@@ -917,64 +1044,107 @@ pub mod library_service_server {
         async fn get_albums(
             &self,
             request: tonic::Request<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn get_artists(
             &self,
             request: tonic::Request<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        >;
         async fn get_tracks(
             &self,
             request: tonic::Request<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_album(
             &self,
             request: tonic::Request<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_artist(
             &self,
             request: tonic::Request<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        >;
         async fn get_track(
             &self,
             request: tonic::Request<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_track(
             &self,
             request: tonic::Request<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn unlike_track(
             &self,
             request: tonic::Request<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_album(
             &self,
             request: tonic::Request<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn unlike_album(
             &self,
             request: tonic::Request<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_tracks(
             &self,
             request: tonic::Request<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_albums(
             &self,
             request: tonic::Request<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn scan_library(
             &self,
             request: tonic::Request<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamLibrary method.
         type StreamLibraryStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StreamLibraryResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_library(
             &self,
             request: tonic::Request<super::StreamLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamLibraryStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamLibraryStream>,
+            tonic::Status,
+        >;
         async fn search(
             &self,
             request: tonic::Request<super::SearchRequest>,
@@ -1001,7 +1171,10 @@ pub mod library_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1056,9 +1229,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumsRequest> for GetAlbumsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumsRequest>
+                    for GetAlbumsSvc<T> {
                         type Response = super::GetAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumsRequest>,
@@ -1095,9 +1274,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtists" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistsRequest> for GetArtistsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistsRequest>
+                    for GetArtistsSvc<T> {
                         type Response = super::GetArtistsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistsRequest>,
@@ -1134,9 +1319,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTracksRequest> for GetTracksSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTracksRequest>
+                    for GetTracksSvc<T> {
                         type Response = super::GetTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTracksRequest>,
@@ -1173,9 +1364,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumRequest> for GetAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumRequest>
+                    for GetAlbumSvc<T> {
                         type Response = super::GetAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumRequest>,
@@ -1212,9 +1409,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtist" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistRequest> for GetArtistSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistRequest>
+                    for GetArtistSvc<T> {
                         type Response = super::GetArtistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistRequest>,
@@ -1251,9 +1454,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTrack" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTrackRequest> for GetTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTrackRequest>
+                    for GetTrackSvc<T> {
                         type Response = super::GetTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackRequest>,
@@ -1290,9 +1499,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct LikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeTrackRequest> for LikeTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeTrackRequest>
+                    for LikeTrackSvc<T> {
                         type Response = super::LikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeTrackRequest>,
@@ -1329,11 +1544,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeTrackRequest>
-                        for UnlikeTrackSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeTrackRequest>
+                    for UnlikeTrackSvc<T> {
                         type Response = super::UnlikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeTrackRequest>,
@@ -1370,9 +1589,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct LikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeAlbumRequest> for LikeAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeAlbumRequest>
+                    for LikeAlbumSvc<T> {
                         type Response = super::LikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeAlbumRequest>,
@@ -1409,11 +1634,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeAlbumRequest>
-                        for UnlikeAlbumSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeAlbumRequest>
+                    for UnlikeAlbumSvc<T> {
                         type Response = super::UnlikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeAlbumRequest>,
@@ -1450,19 +1679,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedTracksRequest>
-                        for GetLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedTracksRequest>
+                    for GetLikedTracksSvc<T> {
                         type Response = super::GetLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_tracks(&inner, request).await
+                                <T as LibraryService>::get_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1492,19 +1725,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedAlbumsRequest>
-                        for GetLikedAlbumsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedAlbumsRequest>
+                    for GetLikedAlbumsSvc<T> {
                         type Response = super::GetLikedAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedAlbumsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_albums(&inner, request).await
+                                <T as LibraryService>::get_liked_albums(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1534,11 +1771,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct ScanLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::ScanLibraryRequest>
-                        for ScanLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::ScanLibraryRequest>
+                    for ScanLibrarySvc<T> {
                         type Response = super::ScanLibraryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScanLibraryRequest>,
@@ -1575,14 +1816,16 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct StreamLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::ServerStreamingService<super::StreamLibraryRequest>
-                        for StreamLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::ServerStreamingService<super::StreamLibraryRequest>
+                    for StreamLibrarySvc<T> {
                         type Response = super::StreamLibraryResponse;
                         type ResponseStream = T::StreamLibraryStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamLibraryRequest>,
@@ -1619,16 +1862,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::SearchRequest>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as LibraryService>::search(&inner, request).await };
+                            let fut = async move {
+                                <T as LibraryService>::search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1654,19 +1904,23 @@ pub mod library_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1695,10 +1949,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1742,8 +1996,9 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1787,7 +2042,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1814,7 +2069,10 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1866,19 +2124,23 @@ pub mod metadata_service_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2162,10 +2424,10 @@ pub mod playback_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaybackServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2209,8 +2471,9 @@ pub mod playback_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaybackServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2249,12 +2512,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PlayRequest>,
         ) -> std::result::Result<tonic::Response<super::PlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Play");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Play",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Play"));
@@ -2264,12 +2533,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PauseRequest>,
         ) -> std::result::Result<tonic::Response<super::PauseResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Pause");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Pause",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Pause"));
@@ -2278,49 +2553,66 @@ pub mod playback_service_client {
         pub async fn play_or_pause(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayOrPause",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayOrPause"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeRequest>,
         ) -> std::result::Result<tonic::Response<super::ResumeResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Resume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Resume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Resume",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Resume"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::NextRequest>,
         ) -> std::result::Result<tonic::Response<super::NextResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Next");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Next",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Next"));
@@ -2329,293 +2621,426 @@ pub mod playback_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Previous");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Previous",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Previous",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Previous"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn fast_forward_rewind(
             &mut self,
             request: impl tonic::IntoRequest<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FastForwardRewind",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FastForwardRewind",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Status");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Status",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Status",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Status"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn current_track(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "CurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "CurrentTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn next_track(
             &mut self,
             request: impl tonic::IntoRequest<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/NextTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/NextTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "NextTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "NextTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn flush_and_reload_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FlushAndReloadTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FlushAndReloadTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_file_position(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "GetFilePosition",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "GetFilePosition",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn hard_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/HardStop");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/HardStop",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "HardStop",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "HardStop"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_album(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayDirectory"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_music_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayMusicDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayMusicDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_track(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayLikedTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAllTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_current_track(
@@ -2625,18 +3050,26 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::CurrentTrackResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamCurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "StreamCurrentTrack",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_status(
@@ -2646,18 +3079,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamStatus"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_playlist(
@@ -2667,18 +3105,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::PlaylistResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamPlaylist"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
     }
@@ -2690,7 +3133,7 @@ pub mod playback_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaybackServiceServer.
@@ -2707,7 +3150,10 @@ pub mod playback_service_server {
         async fn play_or_pause(
             &self,
             request: tonic::Request<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        >;
         async fn resume(
             &self,
             request: tonic::Request<super::ResumeRequest>,
@@ -2719,11 +3165,17 @@ pub mod playback_service_server {
         async fn previous(
             &self,
             request: tonic::Request<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        >;
         async fn fast_forward_rewind(
             &self,
             request: tonic::Request<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        >;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
@@ -2731,82 +3183,133 @@ pub mod playback_service_server {
         async fn current_track(
             &self,
             request: tonic::Request<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        >;
         async fn next_track(
             &self,
             request: tonic::Request<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        >;
         async fn flush_and_reload_tracks(
             &self,
             request: tonic::Request<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_file_position(
             &self,
             request: tonic::Request<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        >;
         async fn hard_stop(
             &self,
             request: tonic::Request<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        >;
         async fn play_album(
             &self,
             request: tonic::Request<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        >;
         async fn play_artist_tracks(
             &self,
             request: tonic::Request<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_playlist(
             &self,
             request: tonic::Request<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn play_directory(
             &self,
             request: tonic::Request<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_music_directory(
             &self,
             request: tonic::Request<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_track(
             &self,
             request: tonic::Request<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        >;
         async fn play_liked_tracks(
             &self,
             request: tonic::Request<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_all_tracks(
             &self,
             request: tonic::Request<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamCurrentTrack method.
         type StreamCurrentTrackStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CurrentTrackResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_current_track(
             &self,
             request: tonic::Request<super::StreamCurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamCurrentTrackStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamCurrentTrackStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamStatus method.
         type StreamStatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_status(
             &self,
             request: tonic::Request<super::StreamStatusRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamStatusStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamStatusStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamPlaylist method.
         type StreamPlaylistStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::PlaylistResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_playlist(
             &self,
             request: tonic::Request<super::StreamPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamPlaylistStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamPlaylistStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaybackServiceServer<T> {
@@ -2829,7 +3332,10 @@ pub mod playback_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2884,16 +3390,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Play" => {
                     #[allow(non_camel_case_types)]
                     struct PlaySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
                         type Response = super::PlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::play(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::play(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2922,16 +3434,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Pause" => {
                     #[allow(non_camel_case_types)]
                     struct PauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
                         type Response = super::PauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PauseRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::pause(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::pause(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2960,11 +3478,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause" => {
                     #[allow(non_camel_case_types)]
                     struct PlayOrPauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayOrPauseRequest>
-                        for PlayOrPauseSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayOrPauseRequest>
+                    for PlayOrPauseSvc<T> {
                         type Response = super::PlayOrPauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayOrPauseRequest>,
@@ -3001,9 +3523,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Resume" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::ResumeRequest> for ResumeSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::ResumeRequest>
+                    for ResumeSvc<T> {
                         type Response = super::ResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeRequest>,
@@ -3040,16 +3568,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
                         type Response = super::NextResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::next(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::next(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3078,9 +3612,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PreviousRequest> for PreviousSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PreviousRequest>
+                    for PreviousSvc<T> {
                         type Response = super::PreviousResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PreviousRequest>,
@@ -3117,19 +3657,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind" => {
                     #[allow(non_camel_case_types)]
                     struct FastForwardRewindSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FastForwardRewindRequest>
-                        for FastForwardRewindSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FastForwardRewindRequest>
+                    for FastForwardRewindSvc<T> {
                         type Response = super::FastForwardRewindResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FastForwardRewindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::fast_forward_rewind(&inner, request).await
+                                <T as PlaybackService>::fast_forward_rewind(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3159,9 +3703,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Status" => {
                     #[allow(non_camel_case_types)]
                     struct StatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::StatusRequest> for StatusSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::StatusRequest>
+                    for StatusSvc<T> {
                         type Response = super::StatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
@@ -3198,11 +3748,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct CurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::CurrentTrackRequest>
-                        for CurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::CurrentTrackRequest>
+                    for CurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CurrentTrackRequest>,
@@ -3239,9 +3793,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/NextTrack" => {
                     #[allow(non_camel_case_types)]
                     struct NextTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextTrackRequest> for NextTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextTrackRequest>
+                    for NextTrackSvc<T> {
                         type Response = super::NextTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextTrackRequest>,
@@ -3278,19 +3838,25 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks" => {
                     #[allow(non_camel_case_types)]
                     struct FlushAndReloadTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
-                        for FlushAndReloadTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
+                    for FlushAndReloadTracksSvc<T> {
                         type Response = super::FlushAndReloadTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FlushAndReloadTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::flush_and_reload_tracks(&inner, request)
+                                <T as PlaybackService>::flush_and_reload_tracks(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -3321,19 +3887,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition" => {
                     #[allow(non_camel_case_types)]
                     struct GetFilePositionSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::GetFilePositionRequest>
-                        for GetFilePositionSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::GetFilePositionRequest>
+                    for GetFilePositionSvc<T> {
                         type Response = super::GetFilePositionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFilePositionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::get_file_position(&inner, request).await
+                                <T as PlaybackService>::get_file_position(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3363,9 +3933,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/HardStop" => {
                     #[allow(non_camel_case_types)]
                     struct HardStopSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::HardStopRequest> for HardStopSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::HardStopRequest>
+                    for HardStopSvc<T> {
                         type Response = super::HardStopResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HardStopRequest>,
@@ -3402,9 +3978,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAlbumSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayAlbumRequest> for PlayAlbumSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAlbumRequest>
+                    for PlayAlbumSvc<T> {
                         type Response = super::PlayAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAlbumRequest>,
@@ -3441,19 +4023,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayArtistTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayArtistTracksRequest>
-                        for PlayArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayArtistTracksRequest>
+                    for PlayArtistTracksSvc<T> {
                         type Response = super::PlayArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_artist_tracks(&inner, request).await
+                                <T as PlaybackService>::play_artist_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3483,11 +4069,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct PlayPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayPlaylistRequest>
-                        for PlayPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayPlaylistRequest>
+                    for PlayPlaylistSvc<T> {
                         type Response = super::PlayPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayPlaylistRequest>,
@@ -3524,19 +4114,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayDirectoryRequest>
-                        for PlayDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayDirectoryRequest>
+                    for PlayDirectorySvc<T> {
                         type Response = super::PlayDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_directory(&inner, request).await
+                                <T as PlaybackService>::play_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3566,19 +4160,26 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayMusicDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
-                        for PlayMusicDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
+                    for PlayMusicDirectorySvc<T> {
                         type Response = super::PlayMusicDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayMusicDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_music_directory(&inner, request).await
+                                <T as PlaybackService>::play_music_directory(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3608,9 +4209,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayTrack" => {
                     #[allow(non_camel_case_types)]
                     struct PlayTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayTrackRequest> for PlayTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayTrackRequest>
+                    for PlayTrackSvc<T> {
                         type Response = super::PlayTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayTrackRequest>,
@@ -3647,19 +4254,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayLikedTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayLikedTracksRequest>
-                        for PlayLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayLikedTracksRequest>
+                    for PlayLikedTracksSvc<T> {
                         type Response = super::PlayLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_liked_tracks(&inner, request).await
+                                <T as PlaybackService>::play_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3689,19 +4300,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAllTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayAllTracksRequest>
-                        for PlayAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAllTracksRequest>
+                    for PlayAllTracksSvc<T> {
                         type Response = super::PlayAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_all_tracks(&inner, request).await
+                                <T as PlaybackService>::play_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3731,21 +4346,28 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct StreamCurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamCurrentTrackRequest>
-                        for StreamCurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamCurrentTrackRequest,
+                    > for StreamCurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
                         type ResponseStream = T::StreamCurrentTrackStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamCurrentTrackRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_current_track(&inner, request).await
+                                <T as PlaybackService>::stream_current_track(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3775,14 +4397,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus" => {
                     #[allow(non_camel_case_types)]
                     struct StreamStatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamStatusRequest>
-                        for StreamStatusSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamStatusRequest>
+                    for StreamStatusSvc<T> {
                         type Response = super::StatusResponse;
                         type ResponseStream = T::StreamStatusStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamStatusRequest>,
@@ -3819,21 +4443,24 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct StreamPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
-                        for StreamPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
+                    for StreamPlaylistSvc<T> {
                         type Response = super::PlaylistResponse;
                         type ResponseStream = T::StreamPlaylistStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_playlist(&inner, request).await
+                                <T as PlaybackService>::stream_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3860,19 +4487,23 @@ pub mod playback_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -4079,10 +4710,10 @@ pub mod playlist_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaylistServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4126,8 +4757,9 @@ pub mod playlist_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaylistServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4165,182 +4797,251 @@ pub mod playlist_service_client {
         pub async fn get_current(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_resume_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetResumeInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetResumeInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetTrackInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetTrackInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_first_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetFirstIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetFirstIndex"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_display_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetDisplayIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "GetDisplayIndex",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn amount(
             &mut self,
             request: impl tonic::IntoRequest<super::AmountRequest>,
         ) -> std::result::Result<tonic::Response<super::AmountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Amount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Amount",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "Amount",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Amount"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn playlist_resume(
             &mut self,
             request: impl tonic::IntoRequest<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "PlaylistResume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "PlaylistResume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume_track(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ResumeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "ResumeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_modified(
             &mut self,
             request: impl tonic::IntoRequest<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/SetModified",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "SetModified",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "SetModified"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn start(
             &mut self,
             request: impl tonic::IntoRequest<super::StartRequest>,
         ) -> std::result::Result<tonic::Response<super::StartResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Start");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Start",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Start"));
@@ -4350,12 +5051,18 @@ pub mod playlist_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncRequest>,
         ) -> std::result::Result<tonic::Response<super::SyncResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Sync");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Sync",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Sync"));
@@ -4364,172 +5071,247 @@ pub mod playlist_service_client {
         pub async fn remove_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "RemoveAllTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "RemoveTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn create_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "CreatePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "CreatePlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_album(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn shuffle_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ShufflePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "ShufflePlaylist",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -4541,7 +5323,7 @@ pub mod playlist_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaylistServiceServer.
@@ -4550,23 +5332,38 @@ pub mod playlist_service_server {
         async fn get_current(
             &self,
             request: tonic::Request<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        >;
         async fn get_resume_info(
             &self,
             request: tonic::Request<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_track_info(
             &self,
             request: tonic::Request<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_first_index(
             &self,
             request: tonic::Request<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        >;
         async fn get_display_index(
             &self,
             request: tonic::Request<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        >;
         async fn amount(
             &self,
             request: tonic::Request<super::AmountRequest>,
@@ -4574,15 +5371,24 @@ pub mod playlist_service_server {
         async fn playlist_resume(
             &self,
             request: tonic::Request<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        >;
         async fn resume_track(
             &self,
             request: tonic::Request<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        >;
         async fn set_modified(
             &self,
             request: tonic::Request<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        >;
         async fn start(
             &self,
             request: tonic::Request<super::StartRequest>,
@@ -4594,39 +5400,66 @@ pub mod playlist_service_server {
         async fn remove_all_tracks(
             &self,
             request: tonic::Request<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        >;
         async fn remove_tracks(
             &self,
             request: tonic::Request<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        >;
         async fn create_playlist(
             &self,
             request: tonic::Request<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_tracks(
             &self,
             request: tonic::Request<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        >;
         async fn insert_directory(
             &self,
             request: tonic::Request<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn insert_playlist(
             &self,
             request: tonic::Request<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_album(
             &self,
             request: tonic::Request<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        >;
         async fn insert_artist_tracks(
             &self,
             request: tonic::Request<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn shuffle_playlist(
             &self,
             request: tonic::Request<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaylistServiceServer<T> {
@@ -4649,7 +5482,10 @@ pub mod playlist_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4704,11 +5540,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetCurrentRequest>
-                        for GetCurrentSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetCurrentRequest>
+                    for GetCurrentSvc<T> {
                         type Response = super::GetCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCurrentRequest>,
@@ -4745,19 +5585,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetResumeInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetResumeInfoRequest>
-                        for GetResumeInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetResumeInfoRequest>
+                    for GetResumeInfoSvc<T> {
                         type Response = super::GetResumeInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetResumeInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_resume_info(&inner, request).await
+                                <T as PlaylistService>::get_resume_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4787,18 +5631,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetTrackInfoRequest>
-                        for GetTrackInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetTrackInfoRequest>
+                    for GetTrackInfoSvc<T> {
                         type Response = super::GetTrackInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_track_info(&inner, request).await
+                                <T as PlaylistService>::get_track_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4828,19 +5677,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetFirstIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetFirstIndexRequest>
-                        for GetFirstIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetFirstIndexRequest>
+                    for GetFirstIndexSvc<T> {
                         type Response = super::GetFirstIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFirstIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_first_index(&inner, request).await
+                                <T as PlaylistService>::get_first_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4870,19 +5723,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetDisplayIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetDisplayIndexRequest>
-                        for GetDisplayIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetDisplayIndexRequest>
+                    for GetDisplayIndexSvc<T> {
                         type Response = super::GetDisplayIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetDisplayIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_display_index(&inner, request).await
+                                <T as PlaylistService>::get_display_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4912,9 +5769,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Amount" => {
                     #[allow(non_camel_case_types)]
                     struct AmountSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::AmountRequest> for AmountSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::AmountRequest>
+                    for AmountSvc<T> {
                         type Response = super::AmountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AmountRequest>,
@@ -4951,19 +5814,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume" => {
                     #[allow(non_camel_case_types)]
                     struct PlaylistResumeSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::PlaylistResumeRequest>
-                        for PlaylistResumeSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::PlaylistResumeRequest>
+                    for PlaylistResumeSvc<T> {
                         type Response = super::PlaylistResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlaylistResumeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::playlist_resume(&inner, request).await
+                                <T as PlaylistService>::playlist_resume(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4993,11 +5860,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeTrackSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::ResumeTrackRequest>
-                        for ResumeTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ResumeTrackRequest>
+                    for ResumeTrackSvc<T> {
                         type Response = super::ResumeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeTrackRequest>,
@@ -5034,11 +5905,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/SetModified" => {
                     #[allow(non_camel_case_types)]
                     struct SetModifiedSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SetModifiedRequest>
-                        for SetModifiedSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SetModifiedRequest>
+                    for SetModifiedSvc<T> {
                         type Response = super::SetModifiedResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetModifiedRequest>,
@@ -5075,16 +5950,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Start" => {
                     #[allow(non_camel_case_types)]
                     struct StartSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
                         type Response = super::StartResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StartRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::start(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::start(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5113,16 +5994,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
                         type Response = super::SyncResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::sync(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::sync(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5151,19 +6038,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveAllTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::RemoveAllTracksRequest>
-                        for RemoveAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveAllTracksRequest>
+                    for RemoveAllTracksSvc<T> {
                         type Response = super::RemoveAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::remove_all_tracks(&inner, request).await
+                                <T as PlaylistService>::remove_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5193,11 +6084,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::RemoveTracksRequest>
-                        for RemoveTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveTracksRequest>
+                    for RemoveTracksSvc<T> {
                         type Response = super::RemoveTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveTracksRequest>,
@@ -5234,19 +6129,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct CreatePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::CreatePlaylistRequest>
-                        for CreatePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::CreatePlaylistRequest>
+                    for CreatePlaylistSvc<T> {
                         type Response = super::CreatePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreatePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::create_playlist(&inner, request).await
+                                <T as PlaylistService>::create_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5276,11 +6175,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertTracksRequest>
-                        for InsertTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertTracksRequest>
+                    for InsertTracksSvc<T> {
                         type Response = super::InsertTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertTracksRequest>,
@@ -5317,19 +6220,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct InsertDirectorySvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertDirectoryRequest>
-                        for InsertDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertDirectoryRequest>
+                    for InsertDirectorySvc<T> {
                         type Response = super::InsertDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_directory(&inner, request).await
+                                <T as PlaylistService>::insert_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5359,19 +6266,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct InsertPlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertPlaylistRequest>
-                        for InsertPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertPlaylistRequest>
+                    for InsertPlaylistSvc<T> {
                         type Response = super::InsertPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_playlist(&inner, request).await
+                                <T as PlaylistService>::insert_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5401,11 +6312,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct InsertAlbumSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertAlbumRequest>
-                        for InsertAlbumSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertAlbumRequest>
+                    for InsertAlbumSvc<T> {
                         type Response = super::InsertAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertAlbumRequest>,
@@ -5442,19 +6357,26 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertArtistTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertArtistTracksRequest>
-                        for InsertArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertArtistTracksRequest>
+                    for InsertArtistTracksSvc<T> {
                         type Response = super::InsertArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_artist_tracks(&inner, request).await
+                                <T as PlaylistService>::insert_artist_tracks(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5484,19 +6406,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct ShufflePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::ShufflePlaylistRequest>
-                        for ShufflePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ShufflePlaylistRequest>
+                    for ShufflePlaylistSvc<T> {
                         type Response = super::ShufflePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ShufflePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::shuffle_playlist(&inner, request).await
+                                <T as PlaylistService>::shuffle_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5523,19 +6449,23 @@ pub mod playlist_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6045,10 +6975,10 @@ pub mod settings_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SettingsServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6092,8 +7022,9 @@ pub mod settings_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SettingsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6131,58 +7062,85 @@ pub mod settings_service_client {
         pub async fn get_settings_list(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetSettingsList",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetSettingsList",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetGlobalSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetGlobalSettings",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn save_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/SaveSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "SaveSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SettingsService", "SaveSettings"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6194,7 +7152,7 @@ pub mod settings_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SettingsServiceServer.
@@ -6203,15 +7161,24 @@ pub mod settings_service_server {
         async fn get_settings_list(
             &self,
             request: tonic::Request<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        >;
         async fn get_global_settings(
             &self,
             request: tonic::Request<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        >;
         async fn save_settings(
             &self,
             request: tonic::Request<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SettingsServiceServer<T> {
@@ -6234,7 +7201,10 @@ pub mod settings_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6289,19 +7259,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList" => {
                     #[allow(non_camel_case_types)]
                     struct GetSettingsListSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetSettingsListRequest>
-                        for GetSettingsListSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetSettingsListRequest>
+                    for GetSettingsListSvc<T> {
                         type Response = super::GetSettingsListResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSettingsListRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_settings_list(&inner, request).await
+                                <T as SettingsService>::get_settings_list(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6331,19 +7305,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetGlobalSettingsRequest>
-                        for GetGlobalSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetGlobalSettingsRequest>
+                    for GetGlobalSettingsSvc<T> {
                         type Response = super::GetGlobalSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalSettingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_global_settings(&inner, request).await
+                                <T as SettingsService>::get_global_settings(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6373,11 +7351,15 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/SaveSettings" => {
                     #[allow(non_camel_case_types)]
                     struct SaveSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService> tonic::server::UnaryService<super::SaveSettingsRequest>
-                        for SaveSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::SaveSettingsRequest>
+                    for SaveSettingsSvc<T> {
                         type Response = super::SaveSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SaveSettingsRequest>,
@@ -6411,19 +7393,23 @@ pub mod settings_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6581,10 +7567,10 @@ pub mod sound_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SoundServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6628,8 +7614,9 @@ pub mod sound_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SoundServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6667,31 +7654,48 @@ pub mod sound_service_client {
         pub async fn adjust_volume(
             &mut self,
             request: impl tonic::IntoRequest<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/AdjustVolume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/AdjustVolume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "AdjustVolume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "AdjustVolume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_set(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundSet");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundSet",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundSet"));
@@ -6700,49 +7704,74 @@ pub mod sound_service_client {
         pub async fn sound_current(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundCurrent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundCurrent",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_default(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundDefault");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundDefault",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundDefault",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundDefault"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_min(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMin");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMin",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMin"));
@@ -6751,13 +7780,22 @@ pub mod sound_service_client {
         pub async fn sound_max(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMax");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMax",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMax"));
@@ -6766,49 +7804,72 @@ pub mod sound_service_client {
         pub async fn sound_unit(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundUnit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundUnit",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundUnit",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundUnit"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_val2_phys(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundVal2Phys",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundVal2Phys"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/GetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/GetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "GetPitch"));
@@ -6817,13 +7878,22 @@ pub mod sound_service_client {
         pub async fn set_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SetPitch"));
@@ -6832,13 +7902,22 @@ pub mod sound_service_client {
         pub async fn beep_play(
             &mut self,
             request: impl tonic::IntoRequest<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/BeepPlay");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/BeepPlay",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "BeepPlay"));
@@ -6847,76 +7926,106 @@ pub mod sound_service_client {
         pub async fn pcmbuf_fade(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/PcmbufFade");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/PcmbufFade",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufFade",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "PcmbufFade"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn pcmbuf_set_low_latency(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufSetLowLatency",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SoundService",
+                        "PcmbufSetLowLatency",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn system_sound_play(
             &mut self,
             request: impl tonic::IntoRequest<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SystemSoundPlay",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SystemSoundPlay"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn keyclick_click(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/KeyclickClick",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "KeyclickClick",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "KeyclickClick"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6928,7 +8037,7 @@ pub mod sound_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SoundServiceServer.
@@ -6937,63 +8046,108 @@ pub mod sound_service_server {
         async fn adjust_volume(
             &self,
             request: tonic::Request<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        >;
         async fn sound_set(
             &self,
             request: tonic::Request<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        >;
         async fn sound_current(
             &self,
             request: tonic::Request<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        >;
         async fn sound_default(
             &self,
             request: tonic::Request<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        >;
         async fn sound_min(
             &self,
             request: tonic::Request<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        >;
         async fn sound_max(
             &self,
             request: tonic::Request<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        >;
         async fn sound_unit(
             &self,
             request: tonic::Request<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        >;
         async fn sound_val2_phys(
             &self,
             request: tonic::Request<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        >;
         async fn get_pitch(
             &self,
             request: tonic::Request<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        >;
         async fn set_pitch(
             &self,
             request: tonic::Request<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        >;
         async fn beep_play(
             &self,
             request: tonic::Request<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_fade(
             &self,
             request: tonic::Request<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_set_low_latency(
             &self,
             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        >;
         async fn system_sound_play(
             &self,
             request: tonic::Request<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        >;
         async fn keyclick_click(
             &self,
             request: tonic::Request<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SoundServiceServer<T> {
@@ -7016,7 +8170,10 @@ pub mod sound_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7071,11 +8228,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/AdjustVolume" => {
                     #[allow(non_camel_case_types)]
                     struct AdjustVolumeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::AdjustVolumeRequest>
-                        for AdjustVolumeSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::AdjustVolumeRequest>
+                    for AdjustVolumeSvc<T> {
                         type Response = super::AdjustVolumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AdjustVolumeRequest>,
@@ -7112,9 +8273,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundSet" => {
                     #[allow(non_camel_case_types)]
                     struct SoundSetSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundSetRequest> for SoundSetSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundSetRequest>
+                    for SoundSetSvc<T> {
                         type Response = super::SoundSetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundSetRequest>,
@@ -7151,11 +8318,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct SoundCurrentSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundCurrentRequest>
-                        for SoundCurrentSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundCurrentRequest>
+                    for SoundCurrentSvc<T> {
                         type Response = super::SoundCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundCurrentRequest>,
@@ -7192,11 +8363,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundDefault" => {
                     #[allow(non_camel_case_types)]
                     struct SoundDefaultSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundDefaultRequest>
-                        for SoundDefaultSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundDefaultRequest>
+                    for SoundDefaultSvc<T> {
                         type Response = super::SoundDefaultResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundDefaultRequest>,
@@ -7233,9 +8408,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMin" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMinSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMinRequest> for SoundMinSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMinRequest>
+                    for SoundMinSvc<T> {
                         type Response = super::SoundMinResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMinRequest>,
@@ -7272,9 +8453,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMax" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMaxSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMaxRequest> for SoundMaxSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMaxRequest>
+                    for SoundMaxSvc<T> {
                         type Response = super::SoundMaxResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMaxRequest>,
@@ -7311,9 +8498,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundUnit" => {
                     #[allow(non_camel_case_types)]
                     struct SoundUnitSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundUnitRequest> for SoundUnitSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundUnitRequest>
+                    for SoundUnitSvc<T> {
                         type Response = super::SoundUnitResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundUnitRequest>,
@@ -7350,11 +8543,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys" => {
                     #[allow(non_camel_case_types)]
                     struct SoundVal2PhysSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundVal2PhysRequest>
-                        for SoundVal2PhysSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundVal2PhysRequest>
+                    for SoundVal2PhysSvc<T> {
                         type Response = super::SoundVal2PhysResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundVal2PhysRequest>,
@@ -7391,9 +8588,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/GetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct GetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::GetPitchRequest> for GetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::GetPitchRequest>
+                    for GetPitchSvc<T> {
                         type Response = super::GetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPitchRequest>,
@@ -7430,9 +8633,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct SetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SetPitchRequest> for SetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SetPitchRequest>
+                    for SetPitchSvc<T> {
                         type Response = super::SetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPitchRequest>,
@@ -7469,9 +8678,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/BeepPlay" => {
                     #[allow(non_camel_case_types)]
                     struct BeepPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::BeepPlayRequest> for BeepPlaySvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::BeepPlayRequest>
+                    for BeepPlaySvc<T> {
                         type Response = super::BeepPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BeepPlayRequest>,
@@ -7508,9 +8723,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufFade" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufFadeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::PcmbufFadeRequest> for PcmbufFadeSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufFadeRequest>
+                    for PcmbufFadeSvc<T> {
                         type Response = super::PcmbufFadeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufFadeRequest>,
@@ -7547,19 +8768,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufSetLowLatencySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService>
-                        tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
-                        for PcmbufSetLowLatencySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
+                    for PcmbufSetLowLatencySvc<T> {
                         type Response = super::PcmbufSetLowLatencyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request).await
+                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7589,18 +8814,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay" => {
                     #[allow(non_camel_case_types)]
                     struct SystemSoundPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SystemSoundPlayRequest>
-                        for SystemSoundPlaySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SystemSoundPlayRequest>
+                    for SystemSoundPlaySvc<T> {
                         type Response = super::SystemSoundPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SystemSoundPlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::system_sound_play(&inner, request).await
+                                <T as SoundService>::system_sound_play(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7630,11 +8860,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/KeyclickClick" => {
                     #[allow(non_camel_case_types)]
                     struct KeyclickClickSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::KeyclickClickRequest>
-                        for KeyclickClickSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::KeyclickClickRequest>
+                    for KeyclickClickSvc<T> {
                         type Response = super::KeyclickClickResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::KeyclickClickRequest>,
@@ -7668,19 +8902,23 @@ pub mod sound_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -7741,10 +8979,10 @@ pub mod system_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SystemServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7788,8 +9026,9 @@ pub mod system_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SystemServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7827,39 +9066,56 @@ pub mod system_service_client {
         pub async fn get_rockbox_version(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetRockboxVersion",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SystemService",
+                        "GetRockboxVersion",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetGlobalStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SystemService", "GetGlobalStatus"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7871,7 +9127,7 @@ pub mod system_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SystemServiceServer.
@@ -7880,11 +9136,17 @@ pub mod system_service_server {
         async fn get_rockbox_version(
             &self,
             request: tonic::Request<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        >;
         async fn get_global_status(
             &self,
             request: tonic::Request<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SystemServiceServer<T> {
@@ -7907,7 +9169,10 @@ pub mod system_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7962,19 +9227,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion" => {
                     #[allow(non_camel_case_types)]
                     struct GetRockboxVersionSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetRockboxVersionRequest>
-                        for GetRockboxVersionSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetRockboxVersionRequest>
+                    for GetRockboxVersionSvc<T> {
                         type Response = super::GetRockboxVersionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRockboxVersionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_rockbox_version(&inner, request).await
+                                <T as SystemService>::get_rockbox_version(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -8004,19 +9273,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalStatusSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetGlobalStatusRequest>
-                        for GetGlobalStatusSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetGlobalStatusRequest>
+                    for GetGlobalStatusSvc<T> {
                         type Response = super::GetGlobalStatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_global_status(&inner, request).await
+                                <T as SystemService>::get_global_status(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -8043,19 +9316,23 @@ pub mod system_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/crates/upnp/src/lib.rs
+++ b/crates/upnp/src/lib.rs
@@ -92,6 +92,20 @@ impl BroadcastBuffer {
         }
     }
 
+    /// Start a subscriber `n` chunks *behind* the live edge so the remote
+    /// client can drain historical buffered data at network speed instead of
+    /// waiting for new chunks to arrive in real time.  Clamped to the oldest
+    /// chunk still in the buffer.
+    pub(crate) fn subscribe_from_behind(self: &Arc<Self>, n: u64) -> BroadcastReceiver {
+        let g = self.inner.lock().unwrap();
+        let front_seq = g.chunks.front().map(|(s, _)| *s).unwrap_or(g.next_seq);
+        let next_seq = g.next_seq.saturating_sub(n).max(front_seq);
+        BroadcastReceiver {
+            buf: Arc::clone(self),
+            next_seq,
+        }
+    }
+
     fn reset(&self) {
         let mut g = self.inner.lock().unwrap();
         g.chunks.clear();
@@ -320,22 +334,29 @@ pub extern "C" fn pcm_upnp_start() -> c_int {
                 if let Some(ref t) = track {
                     *LAST_PCM_TRACK_PATH.lock().unwrap() = t.path.clone();
                 }
-                let album_art_url = if let Some(ref t) = track {
-                    get_album_art_url(&t.path, local_ip).await
-                } else {
-                    None
-                };
-                if let Err(e) = avtransport_play(
-                    &url,
-                    &stream_url,
-                    track.as_ref(),
-                    sample_rate,
-                    true,
-                    album_art_url.as_deref(),
-                )
-                .await
+                // Send SetAVTransportURI + Play immediately without waiting for the
+                // album art DB lookup — this cuts 100–500 ms of startup latency.
+                if let Err(e) =
+                    avtransport_play(&url, &stream_url, track.as_ref(), sample_rate, true, None)
+                        .await
                 {
                     tracing::warn!("UPnP AVTransport play failed: {}", e);
+                    return;
+                }
+                // Follow up with album art once the DB lookup completes (metadata-
+                // only update, no second Play so the renderer stays connected).
+                if let Some(ref t) = track {
+                    if let Some(art) = get_album_art_url(&t.path, local_ip).await {
+                        let _ = avtransport_play(
+                            &url,
+                            &stream_url,
+                            track.as_ref(),
+                            sample_rate,
+                            false,
+                            Some(&art),
+                        )
+                        .await;
+                    }
                 }
             });
         } else {
@@ -357,7 +378,15 @@ pub extern "C" fn pcm_upnp_start() -> c_int {
                 }
             };
 
-            if is_track_change {
+            // If the "new track" is our own WAV stream the renderer is re-ingesting
+            // (http://<ip>:<port>/stream.wav), skip SetAVTransportURI entirely.
+            // Sending it would overwrite the correct DIDL metadata (duration, album
+            // art) stored for the real file with stream.wav's codec values (duration
+            // 0, no art), and would create an infinite feedback loop.
+            let is_our_stream =
+                current_path.starts_with("http://") && current_path.ends_with("/stream.wav");
+
+            if is_track_change && !is_our_stream {
                 // Fire SetAVTransportURI *without* Play at the exact PCM boundary.
                 // The renderer updates its metadata display and — if it supports
                 // metadata-only updates — stays connected to the live /stream.wav
@@ -423,6 +452,22 @@ pub extern "C" fn pcm_upnp_close() {
     *rp = false;
 }
 
+/// Reset the renderer-side state so the next `pcm_upnp_start()` always sends
+/// a fresh SetAVTransportURI + Play to the renderer.  Call this whenever the
+/// UPnP sink is selected (e.g. the user connects to a UPnP device from the UI)
+/// to make output switch-in work without restarting the daemon.
+#[cfg(feature = "ffi")]
+#[no_mangle]
+pub extern "C" fn pcm_upnp_reset_renderer() {
+    // Kill any running track-change monitor — a new one will start with pcm_upnp_start().
+    MONITOR_GEN.fetch_add(1, Ordering::SeqCst);
+    // Clear the last-track hint so the next start is always treated as "first play".
+    *LAST_PCM_TRACK_PATH.lock().unwrap() = String::new();
+    // Reset the "renderer already playing" flag so pcm_upnp_start() sends Play.
+    *RENDERER_PLAYING.lock().unwrap() = false;
+    tracing::debug!("UPnP PCM sink: renderer state reset");
+}
+
 // ---------------------------------------------------------------------------
 // Album art DB lookup
 // ---------------------------------------------------------------------------
@@ -470,7 +515,10 @@ fn ensure_track_monitor(renderer_url: String, port: u16) {
                 .map(|t| t.path.clone())
                 .unwrap_or_default();
 
-            if !current_path.is_empty() && current_path != last_current_path {
+            let is_our_stream =
+                current_path.starts_with("http://") && current_path.ends_with("/stream.wav");
+
+            if !current_path.is_empty() && current_path != last_current_path && !is_our_stream {
                 let is_first = last_current_path.is_empty();
                 last_current_path = current_path.clone();
 

--- a/crates/upnp/src/pcm_server.rs
+++ b/crates/upnp/src/pcm_server.rs
@@ -361,7 +361,10 @@ fn serve_wav_stream(
         if req.wants_icy { " (ICY)" } else { "" }
     );
 
-    let mut rx = buf.subscribe();
+    // Start ~2 s behind the live edge so the renderer can drain historical
+    // buffered chunks at network speed instead of filling at real-time rate.
+    // Each chunk ≈ 8192 bytes ≈ 46 ms; 44 chunks ≈ 2 s.
+    let mut rx = buf.subscribe_from_behind(44);
 
     if req.wants_icy {
         let art_url = art_base_url(local_ip, port);
@@ -476,6 +479,7 @@ pub fn serve(port: u16, sample_rate: u32, buf: Arc<BroadcastBuffer>) {
     for stream in listener.incoming() {
         match stream {
             Ok(mut tcp) => {
+                let _ = tcp.set_nodelay(true);
                 let buf = buf.clone();
                 std::thread::spawn(move || {
                     let peer = tcp.peer_addr().map(|a| a.to_string()).unwrap_or_default();

--- a/crates/upnp/src/renderer.rs
+++ b/crates/upnp/src/renderer.rs
@@ -41,6 +41,10 @@ struct RendererState {
     current_metadata: String,
     transport_state: TransportState,
     mute: bool,
+    /// Value of `current_track().elapsed` when the current track started.
+    /// Subtracted from the live elapsed so RelTime resets to 0 on each track
+    /// change even though the underlying WAV stream is continuous.
+    elapsed_offset: u64,
 }
 
 static RENDERER_STATE: Mutex<RendererState> = Mutex::new(RendererState {
@@ -48,6 +52,7 @@ static RENDERER_STATE: Mutex<RendererState> = Mutex::new(RendererState {
     current_metadata: String::new(),
     transport_state: TransportState::NoMediaPresent,
     mute: false,
+    elapsed_offset: 0,
 });
 
 static RENDERER_UUID: OnceLock<String> = OnceLock::new();
@@ -369,6 +374,14 @@ async fn avtransport_control(body: String, header_action: Option<String>) -> Res
             tracing::info!("UPnP renderer: SetAVTransportURI = {uri}");
             {
                 let mut st = RENDERER_STATE.lock().unwrap();
+                // Track-change while playing: capture current elapsed so that
+                // GetPositionInfo resets RelTime to 0 for the new track.
+                if st.transport_state == TransportState::Playing {
+                    let elapsed = rockbox_sys::playback::current_track()
+                        .map(|t| t.elapsed)
+                        .unwrap_or(0);
+                    st.elapsed_offset = elapsed;
+                }
                 st.current_uri = Some(uri);
                 st.current_metadata = metadata;
                 st.transport_state = TransportState::Stopped;
@@ -381,16 +394,60 @@ async fn avtransport_control(body: String, header_action: Option<String>) -> Res
         }
 
         Some("Play") => {
-            let uri = {
+            let (uri, metadata) = {
                 let st = RENDERER_STATE.lock().unwrap();
-                st.current_uri.clone()
+                (st.current_uri.clone(), st.current_metadata.clone())
             };
+            tracing::info!("UPnP renderer: Play action received, uri={uri:?}");
             match uri {
                 None => soap_error(701, "Transition not available"),
                 Some(uri) => {
                     tracing::info!("UPnP renderer: Play {uri}");
+
+                    // Guard against the self-referential loop: when the UPnP PCM
+                    // output sink sends Play(stream.wav) to the same rockboxd
+                    // instance's renderer, playing the stream back would create a
+                    // circular audio path (engine reads stream.wav → PCM output →
+                    // BroadcastBuffer → stream.wav → ...), overflowing the codec
+                    // thread stack and crashing.  Detect this by matching our own
+                    // PCM HTTP port in the URI.  Audio is already flowing via the
+                    // UPnP sink, so just acknowledge without re-routing.
+                    let own_pcm_port = crate::CONFIG.lock().unwrap().pcm_port;
+                    let is_own_stream = (uri.ends_with("/stream.wav"))
+                        && (uri.contains(&format!(":{own_pcm_port}/"))
+                            || uri.ends_with(&format!(":{own_pcm_port}")));
+                    if is_own_stream {
+                        tracing::warn!(
+                            "UPnP renderer: Play for own PCM stream (port {own_pcm_port}) — \
+                             acknowledging without re-routing to prevent feedback loop"
+                        );
+                        RENDERER_STATE.lock().unwrap().transport_state = TransportState::Playing;
+                        return soap_ok("urn:schemas-upnp-org:service:AVTransport:1", "Play", "");
+                    }
+
+                    let title =
+                        extract_didl_field(&metadata, "title").unwrap_or_else(|| uri.clone());
+                    let artist = extract_didl_field(&metadata, "artist")
+                        .or_else(|| extract_didl_field(&metadata, "creator"))
+                        .unwrap_or_default();
+                    let album = extract_didl_field(&metadata, "album").unwrap_or_default();
+                    let duration_ms = parse_didl_duration_ms(&metadata).unwrap_or(0) as u64;
+                    let album_art_url =
+                        extract_didl_field(&metadata, "albumArtURI").unwrap_or_default();
+                    rockbox_sys::playback::set_metadata_override(
+                        &uri,
+                        &title,
+                        &artist,
+                        &album,
+                        duration_ms,
+                        &album_art_url,
+                    );
                     play_url(&uri).await;
-                    RENDERER_STATE.lock().unwrap().transport_state = TransportState::Playing;
+                    {
+                        let mut st = RENDERER_STATE.lock().unwrap();
+                        st.transport_state = TransportState::Playing;
+                        st.elapsed_offset = 0; // stream restarts from 0
+                    }
                     soap_ok("urn:schemas-upnp-org:service:AVTransport:1", "Play", "")
                 }
             }
@@ -407,6 +464,9 @@ async fn avtransport_control(body: String, header_action: Option<String>) -> Res
             }
             {
                 let mut st = RENDERER_STATE.lock().unwrap();
+                if let Some(ref uri) = st.current_uri {
+                    rockbox_sys::playback::clear_metadata_override(uri);
+                }
                 st.transport_state = TransportState::Stopped;
                 st.current_metadata = String::new();
             }
@@ -521,7 +581,10 @@ async fn avtransport_control(body: String, header_action: Option<String>) -> Res
             )
         }
 
-        _ => soap_error(401, "Invalid Action"),
+        other => {
+            tracing::warn!("UPnP renderer: unknown AVTransport action: {other:?}");
+            soap_error(401, "Invalid Action")
+        }
     }
 }
 
@@ -637,22 +700,58 @@ fn renderer_connection_manager(
     soap_error(401, "Invalid Action")
 }
 
-async fn play_url(uri: &str) {
-    use crate::api::rockbox::v1alpha1::{
-        playback_service_client::PlaybackServiceClient, PlayTrackRequest,
-    };
-    let port = std::env::var("ROCKBOX_PORT").unwrap_or_else(|_| "6061".to_string());
-    let url = format!("tcp://127.0.0.1:{}", port);
-    match PlaybackServiceClient::connect(url).await {
-        Ok(mut client) => {
-            let req = PlayTrackRequest {
-                path: uri.to_string(),
-            };
-            if let Err(e) = client.play_track(req).await {
-                tracing::error!("UPnP renderer: PlayTrack gRPC error: {e}");
+/// Extract a DIDL-Lite field by its local name, trying common namespace prefixes.
+fn extract_didl_field(didl: &str, local_name: &str) -> Option<String> {
+    for prefix in &["dc:", "upnp:", "r:", ""] {
+        let tag = format!("{}{}", prefix, local_name);
+        if let Some(v) = extract_tag(didl, &tag) {
+            if !v.is_empty() {
+                return Some(v);
             }
         }
-        Err(e) => tracing::error!("UPnP renderer: gRPC connect error: {e}"),
+    }
+    None
+}
+
+async fn play_url(uri: &str) {
+    let tcp_port = std::env::var("ROCKBOX_TCP_PORT").unwrap_or_else(|_| "6063".to_string());
+    let base = format!("http://127.0.0.1:{tcp_port}");
+    // The internal HTTP server closes the TCP socket after each response.
+    // pool_max_idle_per_host(0) disables connection pooling so each request
+    // opens a fresh connection instead of reusing a server-closed socket.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .unwrap_or_default();
+
+    let body = serde_json::json!({ "tracks": [uri] });
+    tracing::info!("UPnP renderer: POST {base}/playlists tracks=[{uri}]");
+    match client
+        .post(format!("{base}/playlists"))
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => {
+            tracing::info!("UPnP renderer: playlist created, starting playback");
+        }
+        Ok(r) => {
+            tracing::error!("UPnP renderer: POST /playlists failed: {}", r.status());
+            return;
+        }
+        Err(e) => {
+            tracing::error!("UPnP renderer: POST /playlists error: {e}");
+            return;
+        }
+    }
+
+    tracing::info!("UPnP renderer: PUT {base}/playlists/start");
+    match client.put(format!("{base}/playlists/start")).send().await {
+        Ok(r) if r.status().is_success() => {
+            tracing::info!("UPnP renderer: playback started");
+        }
+        Ok(r) => tracing::error!("UPnP renderer: PUT /playlists/start failed: {}", r.status()),
+        Err(e) => tracing::error!("UPnP renderer: PUT /playlists/start error: {e}"),
     }
 }
 
@@ -673,18 +772,50 @@ fn seek_to(ms: i32) {
 }
 
 fn get_position_info() -> (String, i32, i32) {
-    let uri = RENDERER_STATE
-        .lock()
-        .unwrap()
-        .current_uri
-        .clone()
-        .unwrap_or_default();
-
-    let (elapsed, duration) = match rockbox_sys::playback::current_track() {
-        Some(track) => (track.elapsed as i32, track.length as i32),
-        None => (0, 0),
+    let (uri, metadata, elapsed_offset) = {
+        let st = RENDERER_STATE.lock().unwrap();
+        (
+            st.current_uri.clone().unwrap_or_default(),
+            st.current_metadata.clone(),
+            st.elapsed_offset,
+        )
     };
+
+    // Elapsed from the codec minus the offset captured at the last track
+    // boundary, so RelTime resets to 0 on each track change even though the
+    // underlying WAV stream is continuous.
+    let elapsed = match rockbox_sys::playback::current_track() {
+        Some(track) => (track.elapsed.saturating_sub(elapsed_offset)) as i32,
+        None => 0,
+    };
+
+    // Duration from the DIDL-Lite sent by the source (accurate per-track).
+    let duration = parse_didl_duration_ms(&metadata).unwrap_or(0);
+
     (uri, elapsed, duration)
+}
+
+/// Parse `duration="H:MM:SS.mmm"` from a DIDL-Lite string.
+fn parse_didl_duration_ms(didl: &str) -> Option<i32> {
+    let key = "duration=\"";
+    let start = didl.find(key)? + key.len();
+    let end = didl[start..].find('"')? + start;
+    parse_upnp_duration_ms(&didl[start..end])
+}
+
+/// Parse a UPnP duration string `[H+]:MM:SS[.F+]` into milliseconds.
+fn parse_upnp_duration_ms(s: &str) -> Option<i32> {
+    let mut parts = s.splitn(3, ':');
+    let h: i32 = parts.next()?.parse().ok()?;
+    let m: i32 = parts.next()?.parse().ok()?;
+    let sec_frac = parts.next()?;
+    let mut sec_parts = sec_frac.splitn(2, '.');
+    let sec: i32 = sec_parts.next()?.parse().ok()?;
+    let ms: i32 = sec_parts.next().map_or(0, |f| {
+        let padded = format!("{:0<3}", &f[..f.len().min(3)]);
+        padded.parse().unwrap_or(0)
+    });
+    Some((h * 3600 + m * 60 + sec) * 1000 + ms)
 }
 
 // SOUND_VOLUME = 0 in Rockbox (first entry in the sound settings enum).

--- a/firmware/SOURCES
+++ b/firmware/SOURCES
@@ -541,6 +541,7 @@ target/hosted/pcm-airplay.c
 target/hosted/pcm-squeezelite.c
 target/hosted/pcm-upnp.c
 target/hosted/pcm-chromecast.c
+target/hosted/pcm-tcp.c
 #endif
 #ifdef HAVE_SW_VOLUME_CONTROL
 pcm_sw_volume.c

--- a/firmware/export/pcm_sink.h
+++ b/firmware/export/pcm_sink.h
@@ -58,6 +58,7 @@ enum pcm_sink_ids {
     PCM_SINK_SQUEEZELITE,
     PCM_SINK_UPNP,
     PCM_SINK_CHROMECAST,
+    PCM_SINK_SNAPCAST_TCP,
 #endif
     PCM_SINK_NUM
 };
@@ -86,4 +87,9 @@ extern struct pcm_sink chromecast_pcm_sink;
 void pcm_chromecast_set_http_port(uint16_t port);
 void pcm_chromecast_set_device_host(const char *host);
 void pcm_chromecast_set_device_port(uint16_t port);
+
+/* Snapcast TCP sink — streams raw S16LE PCM to snapserver's tcp:// source */
+extern struct pcm_sink tcp_pcm_sink;
+void pcm_tcp_set_host(const char *host);
+void pcm_tcp_set_port(uint16_t port);
 #endif

--- a/firmware/pcm.c
+++ b/firmware/pcm.c
@@ -86,6 +86,7 @@ static struct pcm_sink* sinks[PCM_SINK_NUM] = {
     [PCM_SINK_SQUEEZELITE]  = &squeezelite_pcm_sink,
     [PCM_SINK_UPNP]         = &upnp_pcm_sink,
     [PCM_SINK_CHROMECAST]   = &chromecast_pcm_sink,
+    [PCM_SINK_SNAPCAST_TCP] = &tcp_pcm_sink,
 #endif
 };
 static enum pcm_sink_ids cur_sink = PCM_SINK_BUILTIN;

--- a/firmware/target/hosted/pcm-tcp.c
+++ b/firmware/target/hosted/pcm-tcp.c
@@ -1,0 +1,260 @@
+/***************************************************************************
+ *             __________               __   ___.
+ *   Open      \______   \ ____   ____ |  | _\_ |__   _______  ___
+ *   Source     |       _//  _ \_/ ___\|  |/ /| __ \ /  _ \  \/  /
+ *   Jukebox    |    |   (  <_> )  \___|    < | \_\ (  <_> > <  <
+ *   Firmware   |____|_  /\____/ \___  >__|_ \|___  /\____/__/\_ \
+ *                     \/            \/     \/    \/            \/
+ *
+ * PCM sink that writes raw S16LE stereo PCM over a TCP socket.
+ * Intended for use with Snapcast (tcp:// source) or similar consumers.
+ *
+ * Usage:
+ *   pcm_tcp_set_host("192.168.1.x");   // snapserver host
+ *   pcm_tcp_set_port(4953);            // snapserver tcp source port (default)
+ *   pcm_switch_sink(PCM_SINK_SNAPCAST_TCP);
+ *
+ * Snapserver config:
+ *   source = tcp://0.0.0.0:4953?name=default&sampleformat=44100:16:2
+ *
+ * Copyright (C) 2026 Rockbox contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ****************************************************************************/
+
+#include "autoconf.h"
+#include "config.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "pcm.h"
+#include "pcm-internal.h"
+#include "pcm_mixer.h"
+#include "pcm_sampr.h"
+#include "pcm_sink.h"
+
+#define LOGF_ENABLE
+#include "logf.h"
+
+#define DEFAULT_TCP_HOST "127.0.0.1"
+#define DEFAULT_TCP_PORT 4953
+
+static char     tcp_host[256] = DEFAULT_TCP_HOST;
+static uint16_t tcp_port      = DEFAULT_TCP_PORT;
+static int      tcp_fd        = -1;
+
+static const void    *pcm_data = NULL;
+static size_t         pcm_size = 0;
+
+static pthread_mutex_t tcp_mtx;
+static pthread_t       tcp_tid;
+static volatile bool   tcp_running = false;
+static volatile bool   tcp_stop    = false;
+
+void pcm_tcp_set_host(const char *host)
+{
+    strncpy(tcp_host, host, sizeof(tcp_host) - 1);
+    tcp_host[sizeof(tcp_host) - 1] = '\0';
+}
+
+void pcm_tcp_set_port(uint16_t port)
+{
+    tcp_port = port;
+}
+
+static int tcp_connect_once(void)
+{
+    struct addrinfo hints, *res, *rp;
+    char portstr[8];
+    int fd = -1;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    snprintf(portstr, sizeof(portstr), "%u", (unsigned)tcp_port);
+    if (getaddrinfo(tcp_host, portstr, &hints, &res) != 0) {
+        logf("pcm-tcp: getaddrinfo(%s:%s) failed: %s",
+             tcp_host, portstr, strerror(errno));
+        return -1;
+    }
+
+    for (rp = res; rp != NULL; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0)
+            continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0)
+            break;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+
+    if (fd < 0)
+        logf("pcm-tcp: connect to %s:%u failed: %s",
+             tcp_host, (unsigned)tcp_port, strerror(errno));
+    else
+        logf("pcm-tcp: connected to %s:%u fd=%d",
+             tcp_host, (unsigned)tcp_port, fd);
+
+    return fd;
+}
+
+static void *tcp_thread(void *arg)
+{
+    (void)arg;
+
+    while (!tcp_stop) {
+        pthread_mutex_lock(&tcp_mtx);
+        const void *data = pcm_data;
+        size_t      size = pcm_size;
+        pcm_data = NULL;
+        pcm_size = 0;
+        pthread_mutex_unlock(&tcp_mtx);
+
+        /* Write current chunk in pieces so stop() can interrupt promptly */
+        while (size > 0 && !tcp_stop) {
+            ssize_t n = write(tcp_fd, data, size);
+            if (n < 0) {
+                if (errno == EINTR || errno == EAGAIN)
+                    continue;
+                logf("pcm-tcp: write error: %s", strerror(errno));
+                /* Mark connection dead; reconnect on next sink_dma_start */
+                close(tcp_fd);
+                tcp_fd = -1;
+                tcp_stop = true;
+                break;
+            }
+            data = (const char *)data + n;
+            size -= n;
+        }
+
+        if (tcp_stop)
+            break;
+
+        /* Request next buffer */
+        pthread_mutex_lock(&tcp_mtx);
+        bool got_more = pcm_play_dma_complete_callback(PCM_DMAST_OK,
+                                                        &pcm_data, &pcm_size);
+        pthread_mutex_unlock(&tcp_mtx);
+
+        if (!got_more) {
+            logf("pcm-tcp: no more PCM data");
+            break;
+        }
+
+        pcm_play_dma_status_callback(PCM_DMAST_STARTED);
+    }
+
+    tcp_running = false;
+    return NULL;
+}
+
+static void sink_dma_init(void)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&tcp_mtx, &attr);
+    pthread_mutexattr_destroy(&attr);
+}
+
+static void sink_dma_postinit(void)
+{
+}
+
+static void sink_set_freq(uint16_t freq)
+{
+    (void)freq;
+}
+
+static void sink_lock(void)
+{
+    pthread_mutex_lock(&tcp_mtx);
+}
+
+static void sink_unlock(void)
+{
+    pthread_mutex_unlock(&tcp_mtx);
+}
+
+static void sink_dma_start(const void *addr, size_t size)
+{
+    logf("pcm-tcp: start (%p, %zu) fd=%d", addr, size, tcp_fd);
+
+    /* Connect on first call or after a write error closed the socket */
+    if (tcp_fd < 0) {
+        tcp_fd = tcp_connect_once();
+        if (tcp_fd < 0) {
+            logf("pcm-tcp: dropping audio (no connection to %s:%u)",
+                 tcp_host, (unsigned)tcp_port);
+            return;
+        }
+    }
+
+    pthread_mutex_lock(&tcp_mtx);
+    pcm_data = addr;
+    pcm_size = size;
+    pthread_mutex_unlock(&tcp_mtx);
+
+    tcp_stop    = false;
+    tcp_running = true;
+    pthread_create(&tcp_tid, NULL, tcp_thread, NULL);
+}
+
+static void sink_dma_stop(void)
+{
+    logf("pcm-tcp: stop");
+
+    tcp_stop = true;
+
+    if (tcp_running) {
+        pthread_join(tcp_tid, NULL);
+        tcp_running = false;
+    }
+
+    pthread_mutex_lock(&tcp_mtx);
+    pcm_data = NULL;
+    pcm_size = 0;
+    pthread_mutex_unlock(&tcp_mtx);
+
+    /* Keep tcp_fd open between tracks so snapserver doesn't see a disconnect.
+     * If the write loop closed it on error, tcp_fd is already -1 and the
+     * next sink_dma_start will reconnect automatically. */
+}
+
+struct pcm_sink tcp_pcm_sink = {
+    .caps = {
+        .samprs       = hw_freq_sampr,
+        .num_samprs   = HW_NUM_FREQ,
+        .default_freq = HW_FREQ_DEFAULT,
+    },
+    .ops = {
+        .init     = sink_dma_init,
+        .postinit = sink_dma_postinit,
+        .set_freq = sink_set_freq,
+        .lock     = sink_lock,
+        .unlock   = sink_unlock,
+        .play     = sink_dma_start,
+        .stop     = sink_dma_stop,
+    },
+};

--- a/gpui/src/ui/components/device_picker.rs
+++ b/gpui/src/ui/components/device_picker.rs
@@ -12,6 +12,7 @@ pub fn device_icon(device: &DeviceItem) -> Icons {
     match device.service.as_str() {
         "chromecast" => Icons::Chromecast,
         "airplay" => Icons::Airplay,
+        "snapcast" => Icons::Speaker,
         _ => {
             if device.is_current_device {
                 Icons::Device

--- a/lib/rbcodec/metadata/wave.c
+++ b/lib/rbcodec/metadata/wave.c
@@ -364,6 +364,10 @@ static bool read_header(int fd, struct mp3entry* id3, const unsigned char *chunk
             fmt.numbytes = chunksize;
             if (fmt.formattag == WAVE_FORMAT_ATRAC3)
                 id3->first_frame_offset = offset;
+            /* 'data' is always the last meaningful chunk. Stop here so the
+             * parser never tries to seek past an infinite-size data chunk
+             * (e.g. live WAV streams use 0xFFFFFFFF as a sentinel size). */
+            break;
         }
         else if (memcmp(buf, chunknames + LIST_CHUNK * namelen, namelen) == 0)
         {


### PR DESCRIPTION
Register PCM_SINK_SNAPCAST_TCP and add a native pcm-tcp.c implementation with FFI hooks (settings, sys bindings, discovery, UI and firmware SOURCES).
Document FIFO vs TCP modes and mDNS auto-discovery. Note: TCP sink reconnects on next play after errors and will drop the in-flight buffer on
EPIPE; FIFO/stdout behavior is unchanged.

Add save_stream_metadata/update_stream_metadata and a playback metadata override API so stream title/artist/album/length are surfaced immediately.
Also add a netstream guard to clamp huge seeks that can hang streaming.