### PR TITLE
Add embeddable librockboxd static library

### DIFF
--- a/.github/workflows/linux-aarch64-build.yml
+++ b/.github/workflows/linux-aarch64-build.yml
@@ -77,6 +77,12 @@ jobs:
         env:
           TAG: ${{ inputs.tag || github.ref_name }}
 
+      - name: Build rockbox-embed
+        run: cargo build --release -p rockbox-embed
+
+      - name: Build librockboxd.a
+        run: cd zig && zig build lib -Doptimize=ReleaseFast
+
       - name: Determine version
         id: vars
         run: |
@@ -91,12 +97,24 @@ jobs:
           sha256sum rockbox_${VERSION}_aarch64-linux.tar.gz \
             > rockbox_${VERSION}_aarch64-linux.tar.gz.sha256
 
+      - name: Package librockboxd.a
+        run: |
+          VERSION="${{ steps.vars.outputs.version }}"
+          mkdir -p dist/lib dist/include
+          cp zig/zig-out/lib/librockboxd.a dist/lib/
+          cp include/rockboxd.h             dist/include/
+          ARCHIVE="librockboxd_${VERSION}_aarch64-linux.tar.gz"
+          tar -C dist -czf "$ARCHIVE" lib include
+          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             rockbox_${{ steps.vars.outputs.version }}_aarch64-linux.tar.gz
             rockbox_${{ steps.vars.outputs.version }}_aarch64-linux.tar.gz.sha256
+            librockboxd_${{ steps.vars.outputs.version }}_aarch64-linux.tar.gz
+            librockboxd_${{ steps.vars.outputs.version }}_aarch64-linux.tar.gz.sha256
           tag_name: ${{ steps.vars.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-embed-lib.yml
+++ b/.github/workflows/release-embed-lib.yml
@@ -36,21 +36,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner:   macos-latest
-            arch:     aarch64
+          - runner: macos-latest
+            arch: aarch64
             os_label: darwin
-          - runner:   macos-15-intel
-            arch:     x86_64
+          - runner: macos-15-intel
+            arch: x86_64
             os_label: darwin
-            zig_cpu:  "-Dcpu=x86_64"
+            zig_cpu: "-Dcpu=x86_64"
             rust_flags: "-C target-cpu=x86-64 -A warnings"
-          - runner:   ubuntu-latest
-            arch:     x86_64
+          - runner: ubuntu-latest
+            arch: x86_64
             os_label: linux
-            zig_cpu:  "-Dcpu=x86_64"
+            zig_cpu: "-Dcpu=x86_64"
             rust_flags: "-C target-cpu=x86-64 -A warnings"
-          - runner:   ubuntu-24.04-arm
-            arch:     aarch64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
             os_label: linux
 
     steps:

--- a/.github/workflows/release-embed-lib.yml
+++ b/.github/workflows/release-embed-lib.yml
@@ -1,0 +1,154 @@
+name: release embed lib
+
+# Builds librockboxd.a (headless/cpal fat static archive) for macOS and Linux
+# and uploads each platform archive to the GitHub release.
+#
+# Contents of each archive:
+#   lib/librockboxd.a   — fat static archive (firmware + codecs + Rust servers)
+#   include/rockboxd.h  — public C/Swift/Rust FFI header
+#
+# Consumers link with:
+#   macOS: -framework CoreAudio -framework AudioUnit -framework AudioToolbox
+#          -framework CoreFoundation -framework Security
+#   Linux: -lasound -lunwind -ldbus-1
+
+on:
+  push:
+    tags-ignore:
+      - "clojure-v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to attach the library to"
+        type: string
+        required: true
+
+jobs:
+  build:
+    name: build (${{ matrix.arch }}-${{ matrix.os_label }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner:   macos-latest
+            arch:     aarch64
+            os_label: darwin
+          - runner:   macos-15-intel
+            arch:     x86_64
+            os_label: darwin
+            zig_cpu:  "-Dcpu=x86_64"
+            rust_flags: "-C target-cpu=x86-64 -A warnings"
+          - runner:   ubuntu-latest
+            arch:     x86_64
+            os_label: linux
+            zig_cpu:  "-Dcpu=x86_64"
+            rust_flags: "-C target-cpu=x86-64 -A warnings"
+          - runner:   ubuntu-24.04-arm
+            arch:     aarch64
+            os_label: linux
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            zig/.zig-cache
+            target
+          key: embed-lib-${{ matrix.runner }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: embed-lib-${{ matrix.runner }}-
+
+      # ── macOS dependencies ────────────────────────────────────────────────
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          # llvm@22 crashes in setSymbolInRelocationInfo on Mach-O — use llvm@21
+          brew install llvm@21 cmake protobuf
+          echo "/opt/homebrew/opt/llvm@21/bin:/usr/local/opt/llvm@21/bin" >> $GITHUB_PATH
+
+      # ── Linux dependencies ────────────────────────────────────────────────
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libunwind-dev \
+            libasound2-dev \
+            libdbus-1-dev \
+            protobuf-compiler \
+            cmake
+
+      # ── Rust flags ────────────────────────────────────────────────────────
+      - name: Set Rust flags
+        run: |
+          FLAGS="${{ matrix.rust_flags || '-A warnings' }}"
+          echo "RUSTFLAGS=$FLAGS" >> $GITHUB_ENV
+
+      # ── Step 1-2: Headless firmware + rockbox-server ──────────────────────
+      # build-headless.sh configures build-headless/, builds firmware .a files,
+      # extracts codec objects, and builds librockbox_cli.a + librockbox_server.a
+      - name: Build headless firmware
+        run: bash scripts/build-headless.sh
+
+      # ── Step 3: rockbox-embed Rust crate ──────────────────────────────────
+      - name: Build rockbox-embed
+        run: cargo build --release -p rockbox-embed
+
+      # ── Step 4: Zig lib step ──────────────────────────────────────────────
+      - name: Build librockboxd.a
+        run: |
+          cd zig
+          zig build lib -Doptimize=ReleaseFast ${{ matrix.zig_cpu }}
+
+      # ── Package ───────────────────────────────────────────────────────────
+      - name: Resolve version
+        id: vars
+        run: |
+          VERSION="${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}"
+          ARCH="${{ matrix.arch }}"
+          OS="${{ matrix.os_label }}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "archive=librockboxd_${VERSION}_${ARCH}-${OS}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Package archive
+        run: |
+          mkdir -p dist/lib dist/include
+          cp zig/zig-out/lib/librockboxd.a dist/lib/
+          cp include/rockboxd.h             dist/include/
+          ARCHIVE="${{ steps.vars.outputs.archive }}"
+          tar -C dist -czf "$ARCHIVE" lib include
+          if command -v sha256sum &>/dev/null; then
+            sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+          fi
+          echo "Archive contents:"
+          tar -tzf "$ARCHIVE"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.vars.outputs.archive }}
+            ${{ steps.vars.outputs.archive }}.sha256
+          tag_name: ${{ steps.vars.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-gpui.yml
+++ b/.github/workflows/release-gpui.yml
@@ -1,6 +1,9 @@
 name: release gpui app
 
 on:
+  push:
+    tags-ignore:
+      - "clojure-v*"
   release:
     types: [published]
   workflow_dispatch:
@@ -23,9 +26,13 @@ jobs:
             arch: aarch64
           - os: macos-15-intel
             arch: x86_64
+            zig_cpu: "-Dcpu=x86_64"
+            rust_flags: "-C target-cpu=x86-64 -A warnings"
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Resolve version
         id: vars
@@ -33,6 +40,10 @@ jobs:
           VERSION="${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "dmg=Rockbox-${VERSION}-gpui-${{ matrix.arch }}.dmg" >> "$GITHUB_OUTPUT"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -42,16 +53,38 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            zig/.zig-cache
+            target
             gpui/target
-          key: ${{ runner.os }}-gpui-${{ hashFiles('gpui/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-gpui-
+          key: gpui-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: gpui-${{ matrix.os }}-
 
-      - name: Install protobuf
-        run: brew install protobuf
+      # llvm@22 crashes in setSymbolInRelocationInfo on Mach-O — use llvm@21
+      - name: Install macOS dependencies
+        run: |
+          brew install llvm@21 cmake protobuf
+          echo "/opt/homebrew/opt/llvm@21/bin:/usr/local/opt/llvm@21/bin" >> $GITHUB_PATH
 
-      - name: Skip Rust Warnings
-        run: echo "RUSTFLAGS=-A warnings" >> $GITHUB_ENV
+      - name: Set Rust flags
+        run: |
+          FLAGS="${{ matrix.rust_flags || '-A warnings' }}"
+          echo "RUSTFLAGS=$FLAGS" >> $GITHUB_ENV
 
+      # ── Step 1-2: Headless firmware + rockbox-server ──────────────────────
+      - name: Build headless firmware
+        run: bash scripts/build-headless.sh
+
+      # ── Step 3: rockbox-embed Rust crate ──────────────────────────────────
+      - name: Build rockbox-embed
+        run: cargo build --release -p rockbox-embed
+
+      # ── Step 4: Fat static library ────────────────────────────────────────
+      - name: Build librockboxd.a
+        run: |
+          cd zig
+          zig build lib -Doptimize=ReleaseFast ${{ matrix.zig_cpu }}
+
+      # ── Step 5: GPUI app + DMG ────────────────────────────────────────────
       - name: Build and package
         run: bash package.sh
         working-directory: gpui

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,12 @@ firmware/          Rockbox C firmware (audio engine, codecs, DSP)
 apps/              Rockbox application layer (playlist, database, plugins)
 lib/               Codec libraries (rbcodec, fixedpoint, skin_parser, tlsf)
 build-lib/         Out-of-tree Make build directory (generated; do not edit)
+build-headless/    Headless (no SDL) Make build directory for the embedded lib
 crates/            Rust workspace
   airplay/         ALAC encoder + RAOP/RTP sender (AirPlay 1 output)
   slim/            Slim Protocol + HTTP broadcast server (Squeezelite multi-room output)
   cli/             Entry point compiled to librockbox_cli.a (staticlib)
+  embed/           Embeddable desktop library (daemon boot + gRPC client C ABI)
   server/          gRPC / HTTP server
   settings/        load_settings() — reads settings.toml, applies sinks
   sys/             FFI bindings to the C firmware (unsafe extern "C")
@@ -52,8 +54,9 @@ crates/            Rust workspace
   tracklist/       Playlist / tracklist management
   types/           Shared Rust types
   traits/          Shared Rust traits
-zig/               Zig build script and thin main.zig entry point
-gpui/              Desktop client (GPUI / Rust) — reference UI for the mobile app
+zig/               Zig build script, main.zig (executable), lib.zig (embedded library)
+include/           Public C header (rockboxd.h) for the embeddable library
+gpui/              Desktop client (GPUI / Rust) — embeds daemon directly via librockboxd.a
 expo/              React Native / Expo mobile app (see `expo/CLAUDE.md` rules below)
 ```
 
@@ -85,6 +88,47 @@ cd build-lib && make lib && cd ..
 cargo build --release -p rockbox-cli -p rockbox-server
 cd zig && zig build
 ```
+
+### Embeddable static library (`librockboxd.a`)
+
+`zig build lib` produces `zig/zig-out/lib/librockboxd.a` — a fat archive that
+any desktop GUI (GPUI, Swift/AppKit, Qt, …) can link against to embed the full
+Rockbox daemon in-process. Uses the **headless/cpal** firmware (no SDL).
+
+Public C header: `include/rockboxd.h`
+
+Build order:
+```sh
+# 1. Headless firmware (no SDL)
+cd build-headless && make lib && cd ..
+
+# 2. Rust embed crate (daemon boot + gRPC client) + server
+cargo build --release -p rockbox-embed -p rockbox-server
+
+# 3. Fat static library
+cd zig && zig build lib
+# → zig-out/lib/librockboxd.a
+```
+
+Consumers must also link these system libraries at final link time:
+
+| Platform | Required flags                                                               |
+| -------- | ---------------------------------------------------------------------------- |
+| macOS    | `-framework CoreAudio -framework AudioUnit -framework AudioToolbox`          |
+|          | `-framework CoreFoundation -framework Security`                              |
+| Linux    | `-lasound -lunwind -ldbus-1`                                                 |
+
+The GPUI desktop client links `librockboxd.a` automatically via `gpui/build.rs`
+and boots the daemon at startup — no external `rockboxd` process is needed.
+
+### GPUI desktop client build
+```sh
+# After building librockboxd.a (see above):
+cd gpui && cargo build --release
+```
+
+The app boots the embedded daemon on launch (shows "Starting Rockbox…" while
+the gRPC server binds, then transitions to the full UI).
 
 ### Critical: stale binary pitfall
 `zig build` only re-links if the `.a` files are newer than the binary. After changing C code, always run `make lib` first. After changing Rust code, run `cargo build --release`. If behavior doesn't match the code, check timestamps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9394,6 +9394,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rockbox-embed"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "netstream",
+ "once_cell",
+ "prost",
+ "reqwest",
+ "rockbox-airplay",
+ "rockbox-chromecast",
+ "rockbox-cpal-sink",
+ "rockbox-discovery",
+ "rockbox-library",
+ "rockbox-server",
+ "rockbox-settings",
+ "rockbox-slim",
+ "rockbox-sys",
+ "rockbox-upnp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rockbox-expo"
 version = "0.1.0"
 dependencies = [

--- a/THREADING.md
+++ b/THREADING.md
@@ -11,11 +11,11 @@ Understanding the boundary between these two classes is critical. Crossing it in
 
 There are three scheduler backends, each selected at compile time by an autoconf define:
 
-| Build target            | Autoconf define         | Backend file                                     |
-| ----------------------- | ----------------------- | ------------------------------------------------ |
-| SDL hosted (simulator)  | `HAVE_SDL_THREADS`      | `firmware/target/hosted/sdl/thread-sdl.c`        |
-| Headless macOS / Linux  | `HAVE_POSIX_THREADS`    | `firmware/target/hosted/headless/thread-posix.c` |
-| Android cdylib          | `HAVE_SIGALTSTACK_THREADS` | `firmware/asm/thread-unix.c` (signal-stack trick) |
+| Build target            | Autoconf define            | Backend file                                              |
+| ----------------------- | -------------------------- | --------------------------------------------------------- |
+| SDL hosted (simulator)  | `HAVE_SDL_THREADS`         | `firmware/target/hosted/sdl/thread-sdl.c`                |
+| Headless macOS / Linux  | `HAVE_POSIX_THREADS`       | `firmware/target/hosted/headless/thread-posix.c`         |
+| Android cdylib          | `HAVE_SIGALTSTACK_THREADS` | `firmware/asm/thread-unix.c` (signal-stack trick)         |
 
 All three share the same C-level `create_thread` / kernel-thread API and the same `struct regs` layout (`void *t, *told, *s; void (*start)(void)`). Only the mechanism for context-switching and blocking differs.
 

--- a/THREADING.md
+++ b/THREADING.md
@@ -9,11 +9,19 @@ Rockboxd has two distinct classes of threads that must coexist:
 
 Understanding the boundary between these two classes is critical. Crossing it incorrectly (e.g. doing a plain OS-level block inside a Rockbox kernel thread) will silently starve every other Rockbox kernel thread.
 
-The scheduler implementation differs between the **SDL hosted target** (desktop, macOS/Linux) and the **headless Android cdylib** target. Both share the same C-level `create_thread` / kernel-thread API, but the underlying concurrency primitive is different.
+There are three scheduler backends, each selected at compile time by an autoconf define:
+
+| Build target            | Autoconf define         | Backend file                                     |
+| ----------------------- | ----------------------- | ------------------------------------------------ |
+| SDL hosted (simulator)  | `HAVE_SDL_THREADS`      | `firmware/target/hosted/sdl/thread-sdl.c`        |
+| Headless macOS / Linux  | `HAVE_POSIX_THREADS`    | `firmware/target/hosted/headless/thread-posix.c` |
+| Android cdylib          | `HAVE_SIGALTSTACK_THREADS` | `firmware/asm/thread-unix.c` (signal-stack trick) |
+
+All three share the same C-level `create_thread` / kernel-thread API and the same `struct regs` layout (`void *t, *told, *s; void (*start)(void)`). Only the mechanism for context-switching and blocking differs.
 
 ---
 
-## The SDL Cooperative Scheduler (desktop — macOS / Linux)
+## The SDL Cooperative Scheduler (SDL hosted target — simulator)
 
 On the `sdlapp` hosted target, each Rockbox kernel thread is backed by a real SDL OS thread (`SDL_CreateThread`). However, Rockbox layers a **cooperative scheduler** on top of those OS threads using a single global SDL mutex:
 
@@ -57,24 +65,78 @@ The `stack` and `stack_size` arguments to `create_thread()` are **ignored** on t
 
 ---
 
+## The POSIX Cooperative Scheduler (headless macOS / Linux)
+
+The headless host target (`build-headless/`, used by `zig build lib` to produce `librockboxd.a`) uses `HAVE_POSIX_THREADS`, implemented in `firmware/target/hosted/headless/thread-posix.c`.
+
+### Why not `HAVE_SIGALTSTACK_THREADS`?
+
+The previous backend (`firmware/asm/thread-unix.c`) used the "signal-stack trick": it called `sigaltstack()` + `SIGUSR1` to bootstrap cooperative thread contexts without ever calling `makecontext()`. On **macOS 12 Monterey x86_64** this fails — `sigaltstack()` returns `EPERM` — causing an infinite retry loop with the message:
+
+```
+thread creation failed.Retrying
+make_context(): Operation not permitted
+```
+
+The root cause is that macOS 12 Monterey returns `EPERM` from `sigaltstack()` when a thread already has an alternate signal stack installed (indicated by `SS_ONSTACK`). `HAVE_POSIX_THREADS` avoids `sigaltstack()` entirely.
+
+### How `HAVE_POSIX_THREADS` works
+
+The design is the same as `HAVE_SDL_THREADS` — one OS thread per Rockbox thread, global mutex for cooperative exclusion — but uses only POSIX primitives:
+
+```c
+// firmware/target/hosted/headless/thread-posix.c
+static pthread_mutex_t g_mutex;   // THE global Rockbox scheduler mutex
+```
+
+Per-thread blocking uses a custom counting semaphore built from `pthread_mutex_t + pthread_cond_t + int count` (because `sem_init()` is deprecated on macOS and `sem_timedwait()` is not available on all Darwin versions):
+
+```c
+typedef struct { pthread_mutex_t mtx; pthread_cond_t cond; int count; } posix_sem_t;
+```
+
+`switch_thread()` is structurally identical to the SDL version:
+
+```c
+void switch_thread(void) {
+    pthread_mutex_unlock(&g_mutex);   // release the token
+    pthread_mutex_lock(&g_mutex);     // re-acquire when it's our turn
+}
+```
+
+Blocked/sleeping threads wait on their per-thread `posix_sem_t` with a `pthread_cond_timedwait`-based timeout; wakeup posts to the same semaphore. `thread_exit()` uses `longjmp` (via the same `thread_jmpbufs` pattern as SDL) to cleanly terminate, then releases `g_mutex` from `runthread`'s `else` branch.
+
+### Stack sizes
+
+Like SDL threads, the `stack` / `stack_size` arguments are ignored (`(void)stack; (void)stack_size;`). The host OS assigns a default stack to each `pthread_create`'d thread.
+
+---
+
 ## The Headless Scheduler (Android cdylib)
 
 The Android cdylib target (`firmware/target/hosted/android/cdylib/`) replaces SDL entirely with plain pthreads and POSIX clock. There is **no SDL mutex**, no event loop, no LCD, no button polling.
 
-### `system-android.c` vs `system-sdl.c`
+### Three-way comparison
 
-| Concern           | SDL hosted                          | Android cdylib                                          |
-| ----------------- | ----------------------------------- | ------------------------------------------------------- |
-| Cooperative token | `SDL_mutex *m` (single global)      | `__cores[0].running` (global current-thread pointer)    |
-| Thread creation   | `SDL_CreateThread`                  | `pthread_create`                                        |
-| Scheduler yield   | `SDL_UnlockMutex` / `SDL_LockMutex` | Rockbox kernel pthread mutex round-trip                 |
-| Boot path         | SDL event thread initialises audio  | `rb_daemon_start` (JNI) spawns `rockbox-engine` pthread |
-| Power-off         | SDL_QUIT event loop                 | `exit(0)` via `power_off()`                             |
-| stdio             | terminal / controlled               | piped to logcat via `redirect_stdio_to_logcat`          |
+| Concern              | SDL hosted                           | Headless macOS/Linux                           | Android cdylib                                          |
+| -------------------- | ------------------------------------ | ---------------------------------------------- | ------------------------------------------------------- |
+| Autoconf define      | `HAVE_SDL_THREADS`                   | `HAVE_POSIX_THREADS`                           | `HAVE_SIGALTSTACK_THREADS`                              |
+| Backend file         | `thread-sdl.c`                       | `thread-posix.c`                               | `thread-unix.c`                                         |
+| Cooperative token    | `SDL_mutex *m` (single global)       | `pthread_mutex_t g_mutex` (single global)      | `__cores[0].running` (global current-thread pointer)    |
+| Per-thread blocking  | `SDL_sem *` (SDL semaphore)          | `posix_sem_t *` (cond+mutex+count)             | `setjmp`/`longjmp` + signal alt-stack                   |
+| Thread creation      | `SDL_CreateThread`                   | `pthread_create` + `pthread_detach`            | Bootstrapped via `sigaltstack()` + `SIGUSR1`            |
+| Scheduler yield      | `SDL_UnlockMutex` / `SDL_LockMutex`  | `pthread_mutex_unlock` / `pthread_mutex_lock`  | `longjmp` to next thread's `jmp_buf`                    |
+| Boot path            | SDL event thread initialises audio   | Zig linker entry → `main_c()`                  | `rb_daemon_start` (JNI) spawns `rockbox-engine` pthread |
+| Power-off            | `SDL_QUIT` event loop                | `exit(0)` via `power_off()`                    | `exit(0)` via `power_off()`                             |
+| Stack size respected | No (SDL default, typically 8 MB)     | No (pthread default)                           | Yes — passed to signal alt-stack                        |
+| macOS 12 x86_64      | Works                                | Works                                          | **Broken** — `sigaltstack()` returns `EPERM`            |
+| stdio                | terminal / controlled                | stderr via `debug-headless.c`                  | piped to logcat via `redirect_stdio_to_logcat`          |
 
 ### `__cores[0].running` — the critical invariant
 
-On the headless pthread target, the Rockbox kernel tracks the currently-executing kernel thread via the global `__cores[0].running` pointer. **Any firmware function that calls `queue_send`, `wakeup_thread`, `pcmbuf_*`, or any kernel primitive reads this pointer to find its own thread entry.**
+On the Android cdylib (and every non-SDL Rockbox target), the kernel tracks the currently-executing kernel thread via the global `__cores[0].running` pointer. **Any firmware function that calls `queue_send`, `wakeup_thread`, `pcmbuf_*`, or any kernel primitive reads this pointer to find its own thread entry.**
+
+On the headless POSIX target (`HAVE_POSIX_THREADS`) the same invariant holds: `__running_self_entry()` expands to `__cores[0].running` and is updated by every thread at the top of `runthread()` and inside `switch_thread()`. The global `g_mutex` guarantees only one Rockbox kernel thread writes this pointer at a time — but OS threads that bypass `g_mutex` (actix workers, gRPC handlers) will still see a stale value.
 
 If such a function is called from a non-Rockbox pthread (e.g. an actix worker or a tonic gRPC handler) the pointer resolves to the wrong thread entry. Consequences:
 - `wakeup_thread_` dereferences a stale or null function pointer → **SIGSEGV at PC=0**
@@ -419,3 +481,20 @@ Read-only queries (status, current track) that only touch atomics or copy struct
 ### Rule 7: `fw_bus::init()` must be called before any handler sends a command
 
 `fw_bus::send()` silently drops commands if the bus hasn't been initialised. `init()` is called inside `start_servers()`, which runs before the HTTP/gRPC servers start accepting requests. On Android, the boot sequence guarantees `start_servers()` (inside `main_c()`) completes before `rb_daemon_start` returns.
+
+### Rule 8: Never re-enable `HAVE_SIGALTSTACK_THREADS` for the headless host
+
+The headless macOS/Linux build uses `HAVE_POSIX_THREADS` (defined in `build-headless/autoconf.h`). Do not replace it with `HAVE_SIGALTSTACK_THREADS` — `sigaltstack()` returns `EPERM` on macOS 12 Monterey x86_64, causing an infinite retry loop at startup:
+
+```
+thread creation failed.Retrying
+make_context(): Operation not permitted
+```
+
+If you re-run `tools/configure` to regenerate `build-headless/autoconf.h`, check that the threading line reads:
+
+```c
+#define HAVE_POSIX_THREADS
+```
+
+and restore it if configure has reverted it to `HAVE_SIGALTSTACK_THREADS`.

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "rockbox-embed"
+version = "0.1.0"
+edition = "2021"
+description = "Embeddable static library — boot rockboxd in-process from any desktop GUI (GPUI, Swift/AppKit, Qt, etc.)"
+license = "LGPL-2.1"
+
+[lib]
+name = "rockbox_embed"
+crate-type = ["staticlib"]
+
+# `daemon` pulls in the full headless firmware stack (cpal PCM sink, servers,
+# library, …). Always on by default — the whole point of this crate is to
+# embed the daemon. Disable only for compile-time type-checking without the
+# firmware build artefacts present.
+[features]
+default = ["daemon"]
+daemon = [
+    "dep:rockbox-server",
+    "dep:rockbox-settings",
+    "dep:rockbox-library",
+    "dep:rockbox-sys",
+    "dep:rbnetstream",
+    "dep:rockbox-airplay",
+    "dep:rockbox-slim",       "rockbox-slim/ffi",
+    "dep:rockbox-chromecast", "rockbox-chromecast/ffi",
+    "dep:rockbox-upnp",       "rockbox-upnp/ffi",
+    "dep:rockbox-cpal-sink",
+    "rockbox-server/fts5",
+]
+
+# ── Always-on: gRPC client surface ──────────────────────────────────────────
+[dependencies]
+prost      = "0.13"
+tokio      = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tonic      = { version = "0.12", default-features = false, features = ["transport", "codegen", "prost"] }
+once_cell  = "1"
+serde      = { version = "1", features = ["derive"] }
+serde_json = "1"
+futures-util       = "0.3"
+rockbox-discovery  = { path = "../discovery" }
+reqwest            = { version = "0.12", default-features = false, features = ["json"] }
+tracing            = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+# ── Optional in-process daemon (headless/cpal build) ─────────────────────────
+rockbox-server   = { path = "../server",   optional = true, default-features = false }
+rockbox-settings = { path = "../settings", optional = true, default-features = false }
+rockbox-library  = { path = "../library",  optional = true, default-features = false }
+rockbox-sys      = { path = "../sys",      optional = true, default-features = false }
+rbnetstream      = { path = "../netstream", package = "netstream", optional = true }
+rockbox-airplay    = { path = "../airplay",    optional = true }
+rockbox-slim       = { path = "../slim",       optional = true }
+rockbox-chromecast = { path = "../chromecast", optional = true }
+rockbox-upnp       = { path = "../upnp",       optional = true }
+rockbox-cpal-sink  = { path = "../cpal-sink",  optional = true }
+
+[build-dependencies]
+tonic-build = { version = "0.12", default-features = false, features = ["prost", "transport"] }

--- a/crates/embed/build.rs
+++ b/crates/embed/build.rs
@@ -1,0 +1,25 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protos = [
+        "proto/rockbox/v1alpha1/browse.proto",
+        "proto/rockbox/v1alpha1/genre.proto",
+        "proto/rockbox/v1alpha1/library.proto",
+        "proto/rockbox/v1alpha1/metadata.proto",
+        "proto/rockbox/v1alpha1/playback.proto",
+        "proto/rockbox/v1alpha1/playlist.proto",
+        "proto/rockbox/v1alpha1/settings.proto",
+        "proto/rockbox/v1alpha1/sound.proto",
+        "proto/rockbox/v1alpha1/system.proto",
+        "proto/rockbox/v1alpha1/saved_playlist.proto",
+        "proto/rockbox/v1alpha1/smart_playlist.proto",
+        "proto/rockbox/v1alpha1/bluetooth.proto",
+    ];
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(true)
+        .type_attribute(".", "#[derive(serde::Serialize)]")
+        .compile_protos(&protos, &["proto"])?;
+    for p in &protos {
+        println!("cargo:rerun-if-changed={p}");
+    }
+    Ok(())
+}

--- a/crates/embed/proto
+++ b/crates/embed/proto
@@ -1,0 +1,1 @@
+../rpc/proto

--- a/crates/embed/src/daemon.rs
+++ b/crates/embed/src/daemon.rs
@@ -1,0 +1,368 @@
+//! Desktop embedded daemon — headless/cpal build.
+//!
+//! Boots the C firmware (`apps/main.c::main_c`) on a dedicated thread.
+//! The firmware starts its own kernel threads, one of which calls
+//! `crates/server::start_servers` and binds gRPC on 127.0.0.1:6061.
+//! After that the in-process `rb_*` gRPC client targets that port.
+
+use std::ffi::CStr;
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+use std::os::raw::{c_char, c_int};
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const STATE_STOPPED: i32 = 0;
+const STATE_STARTING: i32 = 1;
+const STATE_RUNNING: i32 = 2;
+
+static STATE: AtomicI32 = AtomicI32::new(STATE_STOPPED);
+static LOCAL_PORT: AtomicI32 = AtomicI32::new(0);
+
+extern "C" {
+    fn main_c() -> c_int;
+    fn start_server();
+    fn start_servers();
+    fn start_broker();
+}
+
+#[used]
+static _KEEPALIVE_START_SERVER: unsafe extern "C" fn() = start_server;
+#[used]
+static _KEEPALIVE_START_SERVERS: unsafe extern "C" fn() = start_servers;
+#[used]
+static _KEEPALIVE_START_BROKER: unsafe extern "C" fn() = start_broker;
+
+#[used]
+static _KEEPALIVE_ROCKBOX_SERVER: &[&str] = &rockbox_server::AUDIO_EXTENSIONS;
+
+#[used]
+static _KEEPALIVE_AIRPLAY: unsafe extern "C" fn(*const c_char, u16) =
+    rockbox_airplay::pcm_airplay_set_host;
+#[used]
+static _KEEPALIVE_SLIM: extern "C" fn(u16) = rockbox_slim::pcm_squeezelite_set_slim_port;
+#[used]
+static _KEEPALIVE_CHROMECAST: unsafe extern "C" fn(*const c_char) =
+    rockbox_chromecast::pcm::pcm_chromecast_set_device_host;
+#[used]
+static _KEEPALIVE_UPNP: extern "C" fn(u16) = rockbox_upnp::pcm_upnp_set_http_port;
+#[used]
+static _KEEPALIVE_CPAL: extern "C" fn() = rockbox_cpal_sink::_link_cpal_sink;
+
+#[used]
+static _KEEPALIVE_RB_NET_OPEN: unsafe extern "C" fn(*const c_char) -> i32 =
+    rbnetstream::rb_net_open;
+#[used]
+static _KEEPALIVE_RB_NET_READ: unsafe extern "C" fn(i32, *mut std::ffi::c_void, usize) -> i64 =
+    rbnetstream::rb_net_read;
+#[used]
+static _KEEPALIVE_RB_NET_LEN: extern "C" fn(i32) -> i64 = rbnetstream::rb_net_len;
+#[used]
+static _KEEPALIVE_RB_NET_LSEEK: extern "C" fn(i32, i64, i32) -> i64 = rbnetstream::rb_net_lseek;
+#[used]
+static _KEEPALIVE_RB_NET_CLOSE: extern "C" fn(i32) = rbnetstream::rb_net_close;
+
+/// Called by `crates/server` for HTTP-streamed tracks to index metadata.
+#[no_mangle]
+pub extern "C" fn save_remote_track_metadata(url: *const c_char) -> i32 {
+    if url.is_null() {
+        tracing::warn!("save_remote_track_metadata: null url");
+        return -1;
+    }
+    let url = unsafe { CStr::from_ptr(url) };
+    let url = match url.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("save_remote_track_metadata: invalid utf-8: {e}");
+            return -1;
+        }
+    };
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::error!("save_remote_track_metadata: runtime build failed: {e}");
+            return -1;
+        }
+    };
+    match rt.block_on(async {
+        let pool = rockbox_library::create_connection_pool().await?;
+        rockbox_library::audio_scan::save_audio_metadata(pool, url, None).await
+    }) {
+        Ok(()) => 0,
+        Err(e) => {
+            tracing::error!("save_remote_track_metadata: {e}");
+            -1
+        }
+    }
+}
+
+pub(crate) unsafe fn cstr_to_str<'a>(p: *const c_char) -> Option<&'a str> {
+    if p.is_null() {
+        return None;
+    }
+    CStr::from_ptr(p).to_str().ok()
+}
+
+fn configure_environment(music_dir: &str, device_name: &str) {
+    std::env::set_var("ROCKBOX_DEVICE_NAME", device_name);
+    std::env::set_var("ROCKBOX_LIBRARY", music_dir);
+
+    if std::env::var_os("ROCKBOX_PORT").is_none() {
+        std::env::set_var("ROCKBOX_PORT", "6061");
+    }
+    if std::env::var_os("ROCKBOX_GRAPHQL_PORT").is_none() {
+        std::env::set_var("ROCKBOX_GRAPHQL_PORT", "6062");
+    }
+    if std::env::var_os("ROCKBOX_TCP_PORT").is_none() {
+        std::env::set_var("ROCKBOX_TCP_PORT", "6063");
+    }
+    if std::env::var_os("ROCKBOX_MPD_PORT").is_none() {
+        std::env::set_var("ROCKBOX_MPD_PORT", "6600");
+    }
+}
+
+fn install_subscriber() {
+    std::panic::set_hook(Box::new(|info| {
+        tracing::error!("Rust panic: {info}");
+    }));
+    let default_filter = "info,rockbox_embed=debug,rockbox_server=debug,rockbox_graphql=debug,\
+         rockbox_library=debug,rockbox_sys=debug,rockbox_airplay=debug,\
+         rockbox_chromecast=debug,rockbox_slim=debug,rockbox_upnp=debug";
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_filter)),
+        )
+        .try_init();
+}
+
+fn wait_for_grpc(port: u16, deadline: Instant) -> bool {
+    let addr: SocketAddr = (Ipv4Addr::LOCALHOST, port).into();
+    while Instant::now() < deadline {
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+/// Boot the embedded rockbox daemon (headless/cpal build).
+///
+/// Spawns `main_c()` on a dedicated thread and waits up to 30 s for the
+/// gRPC server to bind. Returns the gRPC port on success, or a negative
+/// error code:
+///   -22  invalid input
+///   -110 timeout
+///   -114 already starting / running
+///
+/// # Safety
+/// `music_dir_ptr` and `device_name_ptr` must be NUL-terminated UTF-8 strings.
+/// `music_dir_ptr` may be null (falls back to `$HOME/Music`).
+#[no_mangle]
+pub unsafe extern "C" fn rb_daemon_start(
+    music_dir_ptr: *const c_char,
+    device_name_ptr: *const c_char,
+) -> c_int {
+    if STATE
+        .compare_exchange(
+            STATE_STOPPED,
+            STATE_STARTING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .is_err()
+    {
+        return -114;
+    }
+
+    install_subscriber();
+
+    let music_dir = if music_dir_ptr.is_null() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        format!("{home}/Music")
+    } else {
+        match cstr_to_str(music_dir_ptr) {
+            Some(s) => s.to_string(),
+            None => {
+                STATE.store(STATE_STOPPED, Ordering::Release);
+                return -22;
+            }
+        }
+    };
+
+    let device_name = match cstr_to_str(device_name_ptr) {
+        Some(s) => s.to_string(),
+        None => {
+            STATE.store(STATE_STOPPED, Ordering::Release);
+            return -22;
+        }
+    };
+
+    configure_environment(&music_dir, &device_name);
+
+    let port: u16 = std::env::var("ROCKBOX_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6061);
+
+    tracing::info!("embed: spawning rockbox-engine thread");
+    thread::Builder::new()
+        .name("rockbox-engine".into())
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            tracing::info!("rockbox-engine: calling main_c()");
+            let rc = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe { main_c() }));
+            match rc {
+                Ok(code) => tracing::warn!("rockbox-engine: main_c returned rc={code}"),
+                Err(p) => tracing::error!(
+                    "rockbox-engine: PANICKED — {:?}",
+                    p.downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| p.downcast_ref::<String>().map(|s| s.as_str()))
+                        .unwrap_or("<non-string panic>")
+                ),
+            }
+            STATE.store(STATE_STOPPED, Ordering::Release);
+            LOCAL_PORT.store(0, Ordering::Release);
+        })
+        .expect("spawn rockbox-engine thread");
+
+    tracing::info!("embed: waiting up to 30s for gRPC :{port} to bind");
+    if !wait_for_grpc(port, Instant::now() + Duration::from_secs(30)) {
+        tracing::error!("embed: gRPC did not bind within 30s");
+        STATE.store(STATE_STOPPED, Ordering::Release);
+        return -110;
+    }
+
+    LOCAL_PORT.store(port as i32, Ordering::Release);
+    STATE.store(STATE_RUNNING, Ordering::Release);
+    tracing::info!("embed: started, gRPC bound :{port}");
+
+    // Point the in-process client at the daemon unless the caller already
+    // configured a different URL.
+    let default_url = "http://127.0.0.1:6061";
+    let already_set = crate::SERVER_URL
+        .read()
+        .map(|g| g.as_str() != default_url)
+        .unwrap_or(false);
+    if !already_set {
+        let url = format!("http://127.0.0.1:{port}\0");
+        let _ = crate::rb_set_server_url(url.as_ptr() as *const c_char);
+    }
+
+    let default_http = "http://127.0.0.1:6063";
+    let http_set = crate::HTTP_URL
+        .read()
+        .map(|g| g.as_str() != default_http)
+        .unwrap_or(false);
+    if !http_set {
+        let http_port = std::env::var("ROCKBOX_TCP_PORT").unwrap_or_else(|_| "6063".into());
+        let http_url = format!("http://127.0.0.1:{http_port}\0");
+        let _ = crate::rb_set_http_url(http_url.as_ptr() as *const c_char);
+    }
+
+    spawn_library_scan(false);
+
+    port as i32
+}
+
+/// Stop the embedded daemon. Currently a best-effort signal — the firmware
+/// does not have a clean shutdown path. Returns 0 if it was running.
+#[no_mangle]
+pub extern "C" fn rb_daemon_stop() -> c_int {
+    match STATE.compare_exchange(
+        STATE_RUNNING,
+        STATE_STOPPED,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    ) {
+        Ok(_) => {
+            LOCAL_PORT.store(0, Ordering::Release);
+            0
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Returns the gRPC port of the running daemon, or 0 if not running.
+#[no_mangle]
+pub extern "C" fn rb_daemon_port() -> c_int {
+    LOCAL_PORT.load(Ordering::Acquire)
+}
+
+/// Returns the daemon state: 0 = stopped, 1 = starting, 2 = running.
+#[no_mangle]
+pub extern "C" fn rb_daemon_state() -> c_int {
+    STATE.load(Ordering::Acquire)
+}
+
+/// Force a full re-scan of the music library. Returns 0 immediately; scan
+/// runs in the background. Returns -1 if the daemon is not running.
+#[no_mangle]
+pub extern "C" fn rb_rescan_library() -> c_int {
+    if STATE.load(Ordering::Acquire) != STATE_RUNNING {
+        return -1;
+    }
+    spawn_library_scan(true);
+    0
+}
+
+fn spawn_library_scan(force_arg: bool) {
+    thread::Builder::new()
+        .name("rockbox-library-scan".into())
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let path = std::env::var("ROCKBOX_LIBRARY").unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+                format!("{home}/Music")
+            });
+            let force = force_arg
+                || matches!(
+                    std::env::var("ROCKBOX_UPDATE_LIBRARY").as_deref(),
+                    Ok("1") | Ok("true")
+                );
+            tracing::info!("scan: target={path} force={force}");
+
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    tracing::error!("scan: tokio runtime build failed: {e}");
+                    return;
+                }
+            };
+
+            rt.block_on(async move {
+                let pool = match rockbox_library::create_connection_pool().await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::error!("scan: open library DB failed: {e}");
+                        return;
+                    }
+                };
+                let count = rockbox_library::repo::track::all(pool.clone())
+                    .await
+                    .map(|t| t.len())
+                    .unwrap_or(0);
+                if count > 0 && !force {
+                    tracing::info!("scan: library has {count} tracks, skipping (force=false)");
+                    return;
+                }
+                tracing::info!("scan: scanning {path} ...");
+                match rockbox_library::audio_scan::scan_audio_files(pool.clone(), path.into()).await
+                {
+                    Ok(files) => tracing::info!("scan: done, {} files", files.len()),
+                    Err(e) => tracing::error!("scan: failed: {e}"),
+                }
+                if let Err(e) = rockbox_library::artists::update_metadata(pool.clone()).await {
+                    tracing::warn!("scan: rocksky enrichment skipped: {e}");
+                } else {
+                    tracing::info!("scan: rocksky enrichment done");
+                }
+            });
+        })
+        .expect("spawn rockbox-library-scan thread");
+}

--- a/crates/embed/src/daemon.rs
+++ b/crates/embed/src/daemon.rs
@@ -47,7 +47,7 @@ static _KEEPALIVE_CHROMECAST: unsafe extern "C" fn(*const c_char) =
 #[used]
 static _KEEPALIVE_UPNP: extern "C" fn(u16) = rockbox_upnp::pcm_upnp_set_http_port;
 #[used]
-static _KEEPALIVE_CPAL: extern "C" fn() = rockbox_cpal_sink::_link_cpal_sink;
+static _KEEPALIVE_CPAL: fn() = rockbox_cpal_sink::_link_cpal_sink;
 
 #[used]
 static _KEEPALIVE_RB_NET_OPEN: unsafe extern "C" fn(*const c_char) -> i32 =

--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -1,0 +1,1657 @@
+//! Embeddable rockbox library — desktop edition.
+//!
+//! Exposes a flat C ABI that any GUI can call to boot the Rockbox daemon
+//! in-process (firmware + gRPC/GraphQL/HTTP/MPD servers, headless/cpal audio)
+//! and then control playback via the same `rb_*` entry points used by the
+//! Expo mobile module.
+//!
+//! ## Quick start (C / Swift / Rust FFI)
+//!
+//! ```c
+//! rb_daemon_start("/home/user/.config/rockbox", "/home/user/Music", "My Desktop");
+//! rb_play();
+//! char *json = rb_current_track_json(); // caller must rb_free_string(json)
+//! rb_free_string(json);
+//! ```
+//!
+//! ## ABI
+//! - Unit ops return `i32` (0 = ok, <0 = error).
+//! - Complex reads return a heap-allocated JSON C string; caller MUST free via
+//!   `rb_free_string`.
+//! - All blocking calls dispatch on an internal multi-thread Tokio runtime.
+//!   Call from a background thread when latency matters.
+
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::RwLock;
+use std::time::Duration;
+
+use futures_util::pin_mut;
+use futures_util::StreamExt;
+use once_cell::sync::Lazy;
+use serde::Serialize;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+use tokio::task::AbortHandle;
+
+pub mod api {
+    pub mod v1alpha1 {
+        tonic::include_proto!("rockbox.v1alpha1");
+    }
+}
+
+#[cfg(feature = "daemon")]
+mod daemon;
+
+use api::v1alpha1::{
+    bluetooth_service_client::BluetoothServiceClient, browse_service_client::BrowseServiceClient,
+    genre_service_client::GenreServiceClient, library_service_client::LibraryServiceClient,
+    playback_service_client::PlaybackServiceClient, playlist_service_client::PlaylistServiceClient,
+    saved_playlist_service_client::SavedPlaylistServiceClient,
+    settings_service_client::SettingsServiceClient,
+    smart_playlist_service_client::SmartPlaylistServiceClient,
+    sound_service_client::SoundServiceClient, system_service_client::SystemServiceClient,
+    AddTracksToSavedPlaylistRequest, AdjustVolumeRequest, ConnectBluetoothDeviceRequest,
+    CreateSavedPlaylistRequest, CurrentTrackRequest, DeleteSavedPlaylistRequest,
+    DisconnectBluetoothDeviceRequest, FastForwardRewindRequest, GetAlbumRequest, GetAlbumsRequest,
+    GetArtistRequest, GetArtistsRequest, GetBluetoothDevicesRequest, GetCurrentRequest,
+    GetGenreAlbumsRequest, GetGenreArtistsRequest, GetGenreRequest, GetGenreTracksRequest,
+    GetGenresRequest, GetGlobalSettingsRequest, GetGlobalStatusRequest, GetLikedAlbumsRequest,
+    GetLikedTracksRequest, GetSavedPlaylistTracksRequest, GetSavedPlaylistsRequest,
+    GetSmartPlaylistTracksRequest, GetSmartPlaylistsRequest, GetTracksRequest,
+    InsertDirectoryRequest, InsertTracksRequest, LikeTrackRequest, NextRequest, PauseRequest,
+    PlayAlbumRequest, PlayAllTracksRequest, PlayArtistTracksRequest, PlayDirectoryRequest,
+    PlayOrPauseRequest, PlaySavedPlaylistRequest, PlaySmartPlaylistRequest, PlayTrackRequest,
+    PlaylistResumeRequest, PreviousRequest, RemoveTrackFromSavedPlaylistRequest,
+    RemoveTracksRequest, ResumeRequest, ResumeTrackRequest, SaveSettingsRequest,
+    ScanBluetoothRequest, SearchRequest, ShufflePlaylistRequest, SoundCurrentRequest, StartRequest,
+    StatusRequest, StreamCurrentTrackRequest, StreamLibraryRequest, StreamPlaylistRequest,
+    StreamStatusRequest, TreeGetEntriesRequest, UnlikeTrackRequest, UpdateSavedPlaylistRequest,
+};
+
+// ── Globals ──────────────────────────────────────────────────────────────────
+
+static RT: Lazy<Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(2)
+        .thread_name("rockbox-rpc")
+        .build()
+        .expect("failed to build tokio runtime")
+});
+
+pub(crate) static SERVER_URL: Lazy<RwLock<String>> =
+    Lazy::new(|| RwLock::new("http://127.0.0.1:6061".to_string()));
+
+pub(crate) static HTTP_URL: Lazy<RwLock<String>> =
+    Lazy::new(|| RwLock::new("http://127.0.0.1:6063".to_string()));
+
+fn url() -> String {
+    SERVER_URL.read().expect("server url poisoned").clone()
+}
+
+fn http_url() -> String {
+    HTTP_URL.read().expect("http url poisoned").clone()
+}
+
+// ── String helpers ────────────────────────────────────────────────────────────
+
+pub(crate) unsafe fn cstr_to_str<'a>(p: *const c_char) -> Option<&'a str> {
+    if p.is_null() {
+        return None;
+    }
+    CStr::from_ptr(p).to_str().ok()
+}
+
+fn ok_string<T: Serialize>(value: &T) -> *mut c_char {
+    match serde_json::to_string(value) {
+        Ok(s) => CString::new(s)
+            .map(|c| c.into_raw())
+            .unwrap_or(std::ptr::null_mut()),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+fn err_string(msg: impl AsRef<str>) -> *mut c_char {
+    let payload = serde_json::json!({ "error": msg.as_ref() });
+    CString::new(payload.to_string())
+        .map(|c| c.into_raw())
+        .unwrap_or(std::ptr::null_mut())
+}
+
+fn json_response<T: Serialize>(value: T) -> *mut c_char {
+    match serde_json::to_string(&value) {
+        Ok(s) => CString::new(s)
+            .map(|c| c.into_raw())
+            .unwrap_or(std::ptr::null_mut()),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+fn unwrap_or_err_string<T: Serialize, E: std::fmt::Display>(res: Result<T, E>) -> *mut c_char {
+    match res {
+        Ok(v) => json_response(v),
+        Err(e) => err_string(e.to_string()),
+    }
+}
+
+async fn connect_err<T, F: std::future::Future<Output = Result<T, tonic::Status>>>(
+    fut: F,
+) -> Result<T, String> {
+    fut.await.map_err(|e| e.to_string())
+}
+
+fn b(v: c_int) -> bool {
+    v != 0
+}
+
+fn run_unit<F>(fut: F) -> c_int
+where
+    F: std::future::Future<Output = Result<(), tonic::Status>>,
+{
+    match RT.block_on(fut) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+// ── Memory ────────────────────────────────────────────────────────────────────
+
+/// Frees a string previously returned by any `rb_*_json` entry point.
+///
+/// # Safety
+/// `ptr` must be null or a pointer returned by this library that has not been
+/// freed already.
+#[no_mangle]
+pub unsafe extern "C" fn rb_free_string(ptr: *mut c_char) {
+    if ptr.is_null() {
+        return;
+    }
+    drop(CString::from_raw(ptr));
+}
+
+// ── Init / config ─────────────────────────────────────────────────────────────
+
+/// Set the gRPC server URL. Call once at startup before any other entry.
+///
+/// # Safety
+/// `url_ptr` must point to a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_set_server_url(url_ptr: *const c_char) -> c_int {
+    let Some(s) = cstr_to_str(url_ptr) else {
+        return -1;
+    };
+    match SERVER_URL.write() {
+        Ok(mut g) => {
+            *g = s.to_string();
+            0
+        }
+        Err(_) => -2,
+    }
+}
+
+/// Set the rockboxd HTTP base URL (default `http://127.0.0.1:6063`).
+///
+/// # Safety
+/// `url_ptr` must point to a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_set_http_url(url_ptr: *const c_char) -> c_int {
+    let Some(s) = cstr_to_str(url_ptr) else {
+        return -1;
+    };
+    match HTTP_URL.write() {
+        Ok(mut g) => {
+            *g = s.to_string();
+            0
+        }
+        Err(_) => -2,
+    }
+}
+
+/// Health check — round-trips a Status RPC. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn rb_ping() -> c_int {
+    let res: Result<(), tonic::Status> = RT.block_on(async {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.status(StatusRequest {}).await?;
+        Ok(())
+    });
+    match res {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+// ── Playback control ──────────────────────────────────────────────────────────
+
+macro_rules! simple_call {
+    ($fn_name:ident, $client:ident, $method:ident, $req:expr) => {
+        #[no_mangle]
+        pub extern "C" fn $fn_name() -> c_int {
+            let res: Result<(), tonic::Status> = RT.block_on(async {
+                let mut c = $client::connect(url())
+                    .await
+                    .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+                c.$method($req).await?;
+                Ok(())
+            });
+            match res {
+                Ok(_) => 0,
+                Err(_) => -1,
+            }
+        }
+    };
+}
+
+simple_call!(rb_play, PlaybackServiceClient, resume, ResumeRequest {});
+simple_call!(rb_pause, PlaybackServiceClient, pause, PauseRequest {});
+simple_call!(
+    rb_play_pause,
+    PlaybackServiceClient,
+    play_or_pause,
+    PlayOrPauseRequest {}
+);
+simple_call!(rb_next, PlaybackServiceClient, next, NextRequest {});
+simple_call!(rb_prev, PlaybackServiceClient, previous, PreviousRequest {});
+simple_call!(
+    rb_resume_track,
+    PlaylistServiceClient,
+    resume_track,
+    ResumeTrackRequest {
+        start_index: 0,
+        crc: 0,
+        elapsed: 0,
+        offset: 0,
+    }
+);
+simple_call!(
+    rb_playlist_resume,
+    PlaylistServiceClient,
+    playlist_resume,
+    PlaylistResumeRequest {}
+);
+simple_call!(
+    rb_play_all_tracks,
+    PlaybackServiceClient,
+    play_all_tracks,
+    PlayAllTracksRequest {
+        shuffle: Some(false),
+        position: Some(0),
+    }
+);
+simple_call!(
+    rb_shuffle_playlist,
+    PlaylistServiceClient,
+    shuffle_playlist,
+    ShufflePlaylistRequest { start_index: 0 }
+);
+
+/// Seek to `position_ms` milliseconds from the start of the current track.
+#[no_mangle]
+pub extern "C" fn rb_seek(position_ms: i32) -> c_int {
+    run_unit(async move {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.fast_forward_rewind(FastForwardRewindRequest {
+            new_time: position_ms,
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+// ── Status queries ────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct StatusJson {
+    status: i32,
+}
+
+/// Returns a JSON string `{ "status": <int> }`. Caller must `rb_free_string`.
+#[no_mangle]
+pub extern "C" fn rb_status_json() -> *mut c_char {
+    let res: Result<StatusJson, tonic::Status> = RT.block_on(async {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        let resp = c.status(StatusRequest {}).await?.into_inner();
+        Ok(StatusJson {
+            status: resp.status,
+        })
+    });
+    match res {
+        Ok(v) => ok_string(&v),
+        Err(e) => err_string(format!("status: {e}")),
+    }
+}
+
+#[derive(Serialize, Default)]
+struct TrackJson {
+    id: String,
+    path: String,
+    title: String,
+    artist: String,
+    album: String,
+    album_art: Option<String>,
+    duration_ms: i64,
+    elapsed_ms: i64,
+}
+
+/// Returns the current track as JSON. Caller must `rb_free_string`.
+#[no_mangle]
+pub extern "C" fn rb_current_track_json() -> *mut c_char {
+    let res: Result<TrackJson, tonic::Status> = RT.block_on(async {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        let resp = c.current_track(CurrentTrackRequest {}).await?.into_inner();
+        let album_art = resp.album_art.filter(|s: &String| !s.is_empty());
+        Ok(TrackJson {
+            id: resp.id,
+            path: resp.path,
+            title: resp.title,
+            artist: resp.artist,
+            album: resp.album,
+            album_art,
+            duration_ms: resp.length as i64,
+            elapsed_ms: resp.elapsed as i64,
+        })
+    });
+    match res {
+        Ok(v) => ok_string(&v),
+        Err(_) => ok_string(&TrackJson::default()),
+    }
+}
+
+// ── Queue ─────────────────────────────────────────────────────────────────────
+
+/// Jump to queue position `pos`.
+#[no_mangle]
+pub extern "C" fn rb_jump_to_queue_position(pos: c_int) -> c_int {
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.start(StartRequest {
+            start_index: Some(pos),
+            elapsed: Some(0),
+            offset: Some(0),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `paths_json_ptr` must be a valid NUL-terminated UTF-8 JSON array of strings.
+#[no_mangle]
+pub unsafe extern "C" fn rb_insert_tracks(
+    paths_json_ptr: *const c_char,
+    position: c_int,
+    shuffle: c_int,
+) -> c_int {
+    let Some(paths_json) = cstr_to_str(paths_json_ptr) else {
+        return -1;
+    };
+    let Ok(paths) = serde_json::from_str::<Vec<String>>(paths_json) else {
+        return -2;
+    };
+    let shuffle = b(shuffle);
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.insert_tracks(InsertTracksRequest {
+            playlist_id: None,
+            position,
+            tracks: paths,
+            shuffle: Some(shuffle),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_insert_track_next(path_ptr: *const c_char) -> c_int {
+    let Some(p) = cstr_to_str(path_ptr) else {
+        return -1;
+    };
+    let path = p.to_string();
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.insert_tracks(InsertTracksRequest {
+            playlist_id: None,
+            position: -4,
+            tracks: vec![path],
+            shuffle: Some(false),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_insert_track_last(path_ptr: *const c_char) -> c_int {
+    let Some(p) = cstr_to_str(path_ptr) else {
+        return -1;
+    };
+    let path = p.to_string();
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.insert_tracks(InsertTracksRequest {
+            playlist_id: None,
+            position: -3,
+            tracks: vec![path],
+            shuffle: Some(false),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_insert_directory(path_ptr: *const c_char, position: c_int) -> c_int {
+    let Some(p) = cstr_to_str(path_ptr) else {
+        return -1;
+    };
+    let directory = p.to_string();
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.insert_directory(InsertDirectoryRequest {
+            playlist_id: None,
+            position,
+            directory,
+            recurse: Some(true),
+            shuffle: Some(false),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_remove_from_queue(position: c_int) -> c_int {
+    run_unit(async move {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.remove_tracks(RemoveTracksRequest {
+            positions: vec![position],
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_playlist_current_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = PlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_current(GetCurrentRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Playback (track / album / artist / directory) ─────────────────────────────
+
+/// # Safety
+/// `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_track(path_ptr: *const c_char) -> c_int {
+    let Some(path) = cstr_to_str(path_ptr) else {
+        return -1;
+    };
+    let path = path.to_string();
+    run_unit(async move {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_track(PlayTrackRequest { path }).await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `album_id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_album(album_id_ptr: *const c_char, shuffle: c_int) -> c_int {
+    let Some(album_id) = cstr_to_str(album_id_ptr) else {
+        return -1;
+    };
+    let album_id = album_id.to_string();
+    run_unit(async move {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_album(PlayAlbumRequest {
+            album_id,
+            shuffle: Some(b(shuffle)),
+            position: Some(0),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `artist_id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_artist_tracks(
+    artist_id_ptr: *const c_char,
+    shuffle: c_int,
+) -> c_int {
+    let Some(artist_id) = cstr_to_str(artist_id_ptr) else {
+        return -1;
+    };
+    let artist_id = artist_id.to_string();
+    run_unit(async move {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_artist_tracks(PlayArtistTracksRequest {
+            artist_id,
+            shuffle: Some(b(shuffle)),
+            position: Some(0),
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_directory(
+    path_ptr: *const c_char,
+    shuffle: c_int,
+    position: c_int,
+) -> c_int {
+    let Some(path) = cstr_to_str(path_ptr) else {
+        return -1;
+    };
+    let path = path.to_string();
+    let pos = if position < 0 { None } else { Some(position) };
+    run_unit(async move {
+        let mut c = PlaybackServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_directory(PlayDirectoryRequest {
+            path,
+            shuffle: Some(b(shuffle)),
+            recurse: Some(true),
+            position: pos,
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+// ── Library ───────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_tracks_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_tracks(GetTracksRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_artists_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_artists(GetArtistsRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_albums_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_albums(GetAlbumsRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_liked_tracks_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_liked_tracks(GetLikedTracksRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_liked_albums_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_liked_albums(GetLikedAlbumsRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_artist_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_artist(GetArtistRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_album_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_album(GetAlbumRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `term_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_search_json(term_ptr: *const c_char) -> *mut c_char {
+    let Some(term) = cstr_to_str(term_ptr) else {
+        return err_string("missing term");
+    };
+    let term = term.to_string();
+    let res = RT.block_on(async {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.search(SearchRequest { term })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Like / unlike ─────────────────────────────────────────────────────────────
+
+/// # Safety
+/// `track_id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_like_track(track_id_ptr: *const c_char) -> c_int {
+    let Some(track_id) = cstr_to_str(track_id_ptr) else {
+        return -1;
+    };
+    let track_id = track_id.to_string();
+    run_unit(async move {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.like_track(LikeTrackRequest { id: track_id }).await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `track_id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_unlike_track(track_id_ptr: *const c_char) -> c_int {
+    let Some(track_id) = cstr_to_str(track_id_ptr) else {
+        return -1;
+    };
+    let track_id = track_id.to_string();
+    run_unit(async move {
+        let mut c = LibraryServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.unlike_track(UnlikeTrackRequest { id: track_id }).await?;
+        Ok(())
+    })
+}
+
+// ── Genres ────────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_genres_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = GenreServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_genres(GetGenresRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_genre_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = GenreServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_genre(GetGenreRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_genre_tracks_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = GenreServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_genre_tracks(GetGenreTracksRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_genre_albums_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = GenreServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_genre_albums(GetGenreAlbumsRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_genre_artists_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = GenreServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_genre_artists(GetGenreArtistsRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Sound ─────────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_adjust_volume(steps: c_int) -> c_int {
+    run_unit(async move {
+        let mut c = SoundServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.adjust_volume(AdjustVolumeRequest { steps }).await?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_sound_current_json(setting: c_int) -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = SoundServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.sound_current(SoundCurrentRequest { setting })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Settings ──────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_save_shuffle(enabled: c_int) -> c_int {
+    let enabled = b(enabled);
+    run_unit(async move {
+        let mut c = SettingsServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.save_settings(SaveSettingsRequest {
+            playlist_shuffle: Some(enabled),
+            ..Default::default()
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_save_repeat(repeat_mode: c_int) -> c_int {
+    run_unit(async move {
+        let mut c = SettingsServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.save_settings(SaveSettingsRequest {
+            repeat_mode: Some(repeat_mode),
+            ..Default::default()
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_global_settings_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = SettingsServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_global_settings(GetGlobalSettingsRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── System ────────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_global_status_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = SystemServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_global_status(GetGlobalStatusRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Browse ────────────────────────────────────────────────────────────────────
+
+/// `path_ptr` may be null to fetch the music root.
+///
+/// # Safety
+/// If non-null, `path_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_tree_get_entries_json(path_ptr: *const c_char) -> *mut c_char {
+    let path = if path_ptr.is_null() {
+        None
+    } else {
+        cstr_to_str(path_ptr).map(|s| s.to_string())
+    };
+    let res = RT.block_on(async {
+        let mut c = BrowseServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.tree_get_entries(TreeGetEntriesRequest { path })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+// ── Saved playlists ───────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_saved_playlists_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_saved_playlists(GetSavedPlaylistsRequest { folder_id: None })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `name_ptr` must be valid UTF-8. `description_ptr` may be null.
+/// `track_ids_json_ptr` must be a JSON array of strings (may be `[]`).
+#[no_mangle]
+pub unsafe extern "C" fn rb_create_saved_playlist(
+    name_ptr: *const c_char,
+    description_ptr: *const c_char,
+    track_ids_json_ptr: *const c_char,
+) -> c_int {
+    let Some(name) = cstr_to_str(name_ptr) else {
+        return -1;
+    };
+    let name = name.to_string();
+    let description = if description_ptr.is_null() {
+        None
+    } else {
+        cstr_to_str(description_ptr).map(|s| s.to_string())
+    };
+    let track_ids: Vec<String> = if track_ids_json_ptr.is_null() {
+        Vec::new()
+    } else {
+        let Some(s) = cstr_to_str(track_ids_json_ptr) else {
+            return -2;
+        };
+        match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(_) => return -3,
+        }
+    };
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.create_saved_playlist(CreateSavedPlaylistRequest {
+            name,
+            description,
+            image: None,
+            folder_id: None,
+            track_ids,
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `id_ptr` and `name_ptr` must be valid UTF-8. `description_ptr` may be null.
+#[no_mangle]
+pub unsafe extern "C" fn rb_update_saved_playlist(
+    id_ptr: *const c_char,
+    name_ptr: *const c_char,
+    description_ptr: *const c_char,
+) -> c_int {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let Some(name) = cstr_to_str(name_ptr) else {
+        return -1;
+    };
+    let id = id.to_string();
+    let name = name.to_string();
+    let description = if description_ptr.is_null() {
+        None
+    } else {
+        cstr_to_str(description_ptr).map(|s| s.to_string())
+    };
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.update_saved_playlist(UpdateSavedPlaylistRequest {
+            id,
+            name,
+            description,
+            image: None,
+            folder_id: None,
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_delete_saved_playlist(id_ptr: *const c_char) -> c_int {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let id = id.to_string();
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.delete_saved_playlist(DeleteSavedPlaylistRequest { id })
+            .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// Both pointers must be valid NUL-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn rb_add_track_to_playlist(
+    playlist_id_ptr: *const c_char,
+    track_id_ptr: *const c_char,
+) -> c_int {
+    let Some(playlist_id) = cstr_to_str(playlist_id_ptr) else {
+        return -1;
+    };
+    let Some(track_id) = cstr_to_str(track_id_ptr) else {
+        return -1;
+    };
+    let playlist_id = playlist_id.to_string();
+    let track_id = track_id.to_string();
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.add_tracks_to_saved_playlist(AddTracksToSavedPlaylistRequest {
+            playlist_id,
+            track_ids: vec![track_id],
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// Both pointers must be valid NUL-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn rb_remove_track_from_playlist(
+    playlist_id_ptr: *const c_char,
+    track_id_ptr: *const c_char,
+) -> c_int {
+    let Some(playlist_id) = cstr_to_str(playlist_id_ptr) else {
+        return -1;
+    };
+    let Some(track_id) = cstr_to_str(track_id_ptr) else {
+        return -1;
+    };
+    let playlist_id = playlist_id.to_string();
+    let track_id = track_id.to_string();
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.remove_track_from_saved_playlist(RemoveTrackFromSavedPlaylistRequest {
+            playlist_id,
+            track_id,
+        })
+        .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_saved_playlist_tracks_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let playlist_id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_saved_playlist_tracks(GetSavedPlaylistTracksRequest { playlist_id }))
+            .await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_saved_playlist(id_ptr: *const c_char) -> c_int {
+    let Some(playlist_id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let playlist_id = playlist_id.to_string();
+    run_unit(async move {
+        let mut c = SavedPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_saved_playlist(PlaySavedPlaylistRequest { playlist_id })
+            .await?;
+        Ok(())
+    })
+}
+
+// ── Smart playlists ───────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_smart_playlists_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = SmartPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_smart_playlists(GetSmartPlaylistsRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_get_smart_playlist_tracks_json(id_ptr: *const c_char) -> *mut c_char {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return err_string("missing id");
+    };
+    let id = id.to_string();
+    let res = RT.block_on(async {
+        let mut c = SmartPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_smart_playlist_tracks(GetSmartPlaylistTracksRequest { id })).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_play_smart_playlist(id_ptr: *const c_char) -> c_int {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let id = id.to_string();
+    run_unit(async move {
+        let mut c = SmartPlaylistServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.play_smart_playlist(PlaySmartPlaylistRequest { id })
+            .await?;
+        Ok(())
+    })
+}
+
+// ── Devices (HTTP REST) ───────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_get_devices_json() -> *mut c_char {
+    let res: Result<String, String> = RT.block_on(async {
+        let url = format!("{}/devices", http_url());
+        let body = reqwest::get(&url)
+            .await
+            .map_err(|e| format!("get_devices: {e}"))?
+            .text()
+            .await
+            .map_err(|e| format!("get_devices body: {e}"))?;
+        Ok(body)
+    });
+    match res {
+        Ok(json) => CString::new(json)
+            .map(|c| c.into_raw())
+            .unwrap_or(std::ptr::null_mut()),
+        Err(e) => err_string(e),
+    }
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_connect_device(id_ptr: *const c_char) -> c_int {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let id = id.to_string();
+    let res: Result<(), String> = RT.block_on(async {
+        let url = format!("{}/devices/{id}/connect", http_url());
+        reqwest::Client::new()
+            .put(&url)
+            .send()
+            .await
+            .map_err(|e| format!("connect_device: {e}"))?;
+        Ok(())
+    });
+    if res.is_ok() {
+        0
+    } else {
+        -1
+    }
+}
+
+/// # Safety
+/// `id_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_disconnect_device(id_ptr: *const c_char) -> c_int {
+    let Some(id) = cstr_to_str(id_ptr) else {
+        return -1;
+    };
+    let id = id.to_string();
+    let res: Result<(), String> = RT.block_on(async {
+        let url = format!("{}/devices/{id}/disconnect", http_url());
+        reqwest::Client::new()
+            .put(&url)
+            .send()
+            .await
+            .map_err(|e| format!("disconnect_device: {e}"))?;
+        Ok(())
+    });
+    if res.is_ok() {
+        0
+    } else {
+        -1
+    }
+}
+
+// ── Bluetooth ─────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn rb_scan_bluetooth() -> c_int {
+    let res: Result<(), tonic::Status> = RT.block_on(async {
+        let mut c = BluetoothServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.scan(ScanBluetoothRequest { timeout_secs: 8 }).await?;
+        Ok(())
+    });
+    if res.is_ok() {
+        0
+    } else {
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rb_bluetooth_available() -> c_int {
+    let ok = RT.block_on(async {
+        let Ok(mut c) = BluetoothServiceClient::connect(url()).await else {
+            return false;
+        };
+        c.get_devices(GetBluetoothDevicesRequest {}).await.is_ok()
+    });
+    if ok {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rb_get_bluetooth_devices_json() -> *mut c_char {
+    let res = RT.block_on(async {
+        let mut c = BluetoothServiceClient::connect(url())
+            .await
+            .map_err(|e| e.to_string())?;
+        connect_err(c.get_devices(GetBluetoothDevicesRequest {})).await
+    });
+    unwrap_or_err_string(res.map(|r| r.into_inner()))
+}
+
+/// # Safety
+/// `addr_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_connect_bluetooth(addr_ptr: *const c_char) -> c_int {
+    let Some(s) = cstr_to_str(addr_ptr) else {
+        return -1;
+    };
+    let address = s.to_string();
+    run_unit(async move {
+        let mut c = BluetoothServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.connect_device(ConnectBluetoothDeviceRequest { address })
+            .await?;
+        Ok(())
+    })
+}
+
+/// # Safety
+/// `addr_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_disconnect_bluetooth(addr_ptr: *const c_char) -> c_int {
+    let Some(s) = cstr_to_str(addr_ptr) else {
+        return -1;
+    };
+    let address = s.to_string();
+    run_unit(async move {
+        let mut c = BluetoothServiceClient::connect(url())
+            .await
+            .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+        c.disconnect(DisconnectBluetoothDeviceRequest { address })
+            .await?;
+        Ok(())
+    })
+}
+
+// ── Streaming subscriptions ───────────────────────────────────────────────────
+
+const EVENT_BUFFER: usize = 64;
+
+struct Subscription {
+    rx: mpsc::Receiver<String>,
+    abort: AbortHandle,
+}
+
+static SUBS: Lazy<RwLock<HashMap<i32, Subscription>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+static NEXT_SUB_ID: AtomicI32 = AtomicI32::new(1);
+
+#[derive(Serialize)]
+struct StreamErrorJson {
+    error: String,
+}
+
+fn next_sub_id() -> i32 {
+    NEXT_SUB_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+fn register_sub(rx: mpsc::Receiver<String>, abort: AbortHandle) -> i32 {
+    let id = next_sub_id();
+    if let Ok(mut map) = SUBS.write() {
+        map.insert(id, Subscription { rx, abort });
+    }
+    id
+}
+
+fn spawn_stream<F, Fut>(task_factory: F) -> i32
+where
+    F: FnOnce(mpsc::Sender<String>) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel::<String>(EVENT_BUFFER);
+    let handle = RT.spawn(async move { task_factory(tx).await });
+    register_sub(rx, handle.abort_handle())
+}
+
+#[no_mangle]
+pub extern "C" fn rb_subscribe_status() -> c_int {
+    let server_url = url();
+    spawn_stream(move |tx| async move {
+        loop {
+            let mut c = match PlaybackServiceClient::connect(server_url.clone()).await {
+                Ok(c) => c,
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            let mut s = match c.stream_status(StreamStatusRequest {}).await {
+                Ok(r) => r.into_inner(),
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            while let Ok(Some(msg)) = s.message().await {
+                let payload = serde_json::to_string(&StatusJson { status: msg.status })
+                    .unwrap_or_else(|_| "{}".into());
+                if tx.send(payload).await.is_err() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_subscribe_current_track() -> c_int {
+    let server_url = url();
+    spawn_stream(move |tx| async move {
+        loop {
+            let mut c = match PlaybackServiceClient::connect(server_url.clone()).await {
+                Ok(c) => c,
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            let mut s = match c.stream_current_track(StreamCurrentTrackRequest {}).await {
+                Ok(r) => r.into_inner(),
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            while let Ok(Some(msg)) = s.message().await {
+                let payload = serde_json::to_string(&TrackJson {
+                    id: msg.id,
+                    path: msg.path,
+                    title: msg.title,
+                    artist: msg.artist,
+                    album: msg.album,
+                    album_art: msg.album_art.filter(|a| !a.is_empty()),
+                    duration_ms: msg.length as i64,
+                    elapsed_ms: msg.elapsed as i64,
+                })
+                .unwrap_or_else(|_| "{}".into());
+                if tx.send(payload).await.is_err() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+}
+
+#[derive(Serialize)]
+struct PlaylistEventJson {
+    index: i32,
+    amount: i32,
+    tracks: Vec<TrackJson>,
+}
+
+#[no_mangle]
+pub extern "C" fn rb_subscribe_playlist() -> c_int {
+    let server_url = url();
+    spawn_stream(move |tx| async move {
+        loop {
+            let mut c = match PlaybackServiceClient::connect(server_url.clone()).await {
+                Ok(c) => c,
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            let mut s = match c.stream_playlist(StreamPlaylistRequest {}).await {
+                Ok(r) => r.into_inner(),
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+            while let Ok(Some(msg)) = s.message().await {
+                let tracks: Vec<TrackJson> = msg
+                    .tracks
+                    .into_iter()
+                    .map(|t| TrackJson {
+                        id: t.id,
+                        path: t.path,
+                        title: t.title,
+                        artist: t.artist,
+                        album: t.album,
+                        album_art: t.album_art.filter(|a| !a.is_empty()),
+                        duration_ms: t.length as i64,
+                        elapsed_ms: t.elapsed as i64,
+                    })
+                    .collect();
+                let payload = serde_json::to_string(&PlaylistEventJson {
+                    index: msg.index,
+                    amount: msg.amount,
+                    tracks,
+                })
+                .unwrap_or_else(|_| "{}".into());
+                if tx.send(payload).await.is_err() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rb_subscribe_library() -> c_int {
+    let server_url = url();
+    spawn_stream(move |tx| async move {
+        match LibraryServiceClient::connect(server_url).await {
+            Ok(mut c) => match c.stream_library(StreamLibraryRequest {}).await {
+                Ok(resp) => {
+                    let mut s = resp.into_inner();
+                    while let Ok(Some(msg)) = s.message().await {
+                        let payload = serde_json::to_string(&msg).unwrap_or_else(|_| "{}".into());
+                        if tx.send(payload).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(
+                            serde_json::to_string(&StreamErrorJson {
+                                error: format!("stream_library: {e}"),
+                            })
+                            .unwrap_or_default(),
+                        )
+                        .await;
+                }
+            },
+            Err(e) => {
+                let _ = tx
+                    .send(
+                        serde_json::to_string(&StreamErrorJson {
+                            error: format!("connect: {e}"),
+                        })
+                        .unwrap_or_default(),
+                    )
+                    .await;
+            }
+        }
+    })
+}
+
+#[derive(Serialize)]
+struct DiscoveryEventJson {
+    name: String,
+    fullname: String,
+    hostname: String,
+    port: u16,
+    addresses: Vec<String>,
+    properties: HashMap<String, String>,
+}
+
+/// # Safety
+/// `service_name_ptr` must be a valid NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rb_subscribe_discovery(service_name_ptr: *const c_char) -> c_int {
+    let Some(service_name) = cstr_to_str(service_name_ptr) else {
+        return -1;
+    };
+    let service_name = service_name.to_string();
+    spawn_stream(move |tx| async move {
+        let stream = rockbox_discovery::discover(&service_name);
+        pin_mut!(stream);
+        while let Some(info) = stream.next().await {
+            let payload = DiscoveryEventJson {
+                name: info.get_hostname().to_string(),
+                fullname: info.get_fullname().to_string(),
+                hostname: info.get_hostname().to_string(),
+                port: info.get_port(),
+                addresses: info.get_addresses().iter().map(|a| a.to_string()).collect(),
+                properties: info
+                    .get_properties()
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
+            };
+            let json = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".into());
+            if tx.send(json).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Returns the rockboxd mDNS service name as a heap C string.
+#[no_mangle]
+pub extern "C" fn rb_rockbox_service_name() -> *mut c_char {
+    CString::new(rockbox_discovery::ROCKBOX_SERVICE_NAME)
+        .map(|c| c.into_raw())
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// Blocks up to `timeout_ms` for the next event on subscription `sub_id`.
+/// Returns a heap JSON C string (free with `rb_free_string`), or null on
+/// timeout / closed stream.
+#[no_mangle]
+pub extern "C" fn rb_poll_event(sub_id: c_int, timeout_ms: c_int) -> *mut c_char {
+    let mut rx = {
+        let mut map = match SUBS.write() {
+            Ok(m) => m,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        match map.remove(&sub_id) {
+            Some(s) => s,
+            None => return std::ptr::null_mut(),
+        }
+    };
+
+    let timeout = if timeout_ms < 0 {
+        Duration::from_secs(3600)
+    } else {
+        Duration::from_millis(timeout_ms as u64)
+    };
+
+    let received = RT.block_on(async { tokio::time::timeout(timeout, rx.rx.recv()).await });
+
+    let payload = match received {
+        Ok(Some(msg)) => Some(msg),
+        Ok(None) => None,
+        Err(_) => Some(String::new()),
+    };
+
+    if payload.is_some() {
+        if let Ok(mut map) = SUBS.write() {
+            map.insert(sub_id, rx);
+        }
+    } else {
+        rx.abort.abort();
+    }
+
+    match payload {
+        Some(s) if s.is_empty() => std::ptr::null_mut(),
+        Some(s) => CString::new(s)
+            .map(|c| c.into_raw())
+            .unwrap_or(std::ptr::null_mut()),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Cancels and removes a subscription. Returns 0 if found, -1 otherwise.
+#[no_mangle]
+pub extern "C" fn rb_unsubscribe(sub_id: c_int) -> c_int {
+    let removed = match SUBS.write() {
+        Ok(mut m) => m.remove(&sub_id),
+        Err(_) => return -1,
+    };
+    match removed {
+        Some(s) => {
+            s.abort.abort();
+            0
+        }
+        None => -1,
+    }
+}

--- a/crates/upnp/src/api/rockbox.v1alpha1.rs
+++ b/crates/upnp/src/api/rockbox.v1alpha1.rs
@@ -45,10 +45,10 @@ pub mod browse_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct BrowseServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -92,8 +92,9 @@ pub mod browse_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BrowseServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -131,20 +132,27 @@ pub mod browse_service_client {
         pub async fn tree_get_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.BrowseService",
-                "TreeGetEntries",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.BrowseService", "TreeGetEntries"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -156,7 +164,7 @@ pub mod browse_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BrowseServiceServer.
@@ -165,7 +173,10 @@ pub mod browse_service_server {
         async fn tree_get_entries(
             &self,
             request: tonic::Request<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TreeGetEntriesResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct BrowseServiceServer<T> {
@@ -188,7 +199,10 @@ pub mod browse_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -243,18 +257,23 @@ pub mod browse_service_server {
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries" => {
                     #[allow(non_camel_case_types)]
                     struct TreeGetEntriesSvc<T: BrowseService>(pub Arc<T>);
-                    impl<T: BrowseService> tonic::server::UnaryService<super::TreeGetEntriesRequest>
-                        for TreeGetEntriesSvc<T>
-                    {
+                    impl<
+                        T: BrowseService,
+                    > tonic::server::UnaryService<super::TreeGetEntriesRequest>
+                    for TreeGetEntriesSvc<T> {
                         type Response = super::TreeGetEntriesResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TreeGetEntriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BrowseService>::tree_get_entries(&inner, request).await
+                                <T as BrowseService>::tree_get_entries(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -281,19 +300,23 @@ pub mod browse_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -573,10 +596,10 @@ pub mod library_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct LibraryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -620,8 +643,9 @@ pub mod library_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LibraryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -659,233 +683,325 @@ pub mod library_service_client {
         pub async fn get_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbums");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbums",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbums",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbums"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtists");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtists",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtists",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtists"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTracks");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTracks",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTracks",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTracks"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_album(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artist(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtist");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetArtist",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetArtist",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtist"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/GetTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_track(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeTrack"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_track(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_album(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/LikeAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "LikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeAlbum"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_album(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "UnlikeAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "GetLikedAlbums",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedAlbums"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn scan_library(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "ScanLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "ScanLibrary"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_library(
@@ -895,30 +1011,41 @@ pub mod library_service_client {
             tonic::Response<tonic::codec::Streaming<super::StreamLibraryResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "StreamLibrary",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "StreamLibrary"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/Search");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.LibraryService/Search",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "Search"));
@@ -927,39 +1054,53 @@ pub mod library_service_client {
         pub async fn filter_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::FilterAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FilterAlbumsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FilterAlbumsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/FilterAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "FilterAlbums",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "FilterAlbums"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn filter_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::FilterArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FilterArtistsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FilterArtistsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/FilterArtists",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.LibraryService",
-                "FilterArtists",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "FilterArtists"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -971,7 +1112,7 @@ pub mod library_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LibraryServiceServer.
@@ -980,64 +1121,107 @@ pub mod library_service_server {
         async fn get_albums(
             &self,
             request: tonic::Request<super::GetAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn get_artists(
             &self,
             request: tonic::Request<super::GetArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistsResponse>,
+            tonic::Status,
+        >;
         async fn get_tracks(
             &self,
             request: tonic::Request<super::GetTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_album(
             &self,
             request: tonic::Request<super::GetAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_artist(
             &self,
             request: tonic::Request<super::GetArtistRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetArtistResponse>,
+            tonic::Status,
+        >;
         async fn get_track(
             &self,
             request: tonic::Request<super::GetTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_track(
             &self,
             request: tonic::Request<super::LikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn unlike_track(
             &self,
             request: tonic::Request<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeTrackResponse>,
+            tonic::Status,
+        >;
         async fn like_album(
             &self,
             request: tonic::Request<super::LikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn unlike_album(
             &self,
             request: tonic::Request<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlikeAlbumResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_tracks(
             &self,
             request: tonic::Request<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_liked_albums(
             &self,
             request: tonic::Request<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetLikedAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn scan_library(
             &self,
             request: tonic::Request<super::ScanLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ScanLibraryResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamLibrary method.
         type StreamLibraryStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StreamLibraryResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_library(
             &self,
             request: tonic::Request<super::StreamLibraryRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamLibraryStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamLibraryStream>,
+            tonic::Status,
+        >;
         async fn search(
             &self,
             request: tonic::Request<super::SearchRequest>,
@@ -1045,11 +1229,17 @@ pub mod library_service_server {
         async fn filter_albums(
             &self,
             request: tonic::Request<super::FilterAlbumsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FilterAlbumsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FilterAlbumsResponse>,
+            tonic::Status,
+        >;
         async fn filter_artists(
             &self,
             request: tonic::Request<super::FilterArtistsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FilterArtistsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FilterArtistsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct LibraryServiceServer<T> {
@@ -1072,7 +1262,10 @@ pub mod library_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1127,9 +1320,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumsRequest> for GetAlbumsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumsRequest>
+                    for GetAlbumsSvc<T> {
                         type Response = super::GetAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumsRequest>,
@@ -1166,9 +1365,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtists" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistsRequest> for GetArtistsSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistsRequest>
+                    for GetArtistsSvc<T> {
                         type Response = super::GetArtistsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistsRequest>,
@@ -1205,9 +1410,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTracksRequest> for GetTracksSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTracksRequest>
+                    for GetTracksSvc<T> {
                         type Response = super::GetTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTracksRequest>,
@@ -1244,9 +1455,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumRequest> for GetAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetAlbumRequest>
+                    for GetAlbumSvc<T> {
                         type Response = super::GetAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumRequest>,
@@ -1283,9 +1500,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtist" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistRequest> for GetArtistSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetArtistRequest>
+                    for GetArtistSvc<T> {
                         type Response = super::GetArtistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistRequest>,
@@ -1322,9 +1545,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTrack" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTrackRequest> for GetTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetTrackRequest>
+                    for GetTrackSvc<T> {
                         type Response = super::GetTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackRequest>,
@@ -1361,9 +1590,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct LikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeTrackRequest> for LikeTrackSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeTrackRequest>
+                    for LikeTrackSvc<T> {
                         type Response = super::LikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeTrackRequest>,
@@ -1400,11 +1635,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeTrackRequest>
-                        for UnlikeTrackSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeTrackRequest>
+                    for UnlikeTrackSvc<T> {
                         type Response = super::UnlikeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeTrackRequest>,
@@ -1441,9 +1680,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct LikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeAlbumRequest> for LikeAlbumSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::LikeAlbumRequest>
+                    for LikeAlbumSvc<T> {
                         type Response = super::LikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeAlbumRequest>,
@@ -1480,11 +1725,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeAlbumRequest>
-                        for UnlikeAlbumSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::UnlikeAlbumRequest>
+                    for UnlikeAlbumSvc<T> {
                         type Response = super::UnlikeAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeAlbumRequest>,
@@ -1521,19 +1770,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedTracksRequest>
-                        for GetLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedTracksRequest>
+                    for GetLikedTracksSvc<T> {
                         type Response = super::GetLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_tracks(&inner, request).await
+                                <T as LibraryService>::get_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1563,19 +1816,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::UnaryService<super::GetLikedAlbumsRequest>
-                        for GetLikedAlbumsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::GetLikedAlbumsRequest>
+                    for GetLikedAlbumsSvc<T> {
                         type Response = super::GetLikedAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedAlbumsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_albums(&inner, request).await
+                                <T as LibraryService>::get_liked_albums(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1605,11 +1862,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct ScanLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::ScanLibraryRequest>
-                        for ScanLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::ScanLibraryRequest>
+                    for ScanLibrarySvc<T> {
                         type Response = super::ScanLibraryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScanLibraryRequest>,
@@ -1646,14 +1907,16 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct StreamLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService>
-                        tonic::server::ServerStreamingService<super::StreamLibraryRequest>
-                        for StreamLibrarySvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::ServerStreamingService<super::StreamLibraryRequest>
+                    for StreamLibrarySvc<T> {
                         type Response = super::StreamLibraryResponse;
                         type ResponseStream = T::StreamLibraryStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamLibraryRequest>,
@@ -1690,16 +1953,23 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::SearchRequest>
+                    for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as LibraryService>::search(&inner, request).await };
+                            let fut = async move {
+                                <T as LibraryService>::search(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1728,11 +1998,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/FilterAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct FilterAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::FilterAlbumsRequest>
-                        for FilterAlbumsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::FilterAlbumsRequest>
+                    for FilterAlbumsSvc<T> {
                         type Response = super::FilterAlbumsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FilterAlbumsRequest>,
@@ -1769,11 +2043,15 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/FilterArtists" => {
                     #[allow(non_camel_case_types)]
                     struct FilterArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<T: LibraryService> tonic::server::UnaryService<super::FilterArtistsRequest>
-                        for FilterArtistsSvc<T>
-                    {
+                    impl<
+                        T: LibraryService,
+                    > tonic::server::UnaryService<super::FilterArtistsRequest>
+                    for FilterArtistsSvc<T> {
                         type Response = super::FilterArtistsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FilterArtistsRequest>,
@@ -1807,19 +2085,23 @@ pub mod library_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1848,10 +2130,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1895,8 +2177,9 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1940,7 +2223,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1967,7 +2250,10 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2019,19 +2305,23 @@ pub mod metadata_service_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2315,10 +2605,10 @@ pub mod playback_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaybackServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2362,8 +2652,9 @@ pub mod playback_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaybackServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2402,12 +2693,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PlayRequest>,
         ) -> std::result::Result<tonic::Response<super::PlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Play");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Play",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Play"));
@@ -2417,12 +2714,18 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PauseRequest>,
         ) -> std::result::Result<tonic::Response<super::PauseResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Pause");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Pause",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Pause"));
@@ -2431,49 +2734,66 @@ pub mod playback_service_client {
         pub async fn play_or_pause(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayOrPause",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayOrPause"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeRequest>,
         ) -> std::result::Result<tonic::Response<super::ResumeResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Resume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Resume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Resume",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Resume"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::NextRequest>,
         ) -> std::result::Result<tonic::Response<super::NextResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Next");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Next",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Next"));
@@ -2482,293 +2802,426 @@ pub mod playback_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Previous");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Previous",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Previous",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Previous"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn fast_forward_rewind(
             &mut self,
             request: impl tonic::IntoRequest<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FastForwardRewind",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FastForwardRewind",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Status");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/Status",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "Status",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Status"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn current_track(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "CurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "CurrentTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn next_track(
             &mut self,
             request: impl tonic::IntoRequest<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/NextTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/NextTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "NextTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "NextTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn flush_and_reload_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "FlushAndReloadTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "FlushAndReloadTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_file_position(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "GetFilePosition",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "GetFilePosition",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn hard_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/HardStop");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/HardStop",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "HardStop",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "HardStop"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_album(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayAlbum");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayAlbum",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayDirectory"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_music_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayMusicDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayMusicDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_track(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayTrack");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaybackService/PlayTrack",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayLikedTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "PlayLikedTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "PlayAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAllTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_current_track(
@@ -2778,18 +3231,26 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::CurrentTrackResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamCurrentTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaybackService",
+                        "StreamCurrentTrack",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_status(
@@ -2799,18 +3260,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamStatus"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_playlist(
@@ -2820,18 +3286,23 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::PlaylistResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaybackService",
-                "StreamPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamPlaylist"),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
     }
@@ -2843,7 +3314,7 @@ pub mod playback_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaybackServiceServer.
@@ -2860,7 +3331,10 @@ pub mod playback_service_server {
         async fn play_or_pause(
             &self,
             request: tonic::Request<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayOrPauseResponse>,
+            tonic::Status,
+        >;
         async fn resume(
             &self,
             request: tonic::Request<super::ResumeRequest>,
@@ -2872,11 +3346,17 @@ pub mod playback_service_server {
         async fn previous(
             &self,
             request: tonic::Request<super::PreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PreviousResponse>,
+            tonic::Status,
+        >;
         async fn fast_forward_rewind(
             &self,
             request: tonic::Request<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FastForwardRewindResponse>,
+            tonic::Status,
+        >;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
@@ -2884,82 +3364,133 @@ pub mod playback_service_server {
         async fn current_track(
             &self,
             request: tonic::Request<super::CurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentTrackResponse>,
+            tonic::Status,
+        >;
         async fn next_track(
             &self,
             request: tonic::Request<super::NextTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NextTrackResponse>,
+            tonic::Status,
+        >;
         async fn flush_and_reload_tracks(
             &self,
             request: tonic::Request<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FlushAndReloadTracksResponse>,
+            tonic::Status,
+        >;
         async fn get_file_position(
             &self,
             request: tonic::Request<super::GetFilePositionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFilePositionResponse>,
+            tonic::Status,
+        >;
         async fn hard_stop(
             &self,
             request: tonic::Request<super::HardStopRequest>,
-        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HardStopResponse>,
+            tonic::Status,
+        >;
         async fn play_album(
             &self,
             request: tonic::Request<super::PlayAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAlbumResponse>,
+            tonic::Status,
+        >;
         async fn play_artist_tracks(
             &self,
             request: tonic::Request<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_playlist(
             &self,
             request: tonic::Request<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn play_directory(
             &self,
             request: tonic::Request<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_music_directory(
             &self,
             request: tonic::Request<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayMusicDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn play_track(
             &self,
             request: tonic::Request<super::PlayTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayTrackResponse>,
+            tonic::Status,
+        >;
         async fn play_liked_tracks(
             &self,
             request: tonic::Request<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayLikedTracksResponse>,
+            tonic::Status,
+        >;
         async fn play_all_tracks(
             &self,
             request: tonic::Request<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlayAllTracksResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamCurrentTrack method.
         type StreamCurrentTrackStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CurrentTrackResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_current_track(
             &self,
             request: tonic::Request<super::StreamCurrentTrackRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamCurrentTrackStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamCurrentTrackStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamStatus method.
         type StreamStatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_status(
             &self,
             request: tonic::Request<super::StreamStatusRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamStatusStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamStatusStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the StreamPlaylist method.
         type StreamPlaylistStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::PlaylistResponse, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn stream_playlist(
             &self,
             request: tonic::Request<super::StreamPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<Self::StreamPlaylistStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamPlaylistStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaybackServiceServer<T> {
@@ -2982,7 +3513,10 @@ pub mod playback_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -3037,16 +3571,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Play" => {
                     #[allow(non_camel_case_types)]
                     struct PlaySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
                         type Response = super::PlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::play(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::play(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3075,16 +3615,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Pause" => {
                     #[allow(non_camel_case_types)]
                     struct PauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
                         type Response = super::PauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PauseRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::pause(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::pause(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3113,11 +3659,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause" => {
                     #[allow(non_camel_case_types)]
                     struct PlayOrPauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayOrPauseRequest>
-                        for PlayOrPauseSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayOrPauseRequest>
+                    for PlayOrPauseSvc<T> {
                         type Response = super::PlayOrPauseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayOrPauseRequest>,
@@ -3154,9 +3704,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Resume" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::ResumeRequest> for ResumeSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::ResumeRequest>
+                    for ResumeSvc<T> {
                         type Response = super::ResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeRequest>,
@@ -3193,16 +3749,22 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
                         type Response = super::NextResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaybackService>::next(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaybackService>::next(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3231,9 +3793,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PreviousRequest> for PreviousSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PreviousRequest>
+                    for PreviousSvc<T> {
                         type Response = super::PreviousResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PreviousRequest>,
@@ -3270,19 +3838,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind" => {
                     #[allow(non_camel_case_types)]
                     struct FastForwardRewindSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FastForwardRewindRequest>
-                        for FastForwardRewindSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FastForwardRewindRequest>
+                    for FastForwardRewindSvc<T> {
                         type Response = super::FastForwardRewindResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FastForwardRewindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::fast_forward_rewind(&inner, request).await
+                                <T as PlaybackService>::fast_forward_rewind(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3312,9 +3884,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Status" => {
                     #[allow(non_camel_case_types)]
                     struct StatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::StatusRequest> for StatusSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::StatusRequest>
+                    for StatusSvc<T> {
                         type Response = super::StatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
@@ -3351,11 +3929,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct CurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::CurrentTrackRequest>
-                        for CurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::CurrentTrackRequest>
+                    for CurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CurrentTrackRequest>,
@@ -3392,9 +3974,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/NextTrack" => {
                     #[allow(non_camel_case_types)]
                     struct NextTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextTrackRequest> for NextTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::NextTrackRequest>
+                    for NextTrackSvc<T> {
                         type Response = super::NextTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextTrackRequest>,
@@ -3431,19 +4019,25 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks" => {
                     #[allow(non_camel_case_types)]
                     struct FlushAndReloadTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
-                        for FlushAndReloadTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
+                    for FlushAndReloadTracksSvc<T> {
                         type Response = super::FlushAndReloadTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FlushAndReloadTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::flush_and_reload_tracks(&inner, request)
+                                <T as PlaybackService>::flush_and_reload_tracks(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -3474,19 +4068,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition" => {
                     #[allow(non_camel_case_types)]
                     struct GetFilePositionSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::GetFilePositionRequest>
-                        for GetFilePositionSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::GetFilePositionRequest>
+                    for GetFilePositionSvc<T> {
                         type Response = super::GetFilePositionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFilePositionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::get_file_position(&inner, request).await
+                                <T as PlaybackService>::get_file_position(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3516,9 +4114,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/HardStop" => {
                     #[allow(non_camel_case_types)]
                     struct HardStopSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::HardStopRequest> for HardStopSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::HardStopRequest>
+                    for HardStopSvc<T> {
                         type Response = super::HardStopResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HardStopRequest>,
@@ -3555,9 +4159,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAlbumSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayAlbumRequest> for PlayAlbumSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAlbumRequest>
+                    for PlayAlbumSvc<T> {
                         type Response = super::PlayAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAlbumRequest>,
@@ -3594,19 +4204,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayArtistTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayArtistTracksRequest>
-                        for PlayArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayArtistTracksRequest>
+                    for PlayArtistTracksSvc<T> {
                         type Response = super::PlayArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_artist_tracks(&inner, request).await
+                                <T as PlaybackService>::play_artist_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3636,11 +4250,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct PlayPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayPlaylistRequest>
-                        for PlayPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayPlaylistRequest>
+                    for PlayPlaylistSvc<T> {
                         type Response = super::PlayPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayPlaylistRequest>,
@@ -3677,19 +4295,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayDirectoryRequest>
-                        for PlayDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayDirectoryRequest>
+                    for PlayDirectorySvc<T> {
                         type Response = super::PlayDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_directory(&inner, request).await
+                                <T as PlaybackService>::play_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3719,19 +4341,26 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayMusicDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
-                        for PlayMusicDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
+                    for PlayMusicDirectorySvc<T> {
                         type Response = super::PlayMusicDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayMusicDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_music_directory(&inner, request).await
+                                <T as PlaybackService>::play_music_directory(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3761,9 +4390,15 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayTrack" => {
                     #[allow(non_camel_case_types)]
                     struct PlayTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayTrackRequest> for PlayTrackSvc<T> {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayTrackRequest>
+                    for PlayTrackSvc<T> {
                         type Response = super::PlayTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayTrackRequest>,
@@ -3800,19 +4435,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayLikedTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayLikedTracksRequest>
-                        for PlayLikedTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayLikedTracksRequest>
+                    for PlayLikedTracksSvc<T> {
                         type Response = super::PlayLikedTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_liked_tracks(&inner, request).await
+                                <T as PlaybackService>::play_liked_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3842,19 +4481,23 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAllTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::UnaryService<super::PlayAllTracksRequest>
-                        for PlayAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::UnaryService<super::PlayAllTracksRequest>
+                    for PlayAllTracksSvc<T> {
                         type Response = super::PlayAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_all_tracks(&inner, request).await
+                                <T as PlaybackService>::play_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3884,21 +4527,28 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct StreamCurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamCurrentTrackRequest>
-                        for StreamCurrentTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamCurrentTrackRequest,
+                    > for StreamCurrentTrackSvc<T> {
                         type Response = super::CurrentTrackResponse;
                         type ResponseStream = T::StreamCurrentTrackStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamCurrentTrackRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_current_track(&inner, request).await
+                                <T as PlaybackService>::stream_current_track(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -3928,14 +4578,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus" => {
                     #[allow(non_camel_case_types)]
                     struct StreamStatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamStatusRequest>
-                        for StreamStatusSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamStatusRequest>
+                    for StreamStatusSvc<T> {
                         type Response = super::StatusResponse;
                         type ResponseStream = T::StreamStatusStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamStatusRequest>,
@@ -3972,21 +4624,24 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct StreamPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<T: PlaybackService>
-                        tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
-                        for StreamPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaybackService,
+                    > tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
+                    for StreamPlaylistSvc<T> {
                         type Response = super::PlaylistResponse;
                         type ResponseStream = T::StreamPlaylistStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_playlist(&inner, request).await
+                                <T as PlaybackService>::stream_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4013,19 +4668,23 @@ pub mod playback_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -4232,10 +4891,10 @@ pub mod playlist_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct PlaylistServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4279,8 +4938,9 @@ pub mod playlist_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaylistServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4318,182 +4978,251 @@ pub mod playlist_service_client {
         pub async fn get_current(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_resume_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetResumeInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetResumeInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetTrackInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetTrackInfo"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_first_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetFirstIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetFirstIndex"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_display_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "GetDisplayIndex",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "GetDisplayIndex",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn amount(
             &mut self,
             request: impl tonic::IntoRequest<super::AmountRequest>,
         ) -> std::result::Result<tonic::Response<super::AmountResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Amount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Amount",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "Amount",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Amount"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn playlist_resume(
             &mut self,
             request: impl tonic::IntoRequest<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "PlaylistResume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "PlaylistResume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume_track(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ResumeTrack",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "ResumeTrack"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_modified(
             &mut self,
             request: impl tonic::IntoRequest<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/SetModified",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "SetModified",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "SetModified"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn start(
             &mut self,
             request: impl tonic::IntoRequest<super::StartRequest>,
         ) -> std::result::Result<tonic::Response<super::StartResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Start");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Start",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Start"));
@@ -4503,12 +5232,18 @@ pub mod playlist_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncRequest>,
         ) -> std::result::Result<tonic::Response<super::SyncResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Sync");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.PlaylistService/Sync",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Sync"));
@@ -4517,172 +5252,247 @@ pub mod playlist_service_client {
         pub async fn remove_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveAllTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "RemoveAllTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "RemoveTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "RemoveTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn create_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "CreatePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "CreatePlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertTracks"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertDirectory",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertDirectory",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertPlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertPlaylist"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_album(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertAlbum",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertAlbum"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "InsertArtistTracks",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "InsertArtistTracks",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn shuffle_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.PlaylistService",
-                "ShufflePlaylist",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.PlaylistService",
+                        "ShufflePlaylist",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -4694,7 +5504,7 @@ pub mod playlist_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaylistServiceServer.
@@ -4703,23 +5513,38 @@ pub mod playlist_service_server {
         async fn get_current(
             &self,
             request: tonic::Request<super::GetCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetCurrentResponse>,
+            tonic::Status,
+        >;
         async fn get_resume_info(
             &self,
             request: tonic::Request<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetResumeInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_track_info(
             &self,
             request: tonic::Request<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetTrackInfoResponse>,
+            tonic::Status,
+        >;
         async fn get_first_index(
             &self,
             request: tonic::Request<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetFirstIndexResponse>,
+            tonic::Status,
+        >;
         async fn get_display_index(
             &self,
             request: tonic::Request<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetDisplayIndexResponse>,
+            tonic::Status,
+        >;
         async fn amount(
             &self,
             request: tonic::Request<super::AmountRequest>,
@@ -4727,15 +5552,24 @@ pub mod playlist_service_server {
         async fn playlist_resume(
             &self,
             request: tonic::Request<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PlaylistResumeResponse>,
+            tonic::Status,
+        >;
         async fn resume_track(
             &self,
             request: tonic::Request<super::ResumeTrackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResumeTrackResponse>,
+            tonic::Status,
+        >;
         async fn set_modified(
             &self,
             request: tonic::Request<super::SetModifiedRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetModifiedResponse>,
+            tonic::Status,
+        >;
         async fn start(
             &self,
             request: tonic::Request<super::StartRequest>,
@@ -4747,39 +5581,66 @@ pub mod playlist_service_server {
         async fn remove_all_tracks(
             &self,
             request: tonic::Request<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveAllTracksResponse>,
+            tonic::Status,
+        >;
         async fn remove_tracks(
             &self,
             request: tonic::Request<super::RemoveTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::RemoveTracksResponse>,
+            tonic::Status,
+        >;
         async fn create_playlist(
             &self,
             request: tonic::Request<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_tracks(
             &self,
             request: tonic::Request<super::InsertTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertTracksResponse>,
+            tonic::Status,
+        >;
         async fn insert_directory(
             &self,
             request: tonic::Request<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertDirectoryResponse>,
+            tonic::Status,
+        >;
         async fn insert_playlist(
             &self,
             request: tonic::Request<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertPlaylistResponse>,
+            tonic::Status,
+        >;
         async fn insert_album(
             &self,
             request: tonic::Request<super::InsertAlbumRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertAlbumResponse>,
+            tonic::Status,
+        >;
         async fn insert_artist_tracks(
             &self,
             request: tonic::Request<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::InsertArtistTracksResponse>,
+            tonic::Status,
+        >;
         async fn shuffle_playlist(
             &self,
             request: tonic::Request<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ShufflePlaylistResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct PlaylistServiceServer<T> {
@@ -4802,7 +5663,10 @@ pub mod playlist_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -4857,11 +5721,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetCurrentRequest>
-                        for GetCurrentSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetCurrentRequest>
+                    for GetCurrentSvc<T> {
                         type Response = super::GetCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCurrentRequest>,
@@ -4898,19 +5766,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetResumeInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetResumeInfoRequest>
-                        for GetResumeInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetResumeInfoRequest>
+                    for GetResumeInfoSvc<T> {
                         type Response = super::GetResumeInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetResumeInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_resume_info(&inner, request).await
+                                <T as PlaylistService>::get_resume_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4940,18 +5812,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetTrackInfoRequest>
-                        for GetTrackInfoSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetTrackInfoRequest>
+                    for GetTrackInfoSvc<T> {
                         type Response = super::GetTrackInfoResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_track_info(&inner, request).await
+                                <T as PlaylistService>::get_track_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -4981,19 +5858,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetFirstIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetFirstIndexRequest>
-                        for GetFirstIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetFirstIndexRequest>
+                    for GetFirstIndexSvc<T> {
                         type Response = super::GetFirstIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFirstIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_first_index(&inner, request).await
+                                <T as PlaylistService>::get_first_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5023,19 +5904,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetDisplayIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::GetDisplayIndexRequest>
-                        for GetDisplayIndexSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::GetDisplayIndexRequest>
+                    for GetDisplayIndexSvc<T> {
                         type Response = super::GetDisplayIndexResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetDisplayIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_display_index(&inner, request).await
+                                <T as PlaylistService>::get_display_index(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5065,9 +5950,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Amount" => {
                     #[allow(non_camel_case_types)]
                     struct AmountSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::AmountRequest> for AmountSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::AmountRequest>
+                    for AmountSvc<T> {
                         type Response = super::AmountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AmountRequest>,
@@ -5104,19 +5995,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume" => {
                     #[allow(non_camel_case_types)]
                     struct PlaylistResumeSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::PlaylistResumeRequest>
-                        for PlaylistResumeSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::PlaylistResumeRequest>
+                    for PlaylistResumeSvc<T> {
                         type Response = super::PlaylistResumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlaylistResumeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::playlist_resume(&inner, request).await
+                                <T as PlaylistService>::playlist_resume(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5146,11 +6041,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeTrackSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::ResumeTrackRequest>
-                        for ResumeTrackSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ResumeTrackRequest>
+                    for ResumeTrackSvc<T> {
                         type Response = super::ResumeTrackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeTrackRequest>,
@@ -5187,11 +6086,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/SetModified" => {
                     #[allow(non_camel_case_types)]
                     struct SetModifiedSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SetModifiedRequest>
-                        for SetModifiedSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SetModifiedRequest>
+                    for SetModifiedSvc<T> {
                         type Response = super::SetModifiedResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetModifiedRequest>,
@@ -5228,16 +6131,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Start" => {
                     #[allow(non_camel_case_types)]
                     struct StartSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
                         type Response = super::StartResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StartRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::start(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::start(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5266,16 +6175,22 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
                         type Response = super::SyncResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as PlaylistService>::sync(&inner, request).await };
+                            let fut = async move {
+                                <T as PlaylistService>::sync(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -5304,19 +6219,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveAllTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::RemoveAllTracksRequest>
-                        for RemoveAllTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveAllTracksRequest>
+                    for RemoveAllTracksSvc<T> {
                         type Response = super::RemoveAllTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::remove_all_tracks(&inner, request).await
+                                <T as PlaylistService>::remove_all_tracks(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5346,11 +6265,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::RemoveTracksRequest>
-                        for RemoveTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::RemoveTracksRequest>
+                    for RemoveTracksSvc<T> {
                         type Response = super::RemoveTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveTracksRequest>,
@@ -5387,19 +6310,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct CreatePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::CreatePlaylistRequest>
-                        for CreatePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::CreatePlaylistRequest>
+                    for CreatePlaylistSvc<T> {
                         type Response = super::CreatePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreatePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::create_playlist(&inner, request).await
+                                <T as PlaylistService>::create_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5429,11 +6356,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertTracksRequest>
-                        for InsertTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertTracksRequest>
+                    for InsertTracksSvc<T> {
                         type Response = super::InsertTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertTracksRequest>,
@@ -5470,19 +6401,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct InsertDirectorySvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertDirectoryRequest>
-                        for InsertDirectorySvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertDirectoryRequest>
+                    for InsertDirectorySvc<T> {
                         type Response = super::InsertDirectoryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_directory(&inner, request).await
+                                <T as PlaylistService>::insert_directory(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5512,19 +6447,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct InsertPlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertPlaylistRequest>
-                        for InsertPlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertPlaylistRequest>
+                    for InsertPlaylistSvc<T> {
                         type Response = super::InsertPlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_playlist(&inner, request).await
+                                <T as PlaylistService>::insert_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5554,11 +6493,15 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct InsertAlbumSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertAlbumRequest>
-                        for InsertAlbumSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertAlbumRequest>
+                    for InsertAlbumSvc<T> {
                         type Response = super::InsertAlbumResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertAlbumRequest>,
@@ -5595,19 +6538,26 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertArtistTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::InsertArtistTracksRequest>
-                        for InsertArtistTracksSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::InsertArtistTracksRequest>
+                    for InsertArtistTracksSvc<T> {
                         type Response = super::InsertArtistTracksResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_artist_tracks(&inner, request).await
+                                <T as PlaylistService>::insert_artist_tracks(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5637,19 +6587,23 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct ShufflePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<T: PlaylistService>
-                        tonic::server::UnaryService<super::ShufflePlaylistRequest>
-                        for ShufflePlaylistSvc<T>
-                    {
+                    impl<
+                        T: PlaylistService,
+                    > tonic::server::UnaryService<super::ShufflePlaylistRequest>
+                    for ShufflePlaylistSvc<T> {
                         type Response = super::ShufflePlaylistResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ShufflePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::shuffle_playlist(&inner, request).await
+                                <T as PlaylistService>::shuffle_playlist(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -5676,19 +6630,23 @@ pub mod playlist_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6198,10 +7156,10 @@ pub mod settings_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SettingsServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6245,8 +7203,9 @@ pub mod settings_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SettingsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6284,58 +7243,85 @@ pub mod settings_service_client {
         pub async fn get_settings_list(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetSettingsList",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetSettingsList",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "GetGlobalSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SettingsService",
+                        "GetGlobalSettings",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn save_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/SaveSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SettingsService",
-                "SaveSettings",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SettingsService", "SaveSettings"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -6347,7 +7333,7 @@ pub mod settings_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SettingsServiceServer.
@@ -6356,15 +7342,24 @@ pub mod settings_service_server {
         async fn get_settings_list(
             &self,
             request: tonic::Request<super::GetSettingsListRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetSettingsListResponse>,
+            tonic::Status,
+        >;
         async fn get_global_settings(
             &self,
             request: tonic::Request<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalSettingsResponse>,
+            tonic::Status,
+        >;
         async fn save_settings(
             &self,
             request: tonic::Request<super::SaveSettingsRequest>,
-        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SaveSettingsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SettingsServiceServer<T> {
@@ -6387,7 +7382,10 @@ pub mod settings_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -6442,19 +7440,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList" => {
                     #[allow(non_camel_case_types)]
                     struct GetSettingsListSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetSettingsListRequest>
-                        for GetSettingsListSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetSettingsListRequest>
+                    for GetSettingsListSvc<T> {
                         type Response = super::GetSettingsListResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSettingsListRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_settings_list(&inner, request).await
+                                <T as SettingsService>::get_settings_list(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6484,19 +7486,23 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService>
-                        tonic::server::UnaryService<super::GetGlobalSettingsRequest>
-                        for GetGlobalSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::GetGlobalSettingsRequest>
+                    for GetGlobalSettingsSvc<T> {
                         type Response = super::GetGlobalSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalSettingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_global_settings(&inner, request).await
+                                <T as SettingsService>::get_global_settings(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -6526,11 +7532,15 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/SaveSettings" => {
                     #[allow(non_camel_case_types)]
                     struct SaveSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<T: SettingsService> tonic::server::UnaryService<super::SaveSettingsRequest>
-                        for SaveSettingsSvc<T>
-                    {
+                    impl<
+                        T: SettingsService,
+                    > tonic::server::UnaryService<super::SaveSettingsRequest>
+                    for SaveSettingsSvc<T> {
                         type Response = super::SaveSettingsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SaveSettingsRequest>,
@@ -6564,19 +7574,23 @@ pub mod settings_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -6734,10 +7748,10 @@ pub mod sound_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SoundServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -6781,8 +7795,9 @@ pub mod sound_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SoundServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -6820,31 +7835,48 @@ pub mod sound_service_client {
         pub async fn adjust_volume(
             &mut self,
             request: impl tonic::IntoRequest<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/AdjustVolume");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/AdjustVolume",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "AdjustVolume",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "AdjustVolume"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_set(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundSet");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundSet",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundSet"));
@@ -6853,49 +7885,74 @@ pub mod sound_service_client {
         pub async fn sound_current(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundCurrent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundCurrent",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundCurrent",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundCurrent"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_default(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundDefault");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundDefault",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundDefault",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundDefault"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_min(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMin");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMin",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMin"));
@@ -6904,13 +7961,22 @@ pub mod sound_service_client {
         pub async fn sound_max(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMax");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundMax",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMax"));
@@ -6919,49 +7985,72 @@ pub mod sound_service_client {
         pub async fn sound_unit(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundUnit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SoundUnit",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundUnit",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundUnit"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_val2_phys(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SoundVal2Phys",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundVal2Phys"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/GetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/GetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "GetPitch"));
@@ -6970,13 +8059,22 @@ pub mod sound_service_client {
         pub async fn set_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SetPitch");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/SetPitch",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SetPitch"));
@@ -6985,13 +8083,22 @@ pub mod sound_service_client {
         pub async fn beep_play(
             &mut self,
             request: impl tonic::IntoRequest<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/BeepPlay");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/BeepPlay",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "BeepPlay"));
@@ -7000,76 +8107,106 @@ pub mod sound_service_client {
         pub async fn pcmbuf_fade(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/PcmbufFade");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rockbox.v1alpha1.SoundService/PcmbufFade",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufFade",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "PcmbufFade"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn pcmbuf_set_low_latency(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "PcmbufSetLowLatency",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SoundService",
+                        "PcmbufSetLowLatency",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn system_sound_play(
             &mut self,
             request: impl tonic::IntoRequest<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "SystemSoundPlay",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SystemSoundPlay"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn keyclick_click(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/KeyclickClick",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SoundService",
-                "KeyclickClick",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "KeyclickClick"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7081,7 +8218,7 @@ pub mod sound_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SoundServiceServer.
@@ -7090,63 +8227,108 @@ pub mod sound_service_server {
         async fn adjust_volume(
             &self,
             request: tonic::Request<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AdjustVolumeResponse>,
+            tonic::Status,
+        >;
         async fn sound_set(
             &self,
             request: tonic::Request<super::SoundSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundSetResponse>,
+            tonic::Status,
+        >;
         async fn sound_current(
             &self,
             request: tonic::Request<super::SoundCurrentRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundCurrentResponse>,
+            tonic::Status,
+        >;
         async fn sound_default(
             &self,
             request: tonic::Request<super::SoundDefaultRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundDefaultResponse>,
+            tonic::Status,
+        >;
         async fn sound_min(
             &self,
             request: tonic::Request<super::SoundMinRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMinResponse>,
+            tonic::Status,
+        >;
         async fn sound_max(
             &self,
             request: tonic::Request<super::SoundMaxRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundMaxResponse>,
+            tonic::Status,
+        >;
         async fn sound_unit(
             &self,
             request: tonic::Request<super::SoundUnitRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundUnitResponse>,
+            tonic::Status,
+        >;
         async fn sound_val2_phys(
             &self,
             request: tonic::Request<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SoundVal2PhysResponse>,
+            tonic::Status,
+        >;
         async fn get_pitch(
             &self,
             request: tonic::Request<super::GetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetPitchResponse>,
+            tonic::Status,
+        >;
         async fn set_pitch(
             &self,
             request: tonic::Request<super::SetPitchRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SetPitchResponse>,
+            tonic::Status,
+        >;
         async fn beep_play(
             &self,
             request: tonic::Request<super::BeepPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BeepPlayResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_fade(
             &self,
             request: tonic::Request<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufFadeResponse>,
+            tonic::Status,
+        >;
         async fn pcmbuf_set_low_latency(
             &self,
             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::PcmbufSetLowLatencyResponse>,
+            tonic::Status,
+        >;
         async fn system_sound_play(
             &self,
             request: tonic::Request<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SystemSoundPlayResponse>,
+            tonic::Status,
+        >;
         async fn keyclick_click(
             &self,
             request: tonic::Request<super::KeyclickClickRequest>,
-        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyclickClickResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SoundServiceServer<T> {
@@ -7169,7 +8351,10 @@ pub mod sound_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7224,11 +8409,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/AdjustVolume" => {
                     #[allow(non_camel_case_types)]
                     struct AdjustVolumeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::AdjustVolumeRequest>
-                        for AdjustVolumeSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::AdjustVolumeRequest>
+                    for AdjustVolumeSvc<T> {
                         type Response = super::AdjustVolumeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AdjustVolumeRequest>,
@@ -7265,9 +8454,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundSet" => {
                     #[allow(non_camel_case_types)]
                     struct SoundSetSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundSetRequest> for SoundSetSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundSetRequest>
+                    for SoundSetSvc<T> {
                         type Response = super::SoundSetResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundSetRequest>,
@@ -7304,11 +8499,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct SoundCurrentSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundCurrentRequest>
-                        for SoundCurrentSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundCurrentRequest>
+                    for SoundCurrentSvc<T> {
                         type Response = super::SoundCurrentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundCurrentRequest>,
@@ -7345,11 +8544,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundDefault" => {
                     #[allow(non_camel_case_types)]
                     struct SoundDefaultSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundDefaultRequest>
-                        for SoundDefaultSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundDefaultRequest>
+                    for SoundDefaultSvc<T> {
                         type Response = super::SoundDefaultResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundDefaultRequest>,
@@ -7386,9 +8589,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMin" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMinSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMinRequest> for SoundMinSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMinRequest>
+                    for SoundMinSvc<T> {
                         type Response = super::SoundMinResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMinRequest>,
@@ -7425,9 +8634,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMax" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMaxSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMaxRequest> for SoundMaxSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundMaxRequest>
+                    for SoundMaxSvc<T> {
                         type Response = super::SoundMaxResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMaxRequest>,
@@ -7464,9 +8679,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundUnit" => {
                     #[allow(non_camel_case_types)]
                     struct SoundUnitSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundUnitRequest> for SoundUnitSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundUnitRequest>
+                    for SoundUnitSvc<T> {
                         type Response = super::SoundUnitResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundUnitRequest>,
@@ -7503,11 +8724,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys" => {
                     #[allow(non_camel_case_types)]
                     struct SoundVal2PhysSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SoundVal2PhysRequest>
-                        for SoundVal2PhysSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SoundVal2PhysRequest>
+                    for SoundVal2PhysSvc<T> {
                         type Response = super::SoundVal2PhysResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundVal2PhysRequest>,
@@ -7544,9 +8769,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/GetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct GetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::GetPitchRequest> for GetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::GetPitchRequest>
+                    for GetPitchSvc<T> {
                         type Response = super::GetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPitchRequest>,
@@ -7583,9 +8814,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct SetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SetPitchRequest> for SetPitchSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SetPitchRequest>
+                    for SetPitchSvc<T> {
                         type Response = super::SetPitchResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPitchRequest>,
@@ -7622,9 +8859,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/BeepPlay" => {
                     #[allow(non_camel_case_types)]
                     struct BeepPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::BeepPlayRequest> for BeepPlaySvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::BeepPlayRequest>
+                    for BeepPlaySvc<T> {
                         type Response = super::BeepPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BeepPlayRequest>,
@@ -7661,9 +8904,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufFade" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufFadeSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::PcmbufFadeRequest> for PcmbufFadeSvc<T> {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufFadeRequest>
+                    for PcmbufFadeSvc<T> {
                         type Response = super::PcmbufFadeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufFadeRequest>,
@@ -7700,19 +8949,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufSetLowLatencySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService>
-                        tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
-                        for PcmbufSetLowLatencySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
+                    for PcmbufSetLowLatencySvc<T> {
                         type Response = super::PcmbufSetLowLatencyResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request).await
+                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7742,18 +8995,23 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay" => {
                     #[allow(non_camel_case_types)]
                     struct SystemSoundPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::SystemSoundPlayRequest>
-                        for SystemSoundPlaySvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::SystemSoundPlayRequest>
+                    for SystemSoundPlaySvc<T> {
                         type Response = super::SystemSoundPlayResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SystemSoundPlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::system_sound_play(&inner, request).await
+                                <T as SoundService>::system_sound_play(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -7783,11 +9041,15 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/KeyclickClick" => {
                     #[allow(non_camel_case_types)]
                     struct KeyclickClickSvc<T: SoundService>(pub Arc<T>);
-                    impl<T: SoundService> tonic::server::UnaryService<super::KeyclickClickRequest>
-                        for KeyclickClickSvc<T>
-                    {
+                    impl<
+                        T: SoundService,
+                    > tonic::server::UnaryService<super::KeyclickClickRequest>
+                    for KeyclickClickSvc<T> {
                         type Response = super::KeyclickClickResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::KeyclickClickRequest>,
@@ -7821,19 +9083,23 @@ pub mod sound_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -7894,10 +9160,10 @@ pub mod system_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SystemServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7941,8 +9207,9 @@ pub mod system_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SystemServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7980,39 +9247,56 @@ pub mod system_service_client {
         pub async fn get_rockbox_version(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetRockboxVersion",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "rockbox.v1alpha1.SystemService",
+                        "GetRockboxVersion",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rockbox.v1alpha1.SystemService",
-                "GetGlobalStatus",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("rockbox.v1alpha1.SystemService", "GetGlobalStatus"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -8024,7 +9308,7 @@ pub mod system_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SystemServiceServer.
@@ -8033,11 +9317,17 @@ pub mod system_service_server {
         async fn get_rockbox_version(
             &self,
             request: tonic::Request<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetRockboxVersionResponse>,
+            tonic::Status,
+        >;
         async fn get_global_status(
             &self,
             request: tonic::Request<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetGlobalStatusResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SystemServiceServer<T> {
@@ -8060,7 +9350,10 @@ pub mod system_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -8115,19 +9408,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion" => {
                     #[allow(non_camel_case_types)]
                     struct GetRockboxVersionSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetRockboxVersionRequest>
-                        for GetRockboxVersionSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetRockboxVersionRequest>
+                    for GetRockboxVersionSvc<T> {
                         type Response = super::GetRockboxVersionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRockboxVersionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_rockbox_version(&inner, request).await
+                                <T as SystemService>::get_rockbox_version(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -8157,19 +9454,23 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalStatusSvc<T: SystemService>(pub Arc<T>);
-                    impl<T: SystemService>
-                        tonic::server::UnaryService<super::GetGlobalStatusRequest>
-                        for GetGlobalStatusSvc<T>
-                    {
+                    impl<
+                        T: SystemService,
+                    > tonic::server::UnaryService<super::GetGlobalStatusRequest>
+                    for GetGlobalStatusSvc<T> {
                         type Response = super::GetGlobalStatusResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_global_status(&inner, request).await
+                                <T as SystemService>::get_global_status(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -8196,19 +9497,23 @@ pub mod system_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/crates/upnp/src/api/rockbox.v1alpha1.rs
+++ b/crates/upnp/src/api/rockbox.v1alpha1.rs
@@ -45,10 +45,10 @@ pub mod browse_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct BrowseServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -92,9 +92,8 @@ pub mod browse_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BrowseServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -132,27 +131,20 @@ pub mod browse_service_client {
         pub async fn tree_get_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::TreeGetEntriesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.BrowseService", "TreeGetEntries"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.BrowseService",
+                "TreeGetEntries",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -164,7 +156,7 @@ pub mod browse_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with BrowseServiceServer.
@@ -173,10 +165,7 @@ pub mod browse_service_server {
         async fn tree_get_entries(
             &self,
             request: tonic::Request<super::TreeGetEntriesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::TreeGetEntriesResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::TreeGetEntriesResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct BrowseServiceServer<T> {
@@ -199,10 +188,7 @@ pub mod browse_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -257,23 +243,18 @@ pub mod browse_service_server {
                 "/rockbox.v1alpha1.BrowseService/TreeGetEntries" => {
                     #[allow(non_camel_case_types)]
                     struct TreeGetEntriesSvc<T: BrowseService>(pub Arc<T>);
-                    impl<
-                        T: BrowseService,
-                    > tonic::server::UnaryService<super::TreeGetEntriesRequest>
-                    for TreeGetEntriesSvc<T> {
+                    impl<T: BrowseService> tonic::server::UnaryService<super::TreeGetEntriesRequest>
+                        for TreeGetEntriesSvc<T>
+                    {
                         type Response = super::TreeGetEntriesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TreeGetEntriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BrowseService>::tree_get_entries(&inner, request)
-                                    .await
+                                <T as BrowseService>::tree_get_entries(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -300,23 +281,19 @@ pub mod browse_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -596,10 +573,10 @@ pub mod library_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct LibraryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -643,9 +620,8 @@ pub mod library_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LibraryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -683,325 +659,233 @@ pub mod library_service_client {
         pub async fn get_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAlbumsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetAlbums",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbums");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbums"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetAlbums",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetArtistsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetArtists",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtists");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtists"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetArtists",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetTracks",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTracks");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTracks"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_album(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAlbumResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetAlbum",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetAlbum");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetAlbum"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetAlbum",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_artist(
             &mut self,
             request: impl tonic::IntoRequest<super::GetArtistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetArtistResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetArtist",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetArtist");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetArtist"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetArtist",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/GetTrack",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/GetTrack");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetTrack"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_track(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LikeTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/LikeTrack",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeTrack");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeTrack"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "LikeTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_track(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlikeTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeTrack"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "UnlikeTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn like_album(
             &mut self,
             request: impl tonic::IntoRequest<super::LikeAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LikeAlbumResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/LikeAlbum",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/LikeAlbum");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "LikeAlbum"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "LikeAlbum",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn unlike_album(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlikeAlbumResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "UnlikeAlbum"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "UnlikeAlbum",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLikedTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedTracks"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetLikedTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_liked_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLikedAlbumsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "GetLikedAlbums"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "GetLikedAlbums",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn scan_library(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanLibraryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ScanLibraryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "ScanLibrary"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "ScanLibrary",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_library(
@@ -1011,41 +895,30 @@ pub mod library_service_client {
             tonic::Response<tonic::codec::Streaming<super::StreamLibraryResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "StreamLibrary"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "StreamLibrary",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchRequest>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.LibraryService/Search",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.LibraryService/Search");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.LibraryService", "Search"));
@@ -1054,53 +927,39 @@ pub mod library_service_client {
         pub async fn filter_albums(
             &mut self,
             request: impl tonic::IntoRequest<super::FilterAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FilterAlbumsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FilterAlbumsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/FilterAlbums",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "FilterAlbums"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "FilterAlbums",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn filter_artists(
             &mut self,
             request: impl tonic::IntoRequest<super::FilterArtistsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FilterArtistsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FilterArtistsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.LibraryService/FilterArtists",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.LibraryService", "FilterArtists"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.LibraryService",
+                "FilterArtists",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1112,7 +971,7 @@ pub mod library_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LibraryServiceServer.
@@ -1121,107 +980,64 @@ pub mod library_service_server {
         async fn get_albums(
             &self,
             request: tonic::Request<super::GetAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAlbumsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetAlbumsResponse>, tonic::Status>;
         async fn get_artists(
             &self,
             request: tonic::Request<super::GetArtistsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetArtistsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetArtistsResponse>, tonic::Status>;
         async fn get_tracks(
             &self,
             request: tonic::Request<super::GetTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetTracksResponse>, tonic::Status>;
         async fn get_album(
             &self,
             request: tonic::Request<super::GetAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAlbumResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetAlbumResponse>, tonic::Status>;
         async fn get_artist(
             &self,
             request: tonic::Request<super::GetArtistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetArtistResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetArtistResponse>, tonic::Status>;
         async fn get_track(
             &self,
             request: tonic::Request<super::GetTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetTrackResponse>, tonic::Status>;
         async fn like_track(
             &self,
             request: tonic::Request<super::LikeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LikeTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LikeTrackResponse>, tonic::Status>;
         async fn unlike_track(
             &self,
             request: tonic::Request<super::UnlikeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlikeTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlikeTrackResponse>, tonic::Status>;
         async fn like_album(
             &self,
             request: tonic::Request<super::LikeAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LikeAlbumResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LikeAlbumResponse>, tonic::Status>;
         async fn unlike_album(
             &self,
             request: tonic::Request<super::UnlikeAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlikeAlbumResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlikeAlbumResponse>, tonic::Status>;
         async fn get_liked_tracks(
             &self,
             request: tonic::Request<super::GetLikedTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLikedTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetLikedTracksResponse>, tonic::Status>;
         async fn get_liked_albums(
             &self,
             request: tonic::Request<super::GetLikedAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLikedAlbumsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetLikedAlbumsResponse>, tonic::Status>;
         async fn scan_library(
             &self,
             request: tonic::Request<super::ScanLibraryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ScanLibraryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ScanLibraryResponse>, tonic::Status>;
         /// Server streaming response type for the StreamLibrary method.
         type StreamLibraryStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StreamLibraryResponse, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         async fn stream_library(
             &self,
             request: tonic::Request<super::StreamLibraryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::StreamLibraryStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::StreamLibraryStream>, tonic::Status>;
         async fn search(
             &self,
             request: tonic::Request<super::SearchRequest>,
@@ -1229,17 +1045,11 @@ pub mod library_service_server {
         async fn filter_albums(
             &self,
             request: tonic::Request<super::FilterAlbumsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FilterAlbumsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FilterAlbumsResponse>, tonic::Status>;
         async fn filter_artists(
             &self,
             request: tonic::Request<super::FilterArtistsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FilterArtistsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FilterArtistsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct LibraryServiceServer<T> {
@@ -1262,10 +1072,7 @@ pub mod library_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1320,15 +1127,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetAlbumsRequest>
-                    for GetAlbumsSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumsRequest> for GetAlbumsSvc<T> {
                         type Response = super::GetAlbumsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumsRequest>,
@@ -1365,15 +1166,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtists" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetArtistsRequest>
-                    for GetArtistsSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistsRequest> for GetArtistsSvc<T> {
                         type Response = super::GetArtistsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistsRequest>,
@@ -1410,15 +1205,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetTracksRequest>
-                    for GetTracksSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTracksRequest> for GetTracksSvc<T> {
                         type Response = super::GetTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTracksRequest>,
@@ -1455,15 +1244,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct GetAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetAlbumRequest>
-                    for GetAlbumSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetAlbumRequest> for GetAlbumSvc<T> {
                         type Response = super::GetAlbumResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAlbumRequest>,
@@ -1500,15 +1283,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetArtist" => {
                     #[allow(non_camel_case_types)]
                     struct GetArtistSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetArtistRequest>
-                    for GetArtistSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetArtistRequest> for GetArtistSvc<T> {
                         type Response = super::GetArtistResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetArtistRequest>,
@@ -1545,15 +1322,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetTrack" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetTrackRequest>
-                    for GetTrackSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::GetTrackRequest> for GetTrackSvc<T> {
                         type Response = super::GetTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackRequest>,
@@ -1590,15 +1361,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct LikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::LikeTrackRequest>
-                    for LikeTrackSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeTrackRequest> for LikeTrackSvc<T> {
                         type Response = super::LikeTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeTrackRequest>,
@@ -1635,15 +1400,11 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeTrackSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::UnlikeTrackRequest>
-                    for UnlikeTrackSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeTrackRequest>
+                        for UnlikeTrackSvc<T>
+                    {
                         type Response = super::UnlikeTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeTrackRequest>,
@@ -1680,15 +1441,9 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/LikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct LikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::LikeAlbumRequest>
-                    for LikeAlbumSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::LikeAlbumRequest> for LikeAlbumSvc<T> {
                         type Response = super::LikeAlbumResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LikeAlbumRequest>,
@@ -1725,15 +1480,11 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/UnlikeAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct UnlikeAlbumSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::UnlikeAlbumRequest>
-                    for UnlikeAlbumSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::UnlikeAlbumRequest>
+                        for UnlikeAlbumSvc<T>
+                    {
                         type Response = super::UnlikeAlbumResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlikeAlbumRequest>,
@@ -1770,23 +1521,19 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedTracksSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetLikedTracksRequest>
-                    for GetLikedTracksSvc<T> {
+                    impl<T: LibraryService>
+                        tonic::server::UnaryService<super::GetLikedTracksRequest>
+                        for GetLikedTracksSvc<T>
+                    {
                         type Response = super::GetLikedTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_tracks(&inner, request)
-                                    .await
+                                <T as LibraryService>::get_liked_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1816,23 +1563,19 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/GetLikedAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct GetLikedAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::GetLikedAlbumsRequest>
-                    for GetLikedAlbumsSvc<T> {
+                    impl<T: LibraryService>
+                        tonic::server::UnaryService<super::GetLikedAlbumsRequest>
+                        for GetLikedAlbumsSvc<T>
+                    {
                         type Response = super::GetLikedAlbumsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetLikedAlbumsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LibraryService>::get_liked_albums(&inner, request)
-                                    .await
+                                <T as LibraryService>::get_liked_albums(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1862,15 +1605,11 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/ScanLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct ScanLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::ScanLibraryRequest>
-                    for ScanLibrarySvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::ScanLibraryRequest>
+                        for ScanLibrarySvc<T>
+                    {
                         type Response = super::ScanLibraryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ScanLibraryRequest>,
@@ -1907,16 +1646,14 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/StreamLibrary" => {
                     #[allow(non_camel_case_types)]
                     struct StreamLibrarySvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::ServerStreamingService<super::StreamLibraryRequest>
-                    for StreamLibrarySvc<T> {
+                    impl<T: LibraryService>
+                        tonic::server::ServerStreamingService<super::StreamLibraryRequest>
+                        for StreamLibrarySvc<T>
+                    {
                         type Response = super::StreamLibraryResponse;
                         type ResponseStream = T::StreamLibraryStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamLibraryRequest>,
@@ -1953,23 +1690,16 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/Search" => {
                     #[allow(non_camel_case_types)]
                     struct SearchSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::SearchRequest>
-                    for SearchSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::SearchRequest> for SearchSvc<T> {
                         type Response = super::SearchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SearchRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as LibraryService>::search(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as LibraryService>::search(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1998,15 +1728,11 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/FilterAlbums" => {
                     #[allow(non_camel_case_types)]
                     struct FilterAlbumsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::FilterAlbumsRequest>
-                    for FilterAlbumsSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::FilterAlbumsRequest>
+                        for FilterAlbumsSvc<T>
+                    {
                         type Response = super::FilterAlbumsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FilterAlbumsRequest>,
@@ -2043,15 +1769,11 @@ pub mod library_service_server {
                 "/rockbox.v1alpha1.LibraryService/FilterArtists" => {
                     #[allow(non_camel_case_types)]
                     struct FilterArtistsSvc<T: LibraryService>(pub Arc<T>);
-                    impl<
-                        T: LibraryService,
-                    > tonic::server::UnaryService<super::FilterArtistsRequest>
-                    for FilterArtistsSvc<T> {
+                    impl<T: LibraryService> tonic::server::UnaryService<super::FilterArtistsRequest>
+                        for FilterArtistsSvc<T>
+                    {
                         type Response = super::FilterArtistsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FilterArtistsRequest>,
@@ -2085,23 +1807,19 @@ pub mod library_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -2130,10 +1848,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2177,9 +1895,8 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2223,7 +1940,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -2250,10 +1967,7 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2305,23 +2019,19 @@ pub mod metadata_service_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -2605,10 +2315,10 @@ pub mod playback_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct PlaybackServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -2652,9 +2362,8 @@ pub mod playback_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaybackServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2693,18 +2402,12 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PlayRequest>,
         ) -> std::result::Result<tonic::Response<super::PlayResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Play",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Play");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Play"));
@@ -2714,18 +2417,12 @@ pub mod playback_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PauseRequest>,
         ) -> std::result::Result<tonic::Response<super::PauseResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Pause",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Pause");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Pause"));
@@ -2734,66 +2431,49 @@ pub mod playback_service_client {
         pub async fn play_or_pause(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayOrPauseResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayOrPause"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayOrPause",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeRequest>,
         ) -> std::result::Result<tonic::Response<super::ResumeResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Resume",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Resume");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Resume"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "Resume",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::NextRequest>,
         ) -> std::result::Result<tonic::Response<super::NextResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Next",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Next");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Next"));
@@ -2802,426 +2482,293 @@ pub mod playback_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::PreviousRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PreviousResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Previous",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Previous");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Previous"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "Previous",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn fast_forward_rewind(
             &mut self,
             request: impl tonic::IntoRequest<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FastForwardRewindResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "FastForwardRewind",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "FastForwardRewind",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/Status",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/Status");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "Status"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "Status",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn current_track(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CurrentTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "CurrentTrack"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "CurrentTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn next_track(
             &mut self,
             request: impl tonic::IntoRequest<super::NextTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::NextTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/NextTrack",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/NextTrack");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "NextTrack"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "NextTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn flush_and_reload_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FlushAndReloadTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "FlushAndReloadTracks",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "FlushAndReloadTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_file_position(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFilePositionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetFilePositionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "GetFilePosition",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "GetFilePosition",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn hard_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::HardStopRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HardStopResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/HardStop",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/HardStop");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "HardStop"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "HardStop",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_album(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayAlbumResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/PlayAlbum",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayAlbum");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAlbum"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayAlbum",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayArtistTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "PlayArtistTracks",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayArtistTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayPlaylistResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayPlaylist"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayPlaylist",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayDirectoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayDirectory"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayDirectory",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_music_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayMusicDirectoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "PlayMusicDirectory",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayMusicDirectory",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_track(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaybackService/PlayTrack",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaybackService/PlayTrack");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayTrack"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_liked_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayLikedTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "PlayLikedTracks",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayLikedTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn play_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayAllTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "PlayAllTracks"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "PlayAllTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn stream_current_track(
@@ -3231,26 +2778,18 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::CurrentTrackResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaybackService",
-                        "StreamCurrentTrack",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "StreamCurrentTrack",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_status(
@@ -3260,23 +2799,18 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamStatus"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "StreamStatus",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn stream_playlist(
@@ -3286,23 +2820,18 @@ pub mod playback_service_client {
             tonic::Response<tonic::codec::Streaming<super::PlaylistResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaybackService", "StreamPlaylist"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaybackService",
+                "StreamPlaylist",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
     }
@@ -3314,7 +2843,7 @@ pub mod playback_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaybackServiceServer.
@@ -3331,10 +2860,7 @@ pub mod playback_service_server {
         async fn play_or_pause(
             &self,
             request: tonic::Request<super::PlayOrPauseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayOrPauseResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayOrPauseResponse>, tonic::Status>;
         async fn resume(
             &self,
             request: tonic::Request<super::ResumeRequest>,
@@ -3346,17 +2872,11 @@ pub mod playback_service_server {
         async fn previous(
             &self,
             request: tonic::Request<super::PreviousRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PreviousResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PreviousResponse>, tonic::Status>;
         async fn fast_forward_rewind(
             &self,
             request: tonic::Request<super::FastForwardRewindRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FastForwardRewindResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FastForwardRewindResponse>, tonic::Status>;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
@@ -3364,133 +2884,82 @@ pub mod playback_service_server {
         async fn current_track(
             &self,
             request: tonic::Request<super::CurrentTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CurrentTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CurrentTrackResponse>, tonic::Status>;
         async fn next_track(
             &self,
             request: tonic::Request<super::NextTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::NextTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::NextTrackResponse>, tonic::Status>;
         async fn flush_and_reload_tracks(
             &self,
             request: tonic::Request<super::FlushAndReloadTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FlushAndReloadTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::FlushAndReloadTracksResponse>, tonic::Status>;
         async fn get_file_position(
             &self,
             request: tonic::Request<super::GetFilePositionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetFilePositionResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetFilePositionResponse>, tonic::Status>;
         async fn hard_stop(
             &self,
             request: tonic::Request<super::HardStopRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::HardStopResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::HardStopResponse>, tonic::Status>;
         async fn play_album(
             &self,
             request: tonic::Request<super::PlayAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayAlbumResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayAlbumResponse>, tonic::Status>;
         async fn play_artist_tracks(
             &self,
             request: tonic::Request<super::PlayArtistTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayArtistTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayArtistTracksResponse>, tonic::Status>;
         async fn play_playlist(
             &self,
             request: tonic::Request<super::PlayPlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayPlaylistResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayPlaylistResponse>, tonic::Status>;
         async fn play_directory(
             &self,
             request: tonic::Request<super::PlayDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayDirectoryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayDirectoryResponse>, tonic::Status>;
         async fn play_music_directory(
             &self,
             request: tonic::Request<super::PlayMusicDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayMusicDirectoryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayMusicDirectoryResponse>, tonic::Status>;
         async fn play_track(
             &self,
             request: tonic::Request<super::PlayTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayTrackResponse>, tonic::Status>;
         async fn play_liked_tracks(
             &self,
             request: tonic::Request<super::PlayLikedTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayLikedTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayLikedTracksResponse>, tonic::Status>;
         async fn play_all_tracks(
             &self,
             request: tonic::Request<super::PlayAllTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlayAllTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlayAllTracksResponse>, tonic::Status>;
         /// Server streaming response type for the StreamCurrentTrack method.
         type StreamCurrentTrackStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CurrentTrackResponse, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         async fn stream_current_track(
             &self,
             request: tonic::Request<super::StreamCurrentTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::StreamCurrentTrackStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::StreamCurrentTrackStream>, tonic::Status>;
         /// Server streaming response type for the StreamStatus method.
         type StreamStatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         async fn stream_status(
             &self,
             request: tonic::Request<super::StreamStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::StreamStatusStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::StreamStatusStream>, tonic::Status>;
         /// Server streaming response type for the StreamPlaylist method.
         type StreamPlaylistStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::PlaylistResponse, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         async fn stream_playlist(
             &self,
             request: tonic::Request<super::StreamPlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::StreamPlaylistStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::StreamPlaylistStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct PlaybackServiceServer<T> {
@@ -3513,10 +2982,7 @@ pub mod playback_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -3571,22 +3037,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Play" => {
                     #[allow(non_camel_case_types)]
                     struct PlaySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayRequest> for PlaySvc<T> {
                         type Response = super::PlayResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PlaybackService>::play(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as PlaybackService>::play(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -3615,22 +3075,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Pause" => {
                     #[allow(non_camel_case_types)]
                     struct PauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PauseRequest> for PauseSvc<T> {
                         type Response = super::PauseResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PauseRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PlaybackService>::pause(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as PlaybackService>::pause(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -3659,15 +3113,11 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayOrPause" => {
                     #[allow(non_camel_case_types)]
                     struct PlayOrPauseSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayOrPauseRequest>
-                    for PlayOrPauseSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayOrPauseRequest>
+                        for PlayOrPauseSvc<T>
+                    {
                         type Response = super::PlayOrPauseResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayOrPauseRequest>,
@@ -3704,15 +3154,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Resume" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::ResumeRequest>
-                    for ResumeSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::ResumeRequest> for ResumeSvc<T> {
                         type Response = super::ResumeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeRequest>,
@@ -3749,22 +3193,16 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextRequest> for NextSvc<T> {
                         type Response = super::NextResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PlaybackService>::next(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as PlaybackService>::next(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -3793,15 +3231,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PreviousRequest>
-                    for PreviousSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PreviousRequest> for PreviousSvc<T> {
                         type Response = super::PreviousResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PreviousRequest>,
@@ -3838,23 +3270,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FastForwardRewind" => {
                     #[allow(non_camel_case_types)]
                     struct FastForwardRewindSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::FastForwardRewindRequest>
-                    for FastForwardRewindSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::FastForwardRewindRequest>
+                        for FastForwardRewindSvc<T>
+                    {
                         type Response = super::FastForwardRewindResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FastForwardRewindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::fast_forward_rewind(&inner, request)
-                                    .await
+                                <T as PlaybackService>::fast_forward_rewind(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3884,15 +3312,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/Status" => {
                     #[allow(non_camel_case_types)]
                     struct StatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::StatusRequest>
-                    for StatusSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::StatusRequest> for StatusSvc<T> {
                         type Response = super::StatusResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
@@ -3929,15 +3351,11 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/CurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct CurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::CurrentTrackRequest>
-                    for CurrentTrackSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::CurrentTrackRequest>
+                        for CurrentTrackSvc<T>
+                    {
                         type Response = super::CurrentTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CurrentTrackRequest>,
@@ -3974,15 +3392,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/NextTrack" => {
                     #[allow(non_camel_case_types)]
                     struct NextTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::NextTrackRequest>
-                    for NextTrackSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::NextTrackRequest> for NextTrackSvc<T> {
                         type Response = super::NextTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NextTrackRequest>,
@@ -4019,25 +3431,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/FlushAndReloadTracks" => {
                     #[allow(non_camel_case_types)]
                     struct FlushAndReloadTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
-                    for FlushAndReloadTracksSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::FlushAndReloadTracksRequest>
+                        for FlushAndReloadTracksSvc<T>
+                    {
                         type Response = super::FlushAndReloadTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FlushAndReloadTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::flush_and_reload_tracks(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as PlaybackService>::flush_and_reload_tracks(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -4068,23 +3474,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/GetFilePosition" => {
                     #[allow(non_camel_case_types)]
                     struct GetFilePositionSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::GetFilePositionRequest>
-                    for GetFilePositionSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::GetFilePositionRequest>
+                        for GetFilePositionSvc<T>
+                    {
                         type Response = super::GetFilePositionResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFilePositionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::get_file_position(&inner, request)
-                                    .await
+                                <T as PlaybackService>::get_file_position(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4114,15 +3516,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/HardStop" => {
                     #[allow(non_camel_case_types)]
                     struct HardStopSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::HardStopRequest>
-                    for HardStopSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::HardStopRequest> for HardStopSvc<T> {
                         type Response = super::HardStopResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::HardStopRequest>,
@@ -4159,15 +3555,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAlbumSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayAlbumRequest>
-                    for PlayAlbumSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayAlbumRequest> for PlayAlbumSvc<T> {
                         type Response = super::PlayAlbumResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAlbumRequest>,
@@ -4204,23 +3594,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayArtistTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayArtistTracksRequest>
-                    for PlayArtistTracksSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::PlayArtistTracksRequest>
+                        for PlayArtistTracksSvc<T>
+                    {
                         type Response = super::PlayArtistTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_artist_tracks(&inner, request)
-                                    .await
+                                <T as PlaybackService>::play_artist_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4250,15 +3636,11 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct PlayPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayPlaylistRequest>
-                    for PlayPlaylistSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayPlaylistRequest>
+                        for PlayPlaylistSvc<T>
+                    {
                         type Response = super::PlayPlaylistResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayPlaylistRequest>,
@@ -4295,23 +3677,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayDirectoryRequest>
-                    for PlayDirectorySvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::PlayDirectoryRequest>
+                        for PlayDirectorySvc<T>
+                    {
                         type Response = super::PlayDirectoryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_directory(&inner, request)
-                                    .await
+                                <T as PlaybackService>::play_directory(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4341,26 +3719,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayMusicDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct PlayMusicDirectorySvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
-                    for PlayMusicDirectorySvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::PlayMusicDirectoryRequest>
+                        for PlayMusicDirectorySvc<T>
+                    {
                         type Response = super::PlayMusicDirectoryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayMusicDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_music_directory(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as PlaybackService>::play_music_directory(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4390,15 +3761,9 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayTrack" => {
                     #[allow(non_camel_case_types)]
                     struct PlayTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayTrackRequest>
-                    for PlayTrackSvc<T> {
+                    impl<T: PlaybackService> tonic::server::UnaryService<super::PlayTrackRequest> for PlayTrackSvc<T> {
                         type Response = super::PlayTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayTrackRequest>,
@@ -4435,23 +3800,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayLikedTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayLikedTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayLikedTracksRequest>
-                    for PlayLikedTracksSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::PlayLikedTracksRequest>
+                        for PlayLikedTracksSvc<T>
+                    {
                         type Response = super::PlayLikedTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayLikedTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_liked_tracks(&inner, request)
-                                    .await
+                                <T as PlaybackService>::play_liked_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4481,23 +3842,19 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/PlayAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct PlayAllTracksSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::UnaryService<super::PlayAllTracksRequest>
-                    for PlayAllTracksSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::UnaryService<super::PlayAllTracksRequest>
+                        for PlayAllTracksSvc<T>
+                    {
                         type Response = super::PlayAllTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlayAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::play_all_tracks(&inner, request)
-                                    .await
+                                <T as PlaybackService>::play_all_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4527,28 +3884,21 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamCurrentTrack" => {
                     #[allow(non_camel_case_types)]
                     struct StreamCurrentTrackSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::ServerStreamingService<
-                        super::StreamCurrentTrackRequest,
-                    > for StreamCurrentTrackSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::ServerStreamingService<super::StreamCurrentTrackRequest>
+                        for StreamCurrentTrackSvc<T>
+                    {
                         type Response = super::CurrentTrackResponse;
                         type ResponseStream = T::StreamCurrentTrackStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamCurrentTrackRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_current_track(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as PlaybackService>::stream_current_track(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4578,16 +3928,14 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamStatus" => {
                     #[allow(non_camel_case_types)]
                     struct StreamStatusSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::ServerStreamingService<super::StreamStatusRequest>
-                    for StreamStatusSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::ServerStreamingService<super::StreamStatusRequest>
+                        for StreamStatusSvc<T>
+                    {
                         type Response = super::StatusResponse;
                         type ResponseStream = T::StreamStatusStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamStatusRequest>,
@@ -4624,24 +3972,21 @@ pub mod playback_service_server {
                 "/rockbox.v1alpha1.PlaybackService/StreamPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct StreamPlaylistSvc<T: PlaybackService>(pub Arc<T>);
-                    impl<
-                        T: PlaybackService,
-                    > tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
-                    for StreamPlaylistSvc<T> {
+                    impl<T: PlaybackService>
+                        tonic::server::ServerStreamingService<super::StreamPlaylistRequest>
+                        for StreamPlaylistSvc<T>
+                    {
                         type Response = super::PlaylistResponse;
                         type ResponseStream = T::StreamPlaylistStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StreamPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaybackService>::stream_playlist(&inner, request)
-                                    .await
+                                <T as PlaybackService>::stream_playlist(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -4668,23 +4013,19 @@ pub mod playback_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -4891,10 +4232,10 @@ pub mod playlist_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct PlaylistServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -4938,9 +4279,8 @@ pub mod playlist_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             PlaylistServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -4978,251 +4318,182 @@ pub mod playlist_service_client {
         pub async fn get_current(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCurrentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCurrentResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetCurrent"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "GetCurrent",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_resume_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetResumeInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetResumeInfo"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "GetResumeInfo",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_track_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetTrackInfo"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "GetTrackInfo",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_first_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetFirstIndexResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "GetFirstIndex"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "GetFirstIndex",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_display_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDisplayIndexResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaylistService",
-                        "GetDisplayIndex",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "GetDisplayIndex",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn amount(
             &mut self,
             request: impl tonic::IntoRequest<super::AmountRequest>,
         ) -> std::result::Result<tonic::Response<super::AmountResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaylistService/Amount",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Amount");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Amount"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "Amount",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn playlist_resume(
             &mut self,
             request: impl tonic::IntoRequest<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlaylistResumeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "PlaylistResume"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "PlaylistResume",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn resume_track(
             &mut self,
             request: impl tonic::IntoRequest<super::ResumeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResumeTrackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "ResumeTrack"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "ResumeTrack",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn set_modified(
             &mut self,
             request: impl tonic::IntoRequest<super::SetModifiedRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SetModifiedResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/SetModified",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "SetModified"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "SetModified",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn start(
             &mut self,
             request: impl tonic::IntoRequest<super::StartRequest>,
         ) -> std::result::Result<tonic::Response<super::StartResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaylistService/Start",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Start");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Start"));
@@ -5232,18 +4503,12 @@ pub mod playlist_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SyncRequest>,
         ) -> std::result::Result<tonic::Response<super::SyncResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.PlaylistService/Sync",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.PlaylistService/Sync");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "Sync"));
@@ -5252,247 +4517,172 @@ pub mod playlist_service_client {
         pub async fn remove_all_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RemoveAllTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaylistService",
-                        "RemoveAllTracks",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "RemoveAllTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn remove_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::RemoveTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RemoveTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "RemoveTracks"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "RemoveTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn create_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreatePlaylistResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "CreatePlaylist"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "CreatePlaylist",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertTracks"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "InsertTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_directory(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertDirectoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaylistService",
-                        "InsertDirectory",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "InsertDirectory",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertPlaylistResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertPlaylist"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "InsertPlaylist",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_album(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertAlbumResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.PlaylistService", "InsertAlbum"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "InsertAlbum",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn insert_artist_tracks(
             &mut self,
             request: impl tonic::IntoRequest<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertArtistTracksResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaylistService",
-                        "InsertArtistTracks",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "InsertArtistTracks",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn shuffle_playlist(
             &mut self,
             request: impl tonic::IntoRequest<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ShufflePlaylistResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.PlaylistService",
-                        "ShufflePlaylist",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.PlaylistService",
+                "ShufflePlaylist",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -5504,7 +4694,7 @@ pub mod playlist_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with PlaylistServiceServer.
@@ -5513,38 +4703,23 @@ pub mod playlist_service_server {
         async fn get_current(
             &self,
             request: tonic::Request<super::GetCurrentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetCurrentResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetCurrentResponse>, tonic::Status>;
         async fn get_resume_info(
             &self,
             request: tonic::Request<super::GetResumeInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetResumeInfoResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetResumeInfoResponse>, tonic::Status>;
         async fn get_track_info(
             &self,
             request: tonic::Request<super::GetTrackInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTrackInfoResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetTrackInfoResponse>, tonic::Status>;
         async fn get_first_index(
             &self,
             request: tonic::Request<super::GetFirstIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetFirstIndexResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetFirstIndexResponse>, tonic::Status>;
         async fn get_display_index(
             &self,
             request: tonic::Request<super::GetDisplayIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDisplayIndexResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetDisplayIndexResponse>, tonic::Status>;
         async fn amount(
             &self,
             request: tonic::Request<super::AmountRequest>,
@@ -5552,24 +4727,15 @@ pub mod playlist_service_server {
         async fn playlist_resume(
             &self,
             request: tonic::Request<super::PlaylistResumeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PlaylistResumeResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PlaylistResumeResponse>, tonic::Status>;
         async fn resume_track(
             &self,
             request: tonic::Request<super::ResumeTrackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResumeTrackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResumeTrackResponse>, tonic::Status>;
         async fn set_modified(
             &self,
             request: tonic::Request<super::SetModifiedRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SetModifiedResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SetModifiedResponse>, tonic::Status>;
         async fn start(
             &self,
             request: tonic::Request<super::StartRequest>,
@@ -5581,66 +4747,39 @@ pub mod playlist_service_server {
         async fn remove_all_tracks(
             &self,
             request: tonic::Request<super::RemoveAllTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RemoveAllTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RemoveAllTracksResponse>, tonic::Status>;
         async fn remove_tracks(
             &self,
             request: tonic::Request<super::RemoveTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RemoveTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RemoveTracksResponse>, tonic::Status>;
         async fn create_playlist(
             &self,
             request: tonic::Request<super::CreatePlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreatePlaylistResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreatePlaylistResponse>, tonic::Status>;
         async fn insert_tracks(
             &self,
             request: tonic::Request<super::InsertTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::InsertTracksResponse>, tonic::Status>;
         async fn insert_directory(
             &self,
             request: tonic::Request<super::InsertDirectoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertDirectoryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::InsertDirectoryResponse>, tonic::Status>;
         async fn insert_playlist(
             &self,
             request: tonic::Request<super::InsertPlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertPlaylistResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::InsertPlaylistResponse>, tonic::Status>;
         async fn insert_album(
             &self,
             request: tonic::Request<super::InsertAlbumRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertAlbumResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::InsertAlbumResponse>, tonic::Status>;
         async fn insert_artist_tracks(
             &self,
             request: tonic::Request<super::InsertArtistTracksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InsertArtistTracksResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::InsertArtistTracksResponse>, tonic::Status>;
         async fn shuffle_playlist(
             &self,
             request: tonic::Request<super::ShufflePlaylistRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ShufflePlaylistResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ShufflePlaylistResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct PlaylistServiceServer<T> {
@@ -5663,10 +4802,7 @@ pub mod playlist_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -5721,15 +4857,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct GetCurrentSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::GetCurrentRequest>
-                    for GetCurrentSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetCurrentRequest>
+                        for GetCurrentSvc<T>
+                    {
                         type Response = super::GetCurrentResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetCurrentRequest>,
@@ -5766,23 +4898,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetResumeInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetResumeInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::GetResumeInfoRequest>
-                    for GetResumeInfoSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::GetResumeInfoRequest>
+                        for GetResumeInfoSvc<T>
+                    {
                         type Response = super::GetResumeInfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetResumeInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_resume_info(&inner, request)
-                                    .await
+                                <T as PlaylistService>::get_resume_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -5812,23 +4940,18 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetTrackInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetTrackInfoSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::GetTrackInfoRequest>
-                    for GetTrackInfoSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::GetTrackInfoRequest>
+                        for GetTrackInfoSvc<T>
+                    {
                         type Response = super::GetTrackInfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetTrackInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_track_info(&inner, request)
-                                    .await
+                                <T as PlaylistService>::get_track_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -5858,23 +4981,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetFirstIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetFirstIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::GetFirstIndexRequest>
-                    for GetFirstIndexSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::GetFirstIndexRequest>
+                        for GetFirstIndexSvc<T>
+                    {
                         type Response = super::GetFirstIndexResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetFirstIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_first_index(&inner, request)
-                                    .await
+                                <T as PlaylistService>::get_first_index(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -5904,23 +5023,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/GetDisplayIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetDisplayIndexSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::GetDisplayIndexRequest>
-                    for GetDisplayIndexSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::GetDisplayIndexRequest>
+                        for GetDisplayIndexSvc<T>
+                    {
                         type Response = super::GetDisplayIndexResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetDisplayIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::get_display_index(&inner, request)
-                                    .await
+                                <T as PlaylistService>::get_display_index(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -5950,15 +5065,9 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Amount" => {
                     #[allow(non_camel_case_types)]
                     struct AmountSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::AmountRequest>
-                    for AmountSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::AmountRequest> for AmountSvc<T> {
                         type Response = super::AmountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AmountRequest>,
@@ -5995,23 +5104,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/PlaylistResume" => {
                     #[allow(non_camel_case_types)]
                     struct PlaylistResumeSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::PlaylistResumeRequest>
-                    for PlaylistResumeSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::PlaylistResumeRequest>
+                        for PlaylistResumeSvc<T>
+                    {
                         type Response = super::PlaylistResumeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PlaylistResumeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::playlist_resume(&inner, request)
-                                    .await
+                                <T as PlaylistService>::playlist_resume(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6041,15 +5146,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ResumeTrack" => {
                     #[allow(non_camel_case_types)]
                     struct ResumeTrackSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::ResumeTrackRequest>
-                    for ResumeTrackSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::ResumeTrackRequest>
+                        for ResumeTrackSvc<T>
+                    {
                         type Response = super::ResumeTrackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResumeTrackRequest>,
@@ -6086,15 +5187,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/SetModified" => {
                     #[allow(non_camel_case_types)]
                     struct SetModifiedSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::SetModifiedRequest>
-                    for SetModifiedSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::SetModifiedRequest>
+                        for SetModifiedSvc<T>
+                    {
                         type Response = super::SetModifiedResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetModifiedRequest>,
@@ -6131,22 +5228,16 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Start" => {
                     #[allow(non_camel_case_types)]
                     struct StartSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::StartRequest> for StartSvc<T> {
                         type Response = super::StartResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StartRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PlaylistService>::start(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as PlaylistService>::start(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -6175,22 +5266,16 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/Sync" => {
                     #[allow(non_camel_case_types)]
                     struct SyncSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::SyncRequest> for SyncSvc<T> {
                         type Response = super::SyncResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SyncRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as PlaylistService>::sync(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as PlaylistService>::sync(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -6219,23 +5304,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveAllTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveAllTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::RemoveAllTracksRequest>
-                    for RemoveAllTracksSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::RemoveAllTracksRequest>
+                        for RemoveAllTracksSvc<T>
+                    {
                         type Response = super::RemoveAllTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveAllTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::remove_all_tracks(&inner, request)
-                                    .await
+                                <T as PlaylistService>::remove_all_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6265,15 +5346,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/RemoveTracks" => {
                     #[allow(non_camel_case_types)]
                     struct RemoveTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::RemoveTracksRequest>
-                    for RemoveTracksSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::RemoveTracksRequest>
+                        for RemoveTracksSvc<T>
+                    {
                         type Response = super::RemoveTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemoveTracksRequest>,
@@ -6310,23 +5387,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/CreatePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct CreatePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::CreatePlaylistRequest>
-                    for CreatePlaylistSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::CreatePlaylistRequest>
+                        for CreatePlaylistSvc<T>
+                    {
                         type Response = super::CreatePlaylistResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreatePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::create_playlist(&inner, request)
-                                    .await
+                                <T as PlaylistService>::create_playlist(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6356,15 +5429,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::InsertTracksRequest>
-                    for InsertTracksSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertTracksRequest>
+                        for InsertTracksSvc<T>
+                    {
                         type Response = super::InsertTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertTracksRequest>,
@@ -6401,23 +5470,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertDirectory" => {
                     #[allow(non_camel_case_types)]
                     struct InsertDirectorySvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::InsertDirectoryRequest>
-                    for InsertDirectorySvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::InsertDirectoryRequest>
+                        for InsertDirectorySvc<T>
+                    {
                         type Response = super::InsertDirectoryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertDirectoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_directory(&inner, request)
-                                    .await
+                                <T as PlaylistService>::insert_directory(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6447,23 +5512,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertPlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct InsertPlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::InsertPlaylistRequest>
-                    for InsertPlaylistSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::InsertPlaylistRequest>
+                        for InsertPlaylistSvc<T>
+                    {
                         type Response = super::InsertPlaylistResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertPlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_playlist(&inner, request)
-                                    .await
+                                <T as PlaylistService>::insert_playlist(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6493,15 +5554,11 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertAlbum" => {
                     #[allow(non_camel_case_types)]
                     struct InsertAlbumSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::InsertAlbumRequest>
-                    for InsertAlbumSvc<T> {
+                    impl<T: PlaylistService> tonic::server::UnaryService<super::InsertAlbumRequest>
+                        for InsertAlbumSvc<T>
+                    {
                         type Response = super::InsertAlbumResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertAlbumRequest>,
@@ -6538,26 +5595,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/InsertArtistTracks" => {
                     #[allow(non_camel_case_types)]
                     struct InsertArtistTracksSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::InsertArtistTracksRequest>
-                    for InsertArtistTracksSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::InsertArtistTracksRequest>
+                        for InsertArtistTracksSvc<T>
+                    {
                         type Response = super::InsertArtistTracksResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::InsertArtistTracksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::insert_artist_tracks(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as PlaylistService>::insert_artist_tracks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6587,23 +5637,19 @@ pub mod playlist_service_server {
                 "/rockbox.v1alpha1.PlaylistService/ShufflePlaylist" => {
                     #[allow(non_camel_case_types)]
                     struct ShufflePlaylistSvc<T: PlaylistService>(pub Arc<T>);
-                    impl<
-                        T: PlaylistService,
-                    > tonic::server::UnaryService<super::ShufflePlaylistRequest>
-                    for ShufflePlaylistSvc<T> {
+                    impl<T: PlaylistService>
+                        tonic::server::UnaryService<super::ShufflePlaylistRequest>
+                        for ShufflePlaylistSvc<T>
+                    {
                         type Response = super::ShufflePlaylistResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ShufflePlaylistRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PlaylistService>::shuffle_playlist(&inner, request)
-                                    .await
+                                <T as PlaylistService>::shuffle_playlist(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -6630,23 +5676,19 @@ pub mod playlist_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -7156,10 +6198,10 @@ pub mod settings_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct SettingsServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7203,9 +6245,8 @@ pub mod settings_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SettingsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7243,85 +6284,58 @@ pub mod settings_service_client {
         pub async fn get_settings_list(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSettingsListRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSettingsListResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.SettingsService",
-                        "GetSettingsList",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SettingsService",
+                "GetSettingsList",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGlobalSettingsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.SettingsService",
-                        "GetGlobalSettings",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SettingsService",
+                "GetGlobalSettings",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn save_settings(
             &mut self,
             request: impl tonic::IntoRequest<super::SaveSettingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SaveSettingsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SettingsService/SaveSettings",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SettingsService", "SaveSettings"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SettingsService",
+                "SaveSettings",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -7333,7 +6347,7 @@ pub mod settings_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SettingsServiceServer.
@@ -7342,24 +6356,15 @@ pub mod settings_service_server {
         async fn get_settings_list(
             &self,
             request: tonic::Request<super::GetSettingsListRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetSettingsListResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetSettingsListResponse>, tonic::Status>;
         async fn get_global_settings(
             &self,
             request: tonic::Request<super::GetGlobalSettingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGlobalSettingsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetGlobalSettingsResponse>, tonic::Status>;
         async fn save_settings(
             &self,
             request: tonic::Request<super::SaveSettingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SaveSettingsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SaveSettingsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SettingsServiceServer<T> {
@@ -7382,10 +6387,7 @@ pub mod settings_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -7440,23 +6442,19 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetSettingsList" => {
                     #[allow(non_camel_case_types)]
                     struct GetSettingsListSvc<T: SettingsService>(pub Arc<T>);
-                    impl<
-                        T: SettingsService,
-                    > tonic::server::UnaryService<super::GetSettingsListRequest>
-                    for GetSettingsListSvc<T> {
+                    impl<T: SettingsService>
+                        tonic::server::UnaryService<super::GetSettingsListRequest>
+                        for GetSettingsListSvc<T>
+                    {
                         type Response = super::GetSettingsListResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSettingsListRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_settings_list(&inner, request)
-                                    .await
+                                <T as SettingsService>::get_settings_list(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -7486,23 +6484,19 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/GetGlobalSettings" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<
-                        T: SettingsService,
-                    > tonic::server::UnaryService<super::GetGlobalSettingsRequest>
-                    for GetGlobalSettingsSvc<T> {
+                    impl<T: SettingsService>
+                        tonic::server::UnaryService<super::GetGlobalSettingsRequest>
+                        for GetGlobalSettingsSvc<T>
+                    {
                         type Response = super::GetGlobalSettingsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalSettingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SettingsService>::get_global_settings(&inner, request)
-                                    .await
+                                <T as SettingsService>::get_global_settings(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -7532,15 +6526,11 @@ pub mod settings_service_server {
                 "/rockbox.v1alpha1.SettingsService/SaveSettings" => {
                     #[allow(non_camel_case_types)]
                     struct SaveSettingsSvc<T: SettingsService>(pub Arc<T>);
-                    impl<
-                        T: SettingsService,
-                    > tonic::server::UnaryService<super::SaveSettingsRequest>
-                    for SaveSettingsSvc<T> {
+                    impl<T: SettingsService> tonic::server::UnaryService<super::SaveSettingsRequest>
+                        for SaveSettingsSvc<T>
+                    {
                         type Response = super::SaveSettingsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SaveSettingsRequest>,
@@ -7574,23 +6564,19 @@ pub mod settings_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -7748,10 +6734,10 @@ pub mod sound_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct SoundServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -7795,9 +6781,8 @@ pub mod sound_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SoundServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -7835,48 +6820,31 @@ pub mod sound_service_client {
         pub async fn adjust_volume(
             &mut self,
             request: impl tonic::IntoRequest<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::AdjustVolumeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/AdjustVolume",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/AdjustVolume");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "AdjustVolume"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "AdjustVolume",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_set(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundSetRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundSetResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundSet",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundSet");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundSet"));
@@ -7885,74 +6853,49 @@ pub mod sound_service_client {
         pub async fn sound_current(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundCurrentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundCurrentResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundCurrent",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundCurrent");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundCurrent"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "SoundCurrent",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_default(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundDefaultRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundDefaultResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundDefault",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundDefault");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundDefault"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "SoundDefault",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_min(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMinRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundMinResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundMin",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMin");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMin"));
@@ -7961,22 +6904,13 @@ pub mod sound_service_client {
         pub async fn sound_max(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundMaxRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundMaxResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundMax",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundMax");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundMax"));
@@ -7985,72 +6919,49 @@ pub mod sound_service_client {
         pub async fn sound_unit(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundUnitRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundUnitResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SoundUnit",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SoundUnit");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundUnit"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "SoundUnit",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sound_val2_phys(
             &mut self,
             request: impl tonic::IntoRequest<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundVal2PhysResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SoundVal2Phys"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "SoundVal2Phys",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPitchRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPitchResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/GetPitch",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/GetPitch");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "GetPitch"));
@@ -8059,22 +6970,13 @@ pub mod sound_service_client {
         pub async fn set_pitch(
             &mut self,
             request: impl tonic::IntoRequest<super::SetPitchRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SetPitchResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/SetPitch",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/SetPitch");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "SetPitch"));
@@ -8083,22 +6985,13 @@ pub mod sound_service_client {
         pub async fn beep_play(
             &mut self,
             request: impl tonic::IntoRequest<super::BeepPlayRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::BeepPlayResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/BeepPlay",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/BeepPlay");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "BeepPlay"));
@@ -8107,106 +7000,76 @@ pub mod sound_service_client {
         pub async fn pcmbuf_fade(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PcmbufFadeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rockbox.v1alpha1.SoundService/PcmbufFade",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/rockbox.v1alpha1.SoundService/PcmbufFade");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rockbox.v1alpha1.SoundService", "PcmbufFade"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "PcmbufFade",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn pcmbuf_set_low_latency(
             &mut self,
             request: impl tonic::IntoRequest<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PcmbufSetLowLatencyResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.SoundService",
-                        "PcmbufSetLowLatency",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "PcmbufSetLowLatency",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn system_sound_play(
             &mut self,
             request: impl tonic::IntoRequest<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SystemSoundPlayResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "SystemSoundPlay"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "SystemSoundPlay",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn keyclick_click(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyclickClickRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::KeyclickClickResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SoundService/KeyclickClick",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SoundService", "KeyclickClick"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SoundService",
+                "KeyclickClick",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -8218,7 +7081,7 @@ pub mod sound_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SoundServiceServer.
@@ -8227,108 +7090,63 @@ pub mod sound_service_server {
         async fn adjust_volume(
             &self,
             request: tonic::Request<super::AdjustVolumeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::AdjustVolumeResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::AdjustVolumeResponse>, tonic::Status>;
         async fn sound_set(
             &self,
             request: tonic::Request<super::SoundSetRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundSetResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundSetResponse>, tonic::Status>;
         async fn sound_current(
             &self,
             request: tonic::Request<super::SoundCurrentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundCurrentResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundCurrentResponse>, tonic::Status>;
         async fn sound_default(
             &self,
             request: tonic::Request<super::SoundDefaultRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundDefaultResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundDefaultResponse>, tonic::Status>;
         async fn sound_min(
             &self,
             request: tonic::Request<super::SoundMinRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundMinResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundMinResponse>, tonic::Status>;
         async fn sound_max(
             &self,
             request: tonic::Request<super::SoundMaxRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundMaxResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundMaxResponse>, tonic::Status>;
         async fn sound_unit(
             &self,
             request: tonic::Request<super::SoundUnitRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundUnitResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundUnitResponse>, tonic::Status>;
         async fn sound_val2_phys(
             &self,
             request: tonic::Request<super::SoundVal2PhysRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SoundVal2PhysResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SoundVal2PhysResponse>, tonic::Status>;
         async fn get_pitch(
             &self,
             request: tonic::Request<super::GetPitchRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetPitchResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetPitchResponse>, tonic::Status>;
         async fn set_pitch(
             &self,
             request: tonic::Request<super::SetPitchRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SetPitchResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SetPitchResponse>, tonic::Status>;
         async fn beep_play(
             &self,
             request: tonic::Request<super::BeepPlayRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::BeepPlayResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::BeepPlayResponse>, tonic::Status>;
         async fn pcmbuf_fade(
             &self,
             request: tonic::Request<super::PcmbufFadeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PcmbufFadeResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PcmbufFadeResponse>, tonic::Status>;
         async fn pcmbuf_set_low_latency(
             &self,
             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::PcmbufSetLowLatencyResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::PcmbufSetLowLatencyResponse>, tonic::Status>;
         async fn system_sound_play(
             &self,
             request: tonic::Request<super::SystemSoundPlayRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SystemSoundPlayResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::SystemSoundPlayResponse>, tonic::Status>;
         async fn keyclick_click(
             &self,
             request: tonic::Request<super::KeyclickClickRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::KeyclickClickResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::KeyclickClickResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SoundServiceServer<T> {
@@ -8351,10 +7169,7 @@ pub mod sound_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -8409,15 +7224,11 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/AdjustVolume" => {
                     #[allow(non_camel_case_types)]
                     struct AdjustVolumeSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::AdjustVolumeRequest>
-                    for AdjustVolumeSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::AdjustVolumeRequest>
+                        for AdjustVolumeSvc<T>
+                    {
                         type Response = super::AdjustVolumeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AdjustVolumeRequest>,
@@ -8454,15 +7265,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundSet" => {
                     #[allow(non_camel_case_types)]
                     struct SoundSetSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundSetRequest>
-                    for SoundSetSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundSetRequest> for SoundSetSvc<T> {
                         type Response = super::SoundSetResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundSetRequest>,
@@ -8499,15 +7304,11 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundCurrent" => {
                     #[allow(non_camel_case_types)]
                     struct SoundCurrentSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundCurrentRequest>
-                    for SoundCurrentSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundCurrentRequest>
+                        for SoundCurrentSvc<T>
+                    {
                         type Response = super::SoundCurrentResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundCurrentRequest>,
@@ -8544,15 +7345,11 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundDefault" => {
                     #[allow(non_camel_case_types)]
                     struct SoundDefaultSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundDefaultRequest>
-                    for SoundDefaultSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundDefaultRequest>
+                        for SoundDefaultSvc<T>
+                    {
                         type Response = super::SoundDefaultResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundDefaultRequest>,
@@ -8589,15 +7386,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMin" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMinSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundMinRequest>
-                    for SoundMinSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMinRequest> for SoundMinSvc<T> {
                         type Response = super::SoundMinResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMinRequest>,
@@ -8634,15 +7425,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundMax" => {
                     #[allow(non_camel_case_types)]
                     struct SoundMaxSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundMaxRequest>
-                    for SoundMaxSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundMaxRequest> for SoundMaxSvc<T> {
                         type Response = super::SoundMaxResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundMaxRequest>,
@@ -8679,15 +7464,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundUnit" => {
                     #[allow(non_camel_case_types)]
                     struct SoundUnitSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundUnitRequest>
-                    for SoundUnitSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundUnitRequest> for SoundUnitSvc<T> {
                         type Response = super::SoundUnitResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundUnitRequest>,
@@ -8724,15 +7503,11 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SoundVal2Phys" => {
                     #[allow(non_camel_case_types)]
                     struct SoundVal2PhysSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SoundVal2PhysRequest>
-                    for SoundVal2PhysSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SoundVal2PhysRequest>
+                        for SoundVal2PhysSvc<T>
+                    {
                         type Response = super::SoundVal2PhysResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SoundVal2PhysRequest>,
@@ -8769,15 +7544,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/GetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct GetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::GetPitchRequest>
-                    for GetPitchSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::GetPitchRequest> for GetPitchSvc<T> {
                         type Response = super::GetPitchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetPitchRequest>,
@@ -8814,15 +7583,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SetPitch" => {
                     #[allow(non_camel_case_types)]
                     struct SetPitchSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SetPitchRequest>
-                    for SetPitchSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SetPitchRequest> for SetPitchSvc<T> {
                         type Response = super::SetPitchResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SetPitchRequest>,
@@ -8859,15 +7622,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/BeepPlay" => {
                     #[allow(non_camel_case_types)]
                     struct BeepPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::BeepPlayRequest>
-                    for BeepPlaySvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::BeepPlayRequest> for BeepPlaySvc<T> {
                         type Response = super::BeepPlayResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BeepPlayRequest>,
@@ -8904,15 +7661,9 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufFade" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufFadeSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::PcmbufFadeRequest>
-                    for PcmbufFadeSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::PcmbufFadeRequest> for PcmbufFadeSvc<T> {
                         type Response = super::PcmbufFadeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufFadeRequest>,
@@ -8949,23 +7700,19 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/PcmbufSetLowLatency" => {
                     #[allow(non_camel_case_types)]
                     struct PcmbufSetLowLatencySvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
-                    for PcmbufSetLowLatencySvc<T> {
+                    impl<T: SoundService>
+                        tonic::server::UnaryService<super::PcmbufSetLowLatencyRequest>
+                        for PcmbufSetLowLatencySvc<T>
+                    {
                         type Response = super::PcmbufSetLowLatencyResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PcmbufSetLowLatencyRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request)
-                                    .await
+                                <T as SoundService>::pcmbuf_set_low_latency(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -8995,23 +7742,18 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/SystemSoundPlay" => {
                     #[allow(non_camel_case_types)]
                     struct SystemSoundPlaySvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::SystemSoundPlayRequest>
-                    for SystemSoundPlaySvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::SystemSoundPlayRequest>
+                        for SystemSoundPlaySvc<T>
+                    {
                         type Response = super::SystemSoundPlayResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SystemSoundPlayRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SoundService>::system_sound_play(&inner, request)
-                                    .await
+                                <T as SoundService>::system_sound_play(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -9041,15 +7783,11 @@ pub mod sound_service_server {
                 "/rockbox.v1alpha1.SoundService/KeyclickClick" => {
                     #[allow(non_camel_case_types)]
                     struct KeyclickClickSvc<T: SoundService>(pub Arc<T>);
-                    impl<
-                        T: SoundService,
-                    > tonic::server::UnaryService<super::KeyclickClickRequest>
-                    for KeyclickClickSvc<T> {
+                    impl<T: SoundService> tonic::server::UnaryService<super::KeyclickClickRequest>
+                        for KeyclickClickSvc<T>
+                    {
                         type Response = super::KeyclickClickResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::KeyclickClickRequest>,
@@ -9083,23 +7821,19 @@ pub mod sound_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -9160,10 +7894,10 @@ pub mod system_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct SystemServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -9207,9 +7941,8 @@ pub mod system_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SystemServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -9247,56 +7980,39 @@ pub mod system_service_client {
         pub async fn get_rockbox_version(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetRockboxVersionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "rockbox.v1alpha1.SystemService",
-                        "GetRockboxVersion",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SystemService",
+                "GetRockboxVersion",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_global_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGlobalStatusResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("rockbox.v1alpha1.SystemService", "GetGlobalStatus"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rockbox.v1alpha1.SystemService",
+                "GetGlobalStatus",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -9308,7 +8024,7 @@ pub mod system_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SystemServiceServer.
@@ -9317,17 +8033,11 @@ pub mod system_service_server {
         async fn get_rockbox_version(
             &self,
             request: tonic::Request<super::GetRockboxVersionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetRockboxVersionResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetRockboxVersionResponse>, tonic::Status>;
         async fn get_global_status(
             &self,
             request: tonic::Request<super::GetGlobalStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetGlobalStatusResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetGlobalStatusResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SystemServiceServer<T> {
@@ -9350,10 +8060,7 @@ pub mod system_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -9408,23 +8115,19 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetRockboxVersion" => {
                     #[allow(non_camel_case_types)]
                     struct GetRockboxVersionSvc<T: SystemService>(pub Arc<T>);
-                    impl<
-                        T: SystemService,
-                    > tonic::server::UnaryService<super::GetRockboxVersionRequest>
-                    for GetRockboxVersionSvc<T> {
+                    impl<T: SystemService>
+                        tonic::server::UnaryService<super::GetRockboxVersionRequest>
+                        for GetRockboxVersionSvc<T>
+                    {
                         type Response = super::GetRockboxVersionResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRockboxVersionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_rockbox_version(&inner, request)
-                                    .await
+                                <T as SystemService>::get_rockbox_version(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -9454,23 +8157,19 @@ pub mod system_service_server {
                 "/rockbox.v1alpha1.SystemService/GetGlobalStatus" => {
                     #[allow(non_camel_case_types)]
                     struct GetGlobalStatusSvc<T: SystemService>(pub Arc<T>);
-                    impl<
-                        T: SystemService,
-                    > tonic::server::UnaryService<super::GetGlobalStatusRequest>
-                    for GetGlobalStatusSvc<T> {
+                    impl<T: SystemService>
+                        tonic::server::UnaryService<super::GetGlobalStatusRequest>
+                        for GetGlobalStatusSvc<T>
+                    {
                         type Response = super::GetGlobalStatusResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetGlobalStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SystemService>::get_global_status(&inner, request)
-                                    .await
+                                <T as SystemService>::get_global_status(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -9497,23 +8196,19 @@ pub mod system_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }

--- a/firmware/SOURCES
+++ b/firmware/SOURCES
@@ -2143,6 +2143,8 @@ kernel/semaphore.c
 #endif
 #ifdef HAVE_SDL_THREADS
 target/hosted/sdl/thread-sdl.c
+#elif defined(HAVE_POSIX_THREADS)
+target/hosted/headless/thread-posix.c
 #elif !defined(CTRU)
 kernel/thread.c
 #endif

--- a/firmware/asm/thread.c
+++ b/firmware/asm/thread.c
@@ -1,6 +1,9 @@
   /* First some generic implementations */
 #if defined(HAVE_WIN32_FIBER_THREADS)
   #include "thread-win32.c"
+#elif defined(HAVE_POSIX_THREADS)
+  /* thread-posix.c is compiled as a separate TU (listed in SOURCES);
+   * nothing extra to include here. */
 #elif defined(HAVE_SIGALTSTACK_THREADS)
   #include "thread-unix.c"
 

--- a/firmware/kernel/include/thread.h
+++ b/firmware/kernel/include/thread.h
@@ -89,11 +89,12 @@ struct thread_entry;
  *
  * simulator (possibly) doesn't simulate stack usage anyway but well ... */
 
-#if defined(HAVE_SDL_THREADS) || defined(__PCTOOL__) || defined(CTRU)
+#if defined(HAVE_SDL_THREADS) || defined(HAVE_POSIX_THREADS) || \
+    defined(__PCTOOL__) || defined(CTRU)
 #define DEFAULT_STACK_SIZE 0x100 /* tiny, ignored anyway */
 #else
 #include "asm/thread.h"
-#endif /* HAVE_SDL_THREADS */
+#endif /* HAVE_SDL_THREADS || HAVE_POSIX_THREADS */
 
 extern void yield(void);
 extern unsigned sleep(unsigned ticks);

--- a/firmware/kernel/thread-common.c
+++ b/firmware/kernel/thread-common.c
@@ -231,7 +231,7 @@ void format_thread_name(char *buf, size_t bufsize,
     snprintf(buf, bufsize, fmt, name, thread->id);
 }
 
-#if !defined(HAVE_SDL_THREADS) && !defined(CTRU)
+#if !defined(HAVE_SDL_THREADS) && !defined(HAVE_POSIX_THREADS) && !defined(CTRU)
 /*---------------------------------------------------------------------------
  * Returns the maximum percentage of the stack ever used during runtime.
  *---------------------------------------------------------------------------
@@ -252,7 +252,7 @@ static unsigned int stack_usage(uintptr_t *stackptr, size_t stack_size)
 
     return usage;
 }
-#endif /* !defined(HAVE_SDL_THREADS) && !defined(CTRU) */
+#endif /* !defined(HAVE_SDL_THREADS) && !defined(HAVE_POSIX_THREADS) && !defined(CTRU) */
 
 #if NUM_CORES > 1
 int core_get_debug_info(unsigned int core, struct core_debug_info *infop)
@@ -304,7 +304,7 @@ int thread_get_debug_info(unsigned int thread_id,
 #ifdef HAVE_SCHEDULER_BOOSTCTRL
         cpu_boost = thread->cpu_boost;
 #endif
-#if !defined(HAVE_SDL_THREADS) && !defined(CTRU)
+#if !defined(HAVE_SDL_THREADS) && !defined(HAVE_POSIX_THREADS) && !defined(CTRU)
         infop->stack_usage = stack_usage(thread->stack, thread->stack_size);
 
         size_t stack_used_current =

--- a/firmware/kernel/thread-internal.h
+++ b/firmware/kernel/thread-internal.h
@@ -32,7 +32,8 @@
  *
  * simulator (possibly) doesn't simulate stack usage anyway but well ... */
 
-#if defined(HAVE_SDL_THREADS) || defined(__PCTOOL__) || defined(CTRU)
+#if defined(HAVE_SDL_THREADS) || defined(HAVE_POSIX_THREADS) || \
+    defined(__PCTOOL__) || defined(CTRU)
 struct regs
 {
     void *t;             /* OS thread */
@@ -44,7 +45,7 @@ struct regs
 #define DEFAULT_STACK_SIZE 0x100 /* tiny, ignored anyway */
 #else
 #include "asm/thread.h"
-#endif /* HAVE_SDL_THREADS */
+#endif /* HAVE_SDL_THREADS || HAVE_POSIX_THREADS */
 
 /* NOTE: The use of the word "queue" may also refer to a linked list of
    threads being maintained that are normally dealt with in FIFO order

--- a/firmware/target/hosted/headless/thread-posix.c
+++ b/firmware/target/hosted/headless/thread-posix.c
@@ -1,0 +1,389 @@
+/* firmware/target/hosted/headless/thread-posix.c
+ *
+ * Cooperative Rockbox thread scheduler using POSIX pthreads.
+ * Replaces the HAVE_SIGALTSTACK_THREADS backend for the headless host.
+ *
+ * One OS pthread is created per Rockbox thread.  A single global mutex
+ * (g_mutex) enforces cooperative execution: only one Rockbox thread holds
+ * the mutex at a time.  All blocking/sleeping releases g_mutex and waits on
+ * a per-thread counting semaphore, then re-acquires g_mutex on wake-up.
+ *
+ * Why this exists: macOS 12 Monterey x86_64 returns EPERM from sigaltstack()
+ * inside make_context(), causing an infinite retry loop.  This backend avoids
+ * that syscall entirely and works identically on Monterey x86_64, Sequoia
+ * arm64, and Linux.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <setjmp.h>
+#include <time.h>
+#include <errno.h>
+#include <pthread.h>
+
+/* Pull in struct thread_entry, thread_alloc/free, wait_queue_*, block_thread,
+ * THREAD_ID_SLOT, MAXTHREADS, __running_self_entry, and the rest of the
+ * kernel scheduler interface.  The path "../kernel-internal.h" resolves to
+ * firmware/kernel/kernel-internal.h via -I$(FIRMDIR)/kernel/include. */
+#include "../kernel-internal.h"
+#include "core_alloc.h"
+#include "panic.h"
+#include "debug.h"
+
+/* ── Counting semaphore ──────────────────────────────────────────────────────
+ *
+ * sem_init() is deprecated on macOS; named semaphores need boilerplate.
+ * A mutex+condvar pair is portable and avoids both issues.
+ */
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t  cond;
+    int             count;
+} posix_sem_t;
+
+static posix_sem_t *psem_create(int initial)
+{
+    posix_sem_t *s = malloc(sizeof(posix_sem_t));
+    if (!s) return NULL;
+    pthread_mutex_init(&s->mtx, NULL);
+    pthread_cond_init(&s->cond, NULL);
+    s->count = initial;
+    return s;
+}
+
+static void psem_destroy(posix_sem_t *s)
+{
+    pthread_cond_destroy(&s->cond);
+    pthread_mutex_destroy(&s->mtx);
+    free(s);
+}
+
+static void psem_wait(posix_sem_t *s)
+{
+    pthread_mutex_lock(&s->mtx);
+    while (s->count == 0)
+        pthread_cond_wait(&s->cond, &s->mtx);
+    s->count--;
+    pthread_mutex_unlock(&s->mtx);
+}
+
+/* Returns 0 on success, ETIMEDOUT on timeout. */
+static int psem_timedwait(posix_sem_t *s, unsigned ms)
+{
+    struct timespec abs;
+    clock_gettime(CLOCK_REALTIME, &abs);
+    abs.tv_sec  += ms / 1000;
+    abs.tv_nsec += (long)(ms % 1000) * 1000000L;
+    if (abs.tv_nsec >= 1000000000L) {
+        abs.tv_sec++;
+        abs.tv_nsec -= 1000000000L;
+    }
+    pthread_mutex_lock(&s->mtx);
+    int rc = 0;
+    while (s->count == 0) {
+        rc = pthread_cond_timedwait(&s->cond, &s->mtx, &abs);
+        if (rc == ETIMEDOUT)
+            break;
+        rc = 0; /* spurious wake — re-check count */
+    }
+    if (rc == 0)
+        s->count--;
+    pthread_mutex_unlock(&s->mtx);
+    return rc;
+}
+
+/* Non-blocking decrement; returns EAGAIN if count was 0. */
+static int psem_trywait(posix_sem_t *s)
+{
+    pthread_mutex_lock(&s->mtx);
+    int rc = (s->count > 0) ? 0 : EAGAIN;
+    if (rc == 0)
+        s->count--;
+    pthread_mutex_unlock(&s->mtx);
+    return rc;
+}
+
+static void psem_post(posix_sem_t *s)
+{
+    pthread_mutex_lock(&s->mtx);
+    s->count++;
+    pthread_cond_signal(&s->cond);
+    pthread_mutex_unlock(&s->mtx);
+}
+
+static int psem_value(posix_sem_t *s)
+{
+    pthread_mutex_lock(&s->mtx);
+    int v = s->count;
+    pthread_mutex_unlock(&s->mtx);
+    return v;
+}
+
+/* ── Global state ─────────────────────────────────────────────────────────── */
+
+static jmp_buf         thread_jmpbufs[MAXTHREADS];
+static pthread_mutex_t g_mutex;
+
+#define THREADS_RUN  0
+#define THREADS_EXIT 1
+static volatile int threads_status = THREADS_RUN;
+
+/* Milliseconds since CLOCK_MONOTONIC epoch — used for sleep alignment. */
+static unsigned long posix_get_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned long)ts.tv_sec * 1000UL +
+           (unsigned long)ts.tv_nsec / 1000000UL;
+}
+
+/* ── Scheduler ────────────────────────────────────────────────────────────── */
+
+void switch_thread(void)
+{
+    struct thread_entry *current = __running_self_entry();
+    enable_irq();
+
+    switch (current->state)
+    {
+    case STATE_RUNNING:
+        pthread_mutex_unlock(&g_mutex);
+        pthread_mutex_lock(&g_mutex);
+        break;
+
+    case STATE_BLOCKED:
+    {
+        posix_sem_t *s = (posix_sem_t *)current->context.s;
+        pthread_mutex_unlock(&g_mutex);
+        psem_wait(s);
+        pthread_mutex_lock(&g_mutex);
+        int oldlevel = disable_irq_save();
+        current->state = STATE_RUNNING;
+        restore_irq(oldlevel);
+        break;
+    }
+
+    case STATE_BLOCKED_W_TMO:
+    {
+        posix_sem_t *s = (posix_sem_t *)current->context.s;
+        pthread_mutex_unlock(&g_mutex);
+        int result = psem_timedwait(s, current->tmo_tick);
+        pthread_mutex_lock(&g_mutex);
+        int oldlevel = disable_irq_save();
+        current->state = STATE_RUNNING;
+        if (result == ETIMEDOUT) {
+            /* Drain any posts that raced with the timeout. */
+            while (psem_value(s) > 0)
+                psem_trywait(s);
+        }
+        restore_irq(oldlevel);
+        break;
+    }
+
+    case STATE_SLEEPING:
+    {
+        posix_sem_t *s = (posix_sem_t *)current->context.s;
+        pthread_mutex_unlock(&g_mutex);
+        psem_timedwait(s, current->tmo_tick);
+        pthread_mutex_lock(&g_mutex);
+        current->state = STATE_RUNNING;
+        break;
+    }
+    }
+
+    __running_self_entry() = current;
+
+    if (threads_status != THREADS_RUN)
+        thread_exit();
+}
+
+void sleep_thread(int ticks)
+{
+    struct thread_entry *current = __running_self_entry();
+    current->state = STATE_SLEEPING;
+    /* Align to next tick boundary — same formula as thread-sdl.c. */
+    int rem = (int)(posix_get_ms() % (1000 / HZ));
+    if (rem < 0) rem = 0;
+    current->tmo_tick = (1000 / HZ) * ticks + ((1000 / HZ) - 1) - rem;
+}
+
+void block_thread_(struct thread_entry *current, int ticks)
+{
+    if (ticks < 0)
+        current->state = STATE_BLOCKED;
+    else {
+        current->state = STATE_BLOCKED_W_TMO;
+        current->tmo_tick = (1000 / HZ) * ticks;
+    }
+    wait_queue_register(current);
+}
+
+unsigned int wakeup_thread_(struct thread_entry *thread)
+{
+    switch (thread->state)
+    {
+    case STATE_BLOCKED:
+    case STATE_BLOCKED_W_TMO:
+        wait_queue_remove(thread);
+        thread->state = STATE_RUNNING;
+        psem_post((posix_sem_t *)thread->context.s);
+        return THREAD_OK;
+    }
+    return THREAD_NONE;
+}
+
+void thread_thaw(unsigned int thread_id)
+{
+    struct thread_entry *thread = __thread_id_entry(thread_id);
+    if (thread->id == thread_id && thread->state == STATE_FROZEN)
+    {
+        thread->state = STATE_RUNNING;
+        psem_post((posix_sem_t *)thread->context.s);
+    }
+}
+
+/* ── Thread lifecycle ─────────────────────────────────────────────────────── */
+
+static void *runthread(void *data)
+{
+    pthread_mutex_lock(&g_mutex);
+
+    struct thread_entry *current = (struct thread_entry *)data;
+    __running_self_entry() = current;
+
+    jmp_buf *jb = &thread_jmpbufs[THREAD_ID_SLOT(current->id)];
+
+    if (setjmp(*jb) == 0)
+    {
+        if (current->state == STATE_FROZEN)
+        {
+            posix_sem_t *s = (posix_sem_t *)current->context.s;
+            pthread_mutex_unlock(&g_mutex);
+            psem_wait(s);
+            pthread_mutex_lock(&g_mutex);
+            __running_self_entry() = current;
+        }
+
+        if (threads_status == THREADS_RUN)
+            current->context.start();
+
+        thread_exit();
+    }
+    else
+    {
+        /* thread_exit() longjmp'd here — release mutex and terminate. */
+        pthread_mutex_unlock(&g_mutex);
+    }
+    return NULL;
+}
+
+unsigned int create_thread(void (*function)(void),
+                           void *stack, size_t stack_size,
+                           unsigned flags, const char *name)
+{
+    struct thread_entry *thread = thread_alloc();
+    if (!thread) {
+        DEBUGF("posix: no free thread slot\n");
+        return 0;
+    }
+
+    posix_sem_t *s = psem_create(0);
+    if (!s) {
+        DEBUGF("posix: semaphore alloc failed\n");
+        return 0;
+    }
+
+    thread->name          = name;
+    thread->state         = (flags & CREATE_THREAD_FROZEN) ?
+                             STATE_FROZEN : STATE_RUNNING;
+    thread->context.start = function;
+    thread->context.s     = s;
+    thread->context.t     = NULL;
+    thread->context.told  = NULL;
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, runthread, thread) != 0) {
+        DEBUGF("posix: pthread_create failed\n");
+        psem_destroy(s);
+        return 0;
+    }
+    pthread_detach(tid);
+
+    /* pthread_t stored as void* — valid on all 64-bit targets we support. */
+    thread->context.t = (void *)(uintptr_t)tid;
+
+    return thread->id;
+    (void)stack; (void)stack_size;
+}
+
+void thread_exit(void)
+{
+    struct thread_entry *current = __running_self_entry();
+    int oldlevel = disable_irq_save();
+
+    posix_sem_t *s = (posix_sem_t *)current->context.s;
+
+    current->context.t    = NULL;
+    current->context.s    = NULL;
+    current->context.told = NULL;
+
+    unsigned int id = current->id;
+    new_thread_id(current);
+    current->state = STATE_KILLED;
+    wait_queue_wake(&current->queue);
+
+    psem_destroy(s);
+    restore_irq(oldlevel);
+    thread_free(current);
+
+    longjmp(thread_jmpbufs[THREAD_ID_SLOT(id)], 1);
+    while (1); /* unreachable */
+}
+
+void thread_wait(unsigned int thread_id)
+{
+    struct thread_entry *current = __running_self_entry();
+    struct thread_entry *thread  = __thread_id_entry(thread_id);
+
+    if (thread->id == thread_id && thread->state != STATE_KILLED)
+    {
+        block_thread(current, TIMEOUT_BLOCK, &thread->queue);
+        switch_thread();
+    }
+}
+
+/* ── Initialisation ───────────────────────────────────────────────────────── */
+
+void init_threads(void)
+{
+    pthread_mutex_init(&g_mutex, NULL);
+    pthread_mutex_lock(&g_mutex);
+
+    thread_alloc_init();
+
+    struct thread_entry *thread = thread_alloc();
+    if (!thread) {
+        fprintf(stderr, "posix: main thread alloc failed\n");
+        return;
+    }
+
+    thread->name         = __main_thread_name;
+    thread->state        = STATE_RUNNING;
+    thread->context.s    = psem_create(0);
+    thread->context.t    = NULL;
+    thread->context.told = NULL;
+    __running_self_entry() = thread;
+
+    if (!thread->context.s) {
+        fprintf(stderr, "posix: main semaphore alloc failed\n");
+        return;
+    }
+
+    /* setjmp here is the exit trampoline: if thread_exit() longjmps here
+     * for the main thread we fall through and exit the process. */
+    if (setjmp(thread_jmpbufs[THREAD_ID_SLOT(thread->id)]) == 0)
+        return; /* normal init path */
+
+    pthread_mutex_unlock(&g_mutex);
+    exit(0);
+}

--- a/gpui/build.rs
+++ b/gpui/build.rs
@@ -1,4 +1,28 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Link the embeddable librockboxd.a produced by `cd zig && zig build lib`.
+    // Must be built before `cargo build` in the gpui workspace.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    println!("cargo:rustc-link-search=native={manifest}/../zig/zig-out/lib");
+    println!("cargo:rustc-link-lib=static=rockboxd");
+    println!("cargo:rerun-if-changed={manifest}/../zig/zig-out/lib/librockboxd.a");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    match target_os.as_str() {
+        "macos" => {
+            println!("cargo:rustc-link-lib=framework=CoreAudio");
+            println!("cargo:rustc-link-lib=framework=AudioUnit");
+            println!("cargo:rustc-link-lib=framework=AudioToolbox");
+            println!("cargo:rustc-link-lib=framework=CoreFoundation");
+            println!("cargo:rustc-link-lib=framework=Security");
+        }
+        "linux" => {
+            println!("cargo:rustc-link-lib=dylib=asound");
+            println!("cargo:rustc-link-lib=dylib=unwind");
+            println!("cargo:rustc-link-lib=dylib=dbus-1");
+        }
+        _ => {}
+    }
+
     tonic_build::configure()
         .out_dir("src/api")
         .file_descriptor_set_path("src/api/rockbox_descriptor.bin")

--- a/gpui/src/startup.rs
+++ b/gpui/src/startup.rs
@@ -1,57 +1,39 @@
 use std::net::TcpStream;
+use std::os::raw::{c_char, c_int};
 use std::time::Duration;
 
 const LOCALHOST_GRPC: &str = "127.0.0.1:6061";
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
-const MDNS_SCAN_TIMEOUT: Duration = Duration::from_secs(3);
 
-#[derive(Clone, Copy, Debug)]
-pub enum StartupError {
-    /// `rockboxd` binary not found anywhere in PATH or common locations.
-    NotInstalled,
-    /// Binary found but no daemon is reachable (localhost or network).
-    NotRunning,
+// C ABI from librockboxd.a (built by `cd zig && zig build lib`).
+extern "C" {
+    pub fn rb_daemon_start(music_dir_ptr: *const c_char, device_name_ptr: *const c_char)
+        -> c_int;
+    pub fn rb_daemon_stop() -> c_int;
+    pub fn rb_daemon_port() -> c_int;
+    pub fn rb_daemon_state() -> c_int;
 }
 
-/// Run all pre-flight checks. Returns `None` when everything is ready.
-///
-/// Priority:
-///   1. localhost:6061 — fastest, no mDNS overhead.
-///   2. mDNS scan — discovers remote instances on the local network (blocks up
-///      to MDNS_SCAN_TIMEOUT); sets the active server via `crate::server::set_server`.
-pub fn check() -> Option<StartupError> {
-    if !is_installed() {
-        return Some(StartupError::NotInstalled);
-    }
-    if is_running() {
-        return None;
-    }
-    let discovered = crate::server::scan_mdns(MDNS_SCAN_TIMEOUT);
-    if let Some(server) = discovered.into_iter().next() {
-        crate::server::set_server(server);
-        return None;
-    }
-    Some(StartupError::NotRunning)
-}
-
-pub fn is_installed() -> bool {
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in path_var.split(':') {
-            if std::path::Path::new(dir).join("rockboxd").exists() {
-                return true;
-            }
-        }
-    }
-    [
-        "/usr/local/bin/rockboxd",
-        "/opt/homebrew/bin/rockboxd",
-        "/usr/bin/rockboxd",
-        "/usr/local/sbin/rockboxd",
-    ]
-    .iter()
-    .any(|p| std::path::Path::new(p).exists())
-}
-
+/// Returns true if gRPC port 6061 is already accepting connections.
 pub fn is_running() -> bool {
     TcpStream::connect_timeout(&LOCALHOST_GRPC.parse().unwrap(), CONNECT_TIMEOUT).is_ok()
+}
+
+/// Ensure the daemon is running.
+///
+/// If port 6061 already responds, returns the port immediately without
+/// starting an embedded daemon (useful when a standalone `rockboxd` or a
+/// remote instance is accessible on localhost).
+///
+/// Otherwise boots the embedded daemon (headless/cpal build) in-process.
+/// Blocks up to 30 s waiting for gRPC to bind, then returns the port
+/// (positive) or a negative error code:
+///   -110  timeout — firmware did not bind within 30 s
+///   -114  already starting / running
+pub fn ensure_running() -> i32 {
+    if is_running() {
+        return 6061;
+    }
+    let device_name = b"Rockbox Desktop\0".as_ptr() as *const c_char;
+    unsafe { rb_daemon_start(std::ptr::null(), device_name) }
 }

--- a/gpui/src/ui/startup_gate.rs
+++ b/gpui/src/ui/startup_gate.rs
@@ -1,199 +1,67 @@
 use crate::controller::Controller;
-use crate::startup::StartupError;
 use crate::state::AppState;
 use crate::ui::rockbox::Rockbox;
 use crate::ui::theme::Theme;
-use gpui::prelude::FluentBuilder;
 use gpui::{
-    actions, div, px, App, AppContext, ClipboardItem, Context, Entity, FontWeight,
-    InteractiveElement, IntoElement, ParentElement, Render, StatefulInteractiveElement, Styled,
-    WeakEntity, Window,
+    div, px, App, AppContext, Context, Entity, FontWeight, IntoElement, ParentElement, Render,
+    Styled, WeakEntity, Window,
 };
 
-actions!(startup, [Retry, Quit]);
-
-/// Which copy button (if any) is currently showing "Copied!".
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum CopiedState {
-    None,
-    Main,
-    Start,
-}
-
 pub struct StartupGate {
-    error: Option<StartupError>,
-    /// Populated once the startup check passes (either initially or on retry).
+    /// Populated once the embedded daemon has started.
     rockbox: Option<Entity<Rockbox>>,
-    /// True while a background retry check is in flight.
-    checking: bool,
-    copied: CopiedState,
+    /// Set if rb_daemon_start() returned a negative code.
+    error: Option<String>,
 }
 
 impl StartupGate {
     pub fn new(cx: &mut Context<Self>) -> Self {
-        match crate::startup::check() {
-            None => Self::boot(cx),
-            Some(error) => StartupGate {
-                error: Some(error),
-                rockbox: None,
-                checking: false,
-                copied: CopiedState::None,
-            },
-        }
-    }
-
-    fn boot(cx: &mut Context<Self>) -> Self {
-        let state = cx.new(|_| AppState::new());
-        let controller = Controller::new(state, cx);
-        cx.set_global(controller);
-        StartupGate {
+        let gate = StartupGate {
+            rockbox: None,
             error: None,
-            rockbox: Some(cx.new(Rockbox::new)),
-            checking: false,
-            copied: CopiedState::None,
-        }
-    }
-
-    fn retry(&mut self, cx: &mut Context<Self>) {
-        if self.checking {
-            return;
-        }
-        self.checking = true;
-        cx.notify();
-
+        };
+        // Check if gRPC is already reachable; if so skip the daemon boot.
+        // Otherwise start the embedded daemon (blocks up to 30 s).
         cx.spawn(async move |this: WeakEntity<StartupGate>, cx| {
             let result = cx
                 .background_executor()
-                .spawn(async { crate::startup::check() })
+                .spawn(async { crate::startup::ensure_running() })
                 .await;
 
             let _ = this.update(cx, |this, cx| {
-                this.checking = false;
-                match result {
-                    None => {
-                        let state = cx.new(|_| AppState::new());
-                        let controller = Controller::new(state, cx);
-                        cx.set_global(controller);
-                        this.rockbox = Some(cx.new(Rockbox::new));
-                        this.error = None;
-                    }
-                    Some(e) => {
-                        this.error = Some(e);
-                    }
+                if result > 0 {
+                    let state = cx.new(|_| AppState::new());
+                    let controller = Controller::new(state, cx);
+                    cx.set_global(controller);
+                    this.rockbox = Some(cx.new(Rockbox::new));
+                } else {
+                    this.error = Some(format!(
+                        "Daemon start failed (code {result}). \
+                         Check that build-headless/ is present and zig build lib has run."
+                    ));
                 }
                 cx.notify();
             });
         })
         .detach();
-    }
-
-    fn copy_command(&mut self, text: &str, which: CopiedState, cx: &mut Context<Self>) {
-        cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
-        self.copied = which;
-        cx.notify();
-        cx.spawn(async move |this: WeakEntity<StartupGate>, cx| {
-            cx.background_executor()
-                .timer(std::time::Duration::from_millis(1500))
-                .await;
-            let _ = this.update(cx, |this, cx| {
-                // Only reset if this button is still the one showing "Copied!"
-                if this.copied == which {
-                    this.copied = CopiedState::None;
-                    cx.notify();
-                }
-            });
-        })
-        .detach();
-    }
-
-    /// Renders a code block row: truncated monospace text + a per-button copy indicator.
-    fn code_block(
-        &self,
-        id: &'static str,
-        text: &'static str,
-        which: CopiedState,
-        theme: Theme,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let is_copied = self.copied == which;
-        div()
-            .w_full()
-            .px(px(14.0))
-            .py(px(10.0))
-            .rounded_lg()
-            .bg(theme.app_bg)
-            .border_1()
-            .border_color(theme.border)
-            .flex()
-            .items_center()
-            .gap_x_3()
-            // Text shrinks to make room for the button
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .truncate()
-                    .text_sm()
-                    .font_family("monospace")
-                    .text_color(gpui::rgb(0xFFFFFF))
-                    .child(text),
-            )
-            // Copy button — fixed width so it never gets squeezed
-            .child(
-                div()
-                    .id(id)
-                    .flex_shrink_0()
-                    .px(px(10.0))
-                    .py(px(4.0))
-                    .rounded_md()
-                    .text_xs()
-                    .font_weight(FontWeight(500.0))
-                    .cursor_pointer()
-                    .text_color(if is_copied {
-                        gpui::rgb(0x6F00FF)
-                    } else {
-                        theme.library_header_text
-                    })
-                    .bg(theme.titlebar_bg)
-                    .border_1()
-                    .border_color(theme.border)
-                    .hover(|this| this.border_color(gpui::rgb(0x6F00FF)))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.copy_command(text, which, cx);
-                    }))
-                    .child(if is_copied { "Copied!" } else { "Copy" }),
-            )
+        gate
     }
 }
 
 impl Render for StartupGate {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // Happy path — render the full app transparently.
+        // Happy path — transparent pass-through once the daemon is up.
         if let Some(rockbox) = &self.rockbox {
             return rockbox.clone().into_any_element();
         }
 
         let theme = *cx.global::<Theme>();
-        let checking = self.checking;
 
-        let (title, subtitle, code) = match self.error {
-            Some(StartupError::NotInstalled) | None => (
-                "rockboxd is not installed",
-                "Install the Rockbox CLI, then start the daemon:",
-                "curl -fsSL https://raw.githubusercontent.com/tsirysndr/rockbox-zig/HEAD/install.sh | bash",
-            ),
-            Some(StartupError::NotRunning) => (
-                "rockboxd is not running",
-                "Start the Rockbox daemon by running:",
-                "rockboxd",
-            ),
+        let (title, subtitle) = if let Some(err) = &self.error {
+            ("Failed to start daemon", err.as_str())
+        } else {
+            ("Starting Rockbox…", "Connecting to audio engine, please wait.")
         };
-
-        let start_hint = matches!(self.error, Some(StartupError::NotInstalled));
-
-        let main_code_block = self.code_block("copy-main-cmd", code, CopiedState::Main, theme, cx);
-        let start_code_block =
-            self.code_block("copy-start-cmd", "rockboxd", CopiedState::Start, theme, cx);
 
         div()
             .size_full()
@@ -203,115 +71,48 @@ impl Render for StartupGate {
             .bg(theme.app_bg)
             .child(
                 div()
-                    .w(px(520.0))
+                    .w(px(440.0))
                     .flex()
                     .flex_col()
-                    .gap_y_5()
+                    .gap_y_4()
                     .p(px(36.0))
                     .rounded_xl()
                     .bg(theme.titlebar_bg)
                     .border_1()
                     .border_color(theme.border)
-                    // Warning header
                     .child(
                         div()
-                            .flex()
-                            .items_center()
-                            .gap_x_3()
-                            .child(
-                                div()
-                                    .w(px(36.0))
-                                    .h(px(36.0))
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .rounded_full()
-                                    .bg(gpui::rgba(0x6F00FF20))
-                                    .text_color(gpui::rgb(0x6F00FF))
-                                    .text_xl()
-                                    .font_weight(FontWeight::BOLD)
-                                    .child("⚠"),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap_y_0p5()
-                                    .child(
-                                        div()
-                                            .text_base()
-                                            .font_weight(FontWeight::BOLD)
-                                            .text_color(theme.library_text)
-                                            .child(title),
-                                    )
-                                    .child(
-                                        div()
-                                            .text_sm()
-                                            .text_color(theme.library_header_text)
-                                            .child(subtitle),
-                                    ),
-                            ),
+                            .text_base()
+                            .font_weight(FontWeight::BOLD)
+                            .text_color(theme.library_text)
+                            .child(title),
                     )
-                    // Main command code block
-                    .child(main_code_block)
-                    // "Then start:" — NotInstalled only
-                    .when(start_hint, |this| {
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(theme.library_header_text)
+                            .child(subtitle),
+                    )
+                    .when(self.error.is_some(), |this| {
                         this.child(
                             div()
-                                .flex()
-                                .flex_col()
-                                .gap_y_2()
-                                .child(
-                                    div()
-                                        .text_sm()
-                                        .text_color(theme.library_header_text)
-                                        .child("Then start the daemon:"),
-                                )
-                                .child(start_code_block),
+                                .id("startup-quit")
+                                .w(px(80.0))
+                                .px_5()
+                                .py_2()
+                                .rounded_lg()
+                                .text_sm()
+                                .font_weight(FontWeight(500.0))
+                                .text_color(theme.library_header_text)
+                                .bg(theme.app_bg)
+                                .border_1()
+                                .border_color(theme.border)
+                                .cursor_pointer()
+                                .hover(|this| this.bg(theme.border))
+                                .on_click(|_, _, cx: &mut App| cx.quit())
+                                .child("Quit"),
                         )
-                    })
-                    // Action buttons
-                    .child(
-                        div()
-                            .flex()
-                            .justify_end()
-                            .gap_x_3()
-                            .child(
-                                div()
-                                    .id("startup-quit")
-                                    .px_5()
-                                    .py_2()
-                                    .rounded_lg()
-                                    .text_sm()
-                                    .font_weight(FontWeight(500.0))
-                                    .text_color(theme.library_header_text)
-                                    .bg(theme.app_bg)
-                                    .border_1()
-                                    .border_color(theme.border)
-                                    .cursor_pointer()
-                                    .hover(|this| this.bg(theme.border))
-                                    .on_click(|_, _, cx: &mut App| cx.quit())
-                                    .child("Quit"),
-                            )
-                            .child(
-                                div()
-                                    .id("startup-retry")
-                                    .px_5()
-                                    .py_2()
-                                    .rounded_lg()
-                                    .text_sm()
-                                    .font_weight(FontWeight(500.0))
-                                    .text_color(gpui::rgb(0xFFFFFF))
-                                    .bg(gpui::rgb(0x6F00FF))
-                                    .cursor_pointer()
-                                    .hover(|this| this.bg(gpui::rgb(0x5A00D6)))
-                                    .when(checking, |this| this.opacity(0.6).cursor_default())
-                                    .on_click(cx.listener(|this, _, _, cx| {
-                                        this.retry(cx);
-                                    }))
-                                    .child(if checking { "Checking…" } else { "Retry" }),
-                            ),
-                    ),
+                    }),
             )
             .into_any_element()
     }

--- a/gpui/src/ui/startup_gate.rs
+++ b/gpui/src/ui/startup_gate.rs
@@ -3,9 +3,10 @@ use crate::state::AppState;
 use crate::ui::rockbox::Rockbox;
 use crate::ui::theme::Theme;
 use gpui::{
-    div, px, App, AppContext, Context, Entity, FontWeight, IntoElement, ParentElement, Render,
-    Styled, WeakEntity, Window,
+    div, px, App, AppContext, Context, Entity, FontWeight, InteractiveElement, IntoElement,
+    ParentElement, Render, StatefulInteractiveElement, Styled, WeakEntity, Window,
 };
+use gpui::prelude::FluentBuilder;
 
 pub struct StartupGate {
     /// Populated once the embedded daemon has started.
@@ -57,10 +58,15 @@ impl Render for StartupGate {
 
         let theme = *cx.global::<Theme>();
 
-        let (title, subtitle) = if let Some(err) = &self.error {
-            ("Failed to start daemon", err.as_str())
+        let title = if self.error.is_some() {
+            "Failed to start daemon"
         } else {
-            ("Starting Rockbox…", "Connecting to audio engine, please wait.")
+            "Starting Rockbox…"
+        };
+        let subtitle: String = if let Some(err) = &self.error {
+            err.clone()
+        } else {
+            "Connecting to audio engine, please wait.".to_string()
         };
 
         div()

--- a/include/rockboxd.h
+++ b/include/rockboxd.h
@@ -1,0 +1,171 @@
+#ifndef ROCKBOXD_H
+#define ROCKBOXD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Daemon lifecycle ─────────────────────────────────────────────────────────
+ *
+ * rb_daemon_start() boots the full Rockbox firmware + gRPC/GraphQL/HTTP/MPD
+ * servers + headless cpal audio sink in-process on a dedicated thread.
+ * It blocks until the gRPC server binds (up to 30 s) then returns.
+ *
+ * Returns: gRPC port (positive) on success, or a negative error code:
+ *   -22   invalid input (null device_name)
+ *   -110  timeout — firmware did not bind within 30 s
+ *   -114  already starting / running
+ *
+ * music_dir_ptr  Path to the music library. Pass NULL to fall back to
+ *                $HOME/Music.
+ * device_name_ptr  Name shown in mDNS advertisements. Must be non-null.
+ * -------------------------------------------------------------------------- */
+int rb_daemon_start(const char *music_dir_ptr, const char *device_name_ptr);
+
+/* Best-effort stop signal. Returns 0 if it was running. */
+int rb_daemon_stop(void);
+
+/* Returns the gRPC port of the running daemon, or 0 if not running. */
+int rb_daemon_port(void);
+
+/* Returns the daemon state: 0 = stopped, 1 = starting, 2 = running. */
+int rb_daemon_state(void);
+
+/* Trigger a full background rescan of the music library. Returns 0 immediately.
+ * Returns -1 if the daemon is not running. */
+int rb_rescan_library(void);
+
+/* ── Memory ───────────────────────────────────────────────────────────────────
+ *
+ * All rb_*_json() functions return heap-allocated NUL-terminated C strings.
+ * The caller MUST free them via rb_free_string(); do NOT use free() directly.
+ * Passing NULL is safe. */
+void rb_free_string(char *ptr);
+
+/* ── Configuration ────────────────────────────────────────────────────────────
+ *
+ * Call before any other rb_* function to override the default localhost URLs.
+ * Defaults: gRPC = http://127.0.0.1:6061, HTTP = http://127.0.0.1:6063 */
+int rb_set_server_url(const char *url_ptr);
+int rb_set_http_url(const char *url_ptr);
+
+/* Health check — returns 0 if the gRPC server responds. */
+int rb_ping(void);
+
+/* ── Playback control ─────────────────────────────────────────────────────────
+ * All return 0 on success, -1 on RPC failure. */
+int rb_play(void);
+int rb_pause(void);
+int rb_play_pause(void);
+int rb_next(void);
+int rb_prev(void);
+int rb_seek(int position_ms);
+int rb_resume_track(void);
+int rb_playlist_resume(void);
+int rb_play_all_tracks(void);
+int rb_shuffle_playlist(void);
+int rb_play_track(const char *path_ptr);
+int rb_play_album(const char *album_id_ptr, int shuffle);
+int rb_play_artist_tracks(const char *artist_id_ptr, int shuffle);
+int rb_play_directory(const char *path_ptr, int shuffle, int position);
+int rb_play_saved_playlist(const char *id_ptr);
+int rb_play_smart_playlist(const char *id_ptr);
+
+/* ── Status (returns JSON, caller must rb_free_string) ────────────────────── */
+char *rb_status_json(void);
+char *rb_current_track_json(void);
+char *rb_get_playlist_current_json(void);
+
+/* ── Queue ─────────────────────────────────────────────────────────────────── */
+int rb_jump_to_queue_position(int pos);
+int rb_insert_tracks(const char *paths_json_ptr, int position, int shuffle);
+int rb_insert_track_next(const char *path_ptr);
+int rb_insert_track_last(const char *path_ptr);
+int rb_insert_directory(const char *path_ptr, int position);
+int rb_remove_from_queue(int position);
+
+/* ── Library (JSON; caller must rb_free_string) ───────────────────────────── */
+char *rb_get_tracks_json(void);
+char *rb_get_artists_json(void);
+char *rb_get_albums_json(void);
+char *rb_get_liked_tracks_json(void);
+char *rb_get_liked_albums_json(void);
+char *rb_get_artist_json(const char *id_ptr);
+char *rb_get_album_json(const char *id_ptr);
+char *rb_search_json(const char *term_ptr);
+
+/* ── Like / unlike ─────────────────────────────────────────────────────────── */
+int rb_like_track(const char *track_id_ptr);
+int rb_unlike_track(const char *track_id_ptr);
+
+/* ── Genres (JSON; caller must rb_free_string) ────────────────────────────── */
+char *rb_get_genres_json(void);
+char *rb_get_genre_json(const char *id_ptr);
+char *rb_get_genre_tracks_json(const char *id_ptr);
+char *rb_get_genre_albums_json(const char *id_ptr);
+char *rb_get_genre_artists_json(const char *id_ptr);
+
+/* ── Sound / settings ─────────────────────────────────────────────────────── */
+int rb_adjust_volume(int steps);
+char *rb_sound_current_json(int setting);
+int rb_save_shuffle(int enabled);
+int rb_save_repeat(int repeat_mode);
+char *rb_get_global_settings_json(void);
+char *rb_get_global_status_json(void);
+
+/* ── Browse ─────────────────────────────────────────────────────────────────
+ * path_ptr may be NULL to fetch the music root. */
+char *rb_tree_get_entries_json(const char *path_ptr);
+
+/* ── Saved / smart playlists (JSON; caller must rb_free_string) ───────────── */
+char *rb_get_saved_playlists_json(void);
+int rb_create_saved_playlist(const char *name_ptr, const char *description_ptr,
+                              const char *track_ids_json_ptr);
+int rb_update_saved_playlist(const char *id_ptr, const char *name_ptr,
+                              const char *description_ptr);
+int rb_delete_saved_playlist(const char *id_ptr);
+int rb_add_track_to_playlist(const char *playlist_id_ptr, const char *track_id_ptr);
+int rb_remove_track_from_playlist(const char *playlist_id_ptr, const char *track_id_ptr);
+char *rb_get_saved_playlist_tracks_json(const char *id_ptr);
+char *rb_get_smart_playlists_json(void);
+char *rb_get_smart_playlist_tracks_json(const char *id_ptr);
+
+/* ── Devices (Chromecast / AirPlay / Snapcast via HTTP REST) ─────────────── */
+char *rb_get_devices_json(void);
+int rb_connect_device(const char *id_ptr);
+int rb_disconnect_device(const char *id_ptr);
+
+/* ── Bluetooth ──────────────────────────────────────────────────────────────
+ * Returns 1 if the Bluetooth service is available, 0 otherwise. */
+int rb_scan_bluetooth(void);
+int rb_bluetooth_available(void);
+char *rb_get_bluetooth_devices_json(void);
+int rb_connect_bluetooth(const char *addr_ptr);
+int rb_disconnect_bluetooth(const char *addr_ptr);
+
+/* ── Streaming subscriptions ─────────────────────────────────────────────────
+ *
+ * Each rb_subscribe_*() call spawns a background task that drains the
+ * corresponding server-streaming RPC into an internal queue, and returns an
+ * opaque subscription id (positive integer).
+ *
+ * Call rb_poll_event(id, timeout_ms) in a loop to receive events as JSON
+ * C strings (free each with rb_free_string). Returns NULL on timeout.
+ *
+ * Call rb_unsubscribe(id) to cancel and free the subscription. */
+int rb_subscribe_status(void);
+int rb_subscribe_current_track(void);
+int rb_subscribe_playlist(void);
+int rb_subscribe_library(void);
+int rb_subscribe_discovery(const char *service_name_ptr);
+char *rb_poll_event(int sub_id, int timeout_ms);
+int rb_unsubscribe(int sub_id);
+
+/* Well-known mDNS service names (heap strings; free with rb_free_string). */
+char *rb_rockbox_service_name(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ROCKBOXD_H */

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,27 @@
+# Memory Index
+
+- [Project: HTTP stream playback](project_http_streaming.md) — rockbox-zig branch `copilot/add-http-stream-playback-support`; fixes to metadata parsers and netstream crate for HTTP(S) playback
+- [Feedback: stale binary caused silent failures](feedback_stale_binary.md) — always rebuild `target/release/rockbox` after changing C/Rust code; `librockbox.a` relink does not happen automatically
+- [Project: Snapcast FIFO audio output](project_snapcast_fifo.md) — pcm-fifo sink setup, startup order, snapserver config workaround for macOS
+- [Feedback: use tracing for logging](feedback_tracing_logging.md) — never use eprintln!/println! in Rust; always use tracing::debug/info/warn/error
+- [Project: Squeezelite PCM sink](project_squeezelite_sink.md) — squeezelite output via Slim Protocol TCP + HTTP PCM stream; crates/slim/, PCM_SINK_SQUEEZELITE=3, key bugs: tv_nsec overflow, HTTP kick loop, 36s watchdog
+- [Feedback: Slim Protocol keepalive required](feedback_slim_keepalive.md) — send audg on every STMt heartbeat or squeezelite disconnects after 36s; full-volume audg is 9 bytes
+- [Project: GPUI context menu positioning pattern](project_gpui_context_menu_pattern.md) — context menus must be rendered at LibraryPage root div level, not inside nested entities like FilesView
+- [Project: Expo mobile app](project_expo_app.md) — rockbox-zig/expo React Native + NativeWind client mirroring the GPUI desktop UI, mock data today
+- [Feedback: Expo app — always use NativeWind, no inline styles](feedback_expo_nativewind.md) — className-only styling rule; never combine function `style` with `className`
+- [Project: Expo module — symmetric peer](project_expo_dual_mode.md) — phone runs full embedded rockboxd (firmware + codecs + gRPC/GraphQL/HTTP/MPD servers + AAudio sink + mDNS advertise) AND keeps the tonic LAN client to control other peers
+- [Feedback: Android embedded daemon — always FTS5, never typesense](feedback_android_fts5.md) — search backend on Android cdylib must use the `fts5` Cargo feature; no typesense subprocess
+- [Project: Codec loading — desktop dlopen vs Android static-link](project_codec_loading.md) — `.codec` files are dlopen'd `.so`/`.dylib` on desktop; Android blocks dlopen from app dirs so codecs must be statically linked into the cdylib (the model Rockbox hardware targets already use)
+- [Project: Android codecs use BINFMT_STATIC](project_codecs_static_binfmt.md) — concrete plan: add 3rd CONFIG_BINFMT value + CODECS_STATIC make flag + per-codec __header rename + lc-android.c table loader
+- [Project: rockbox-sys depends on Zig-exported rb_* symbols](project_zig_ffi_dependency.md) — 18 extern symbols in crates/sys/src/lib.rs come from zig/src/main.zig wrappers; need a C compat layer (rb_zig_compat.c) for the Android cdylib
+- [Feedback: macOS Mach-O underscore prefix in objcopy --redefine-sym](feedback_macos_objcopy_mangling.md) — pass both `name=new` and `_name=_new` to handle both Mach-O and ELF; verified during CODECS_STATIC smoke test
+- [Feedback: Android cdylib needs --features embedded-daemon + --platform 26](feedback_android_embedded_daemon_features.md) — without `embedded-daemon` Cargo feature the .so is a 6 MB remote-only client; AAudio needs API 26 sysroot
+- [Project: Android cdylib needs both ROCKBOX_SERVER and CONFIG_SERVER](project_android_server_macros.md) — `apps/main.c:486` gates server_init() call on ROCKBOX_SERVER; `apps/SOURCES:314` gates the .c COMPILATION on CONFIG_SERVER — define both
+- [Feedback: Android FGS — startForeground within 5s of every startForegroundService](feedback_android_fgs_deadline.md) — every onStartCommand action branch must reach refreshNotification() or Android kills the process
+- [Project: Android codec filename split — CODECS_STATIC vs Java-shell](project_android_codec_filename.md) — metadata.h's CODEC_PREFIX/EXTENSION must use `<name>.codec` (not `libNAME.so`) when CODECS_STATIC, or every play call dies with "Codec: cannot read file"
+- [Project: CODECS_STATIC ci-symbol type collision](project_codecs_static_ci_collision.md) — `apps/codecs.c::ci` (264-byte struct) silently merges with each codec's `codec_crt0.c::ci` (8-byte pointer); fix is firmware-side rename to `firmware_ci`
+- [Feedback: pcm_sink set_freq receives an INDEX, not Hz](feedback_pcm_sink_set_freq_index.md) — translate via `hw_freq_sampr[idx]` before handing to the OS API or you get chipmunk audio
+- [Project: Firmware-command bus (fw_bus) — Rust FFI must run on broker](project_fw_command_bus.md) — Rockbox kernel uses `__cores[0].running` as global "current thread" (no TLS); calling FFI from actix workers corrupts state. Every mutating handler wraps in `crate::fw_bus::run_on_broker(...)`. **THIS IS THE LOAD-BEARING FIX** — pcm_play_lock and sleep(HZ/10) below are defence-in-depth
+- [Project: pcm-aaudio pthread races kernel mid-stream pcmbuf reconfig](project_pthread_pcm_race.md) — narrower race window in `pcmbuf_init`; wrapped in pcm_play_lock/unlock as defence-in-depth. Real fix is the fw_bus
+- [Project: stale thread->blocker → wakeup_thread NULL-fn-ptr crash](project_stale_blocker_kernel_crash.md) — same root cause as fw_bus; my kernel-side fixes were all wrong guesses (reverted). Real fix is the fw_bus
+- [Project: Embeddable desktop library (librockboxd.a)](project_embedded_desktop_lib.md) — crates/embed + zig build lib → fat static archive; gpui embeds daemon directly, no external rockboxd process

--- a/memory/project_embedded_desktop_lib.md
+++ b/memory/project_embedded_desktop_lib.md
@@ -1,0 +1,49 @@
+---
+name: Embeddable desktop library (librockboxd.a)
+description: New crates/embed + zig build lib produces a fat static lib; gpui embeds daemon directly — no external rockboxd process needed
+type: project
+---
+
+## Key facts
+
+New build target `zig build lib` produces `zig/zig-out/lib/librockboxd.a` — a fat static archive
+containing headless firmware + codecs + Rust gRPC servers + embed crate daemon boot code.
+
+**Why:** Any desktop GUI (GPUI, Swift/AppKit, Qt) can embed the full Rockbox audio engine
+in-process without spawning a subprocess. Same pattern as the Android cdylib (`crates/expo`
+with `embedded-daemon` feature) but for desktop/headless.
+
+**How to apply:** When working on gpui or a new desktop GUI, do NOT look for or spawn `rockboxd`.
+The daemon boots via `rb_daemon_start()` (from `librockboxd.a`) at app startup.
+
+## Files added / changed
+
+- `crates/embed/` — new Rust `staticlib` crate (daemon boot + full gRPC client `rb_*` C ABI)
+  - `src/lib.rs` — all `rb_*` gRPC client entry points (mirrors `crates/expo/src/lib.rs`)
+  - `src/daemon.rs` — desktop daemon boot: `rb_daemon_start(music_dir, device_name)` (2 args, no config_dir since $HOME always exists on desktop)
+  - `Cargo.toml` — `daemon` feature (default=on) pulls in headless stack; `fts5` search (no typesense)
+  - `build.rs` — only proto compilation; firmware linking done by Zig
+  - `proto` symlink → `../rpc/proto`
+- `zig/src/lib.zig` — same `rb_*` firmware exports as `main.zig` but without `main()`
+- `zig/build.zig` — added `lib` step; hoisted `codec_names`/`lib_names` to module scope
+- `include/rockboxd.h` — public C header for all `rb_*` functions
+- `gpui/build.rs` — links `librockboxd.a` + CoreAudio/etc frameworks automatically
+- `gpui/src/startup.rs` — replaced with `extern "C"` declarations + `start_embedded()` fn
+- `gpui/src/ui/startup_gate.rs` — removed error gate; now shows loading spinner while daemon boots
+
+## Build order for librockboxd.a
+
+1. `cd build-headless && make lib`
+2. `cargo build --release -p rockbox-embed -p rockbox-server`
+3. `cd zig && zig build lib` → `zig-out/lib/librockboxd.a`
+4. `cd gpui && cargo build --release` (links against librockboxd.a automatically)
+
+## rb_daemon_start signature (desktop — 2 args, not 3 like Android)
+
+```c
+int rb_daemon_start(const char *music_dir_ptr,    // NULL → $HOME/Music
+                    const char *device_name_ptr);  // must be non-null
+```
+
+Android version has a third `config_dir_ptr` arg (sets $HOME on Android).
+Desktop version omits it — $HOME already exists.

--- a/tools/configure
+++ b/tools/configure
@@ -30,6 +30,7 @@ sharedir=
 sdl_config=sdl2-config
 arm_thumb_boot=
 thread_support="ASSEMBLER_THREADS"
+thread_support_comment="/* the threading backend we use */"
 sysfont="08-Schumacher-Clean"
 app_lcd_width=
 app_lcd_height=
@@ -727,7 +728,16 @@ headlesshostcc () {
     GLOBAL_LDOPTS=""
     LDOPTS="-lpthread"
 
-    thread_support="HAVE_SIGALTSTACK_THREADS"
+    # HAVE_SIGALTSTACK_THREADS is broken on macOS 12 Monterey x86_64:
+    # sigaltstack() returns EPERM, causing an infinite retry loop at boot.
+    # HAVE_POSIX_THREADS uses one pthread per Rockbox thread with a global
+    # cooperative mutex instead, avoiding sigaltstack() entirely.
+    thread_support="HAVE_POSIX_THREADS"
+    thread_support_comment="/* the threading backend we use */
+/* HAVE_SIGALTSTACK_THREADS is broken on macOS 12 Monterey x86_64:
+ * sigaltstack() returns EPERM, causing an infinite retry loop.
+ * HAVE_POSIX_THREADS uses one pthread per Rockbox thread with a global
+ * cooperative mutex instead, avoiding sigaltstack() entirely. */"
     gccchoice=""
     gcctarget=""
 
@@ -5006,7 +5016,7 @@ ${use_usb_serial}
 ${config_rtc}
 ${have_rtc_alarm}
 
-/* the threading backend we use */
+${thread_support_comment}
 #define ${thread_support}
 
 /* lcd dimensions for application builds from configure */

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -6,6 +6,26 @@ const std = @import("std");
 // for defining build steps and express dependencies between them, allowing the
 // build runner to parallelize the build automatically (and the cache system to
 // know when a step doesn't need to be re-run).
+// Codec names used by both the headless executable and the embeddable lib.
+const codec_names = [_][]const u8{
+    "a52",        "a52_rm",    "aac",     "aac_bsf",
+    "adx",        "aiff",      "alac",    "ape",
+    "atrac3_oma", "atrac3_rm", "au",      "cook",
+    "flac",       "mod",       "mpa",     "mpc",
+    "opus",       "raac",      "shorten", "smaf",
+    "speex",      "tta",       "vorbis",  "vox",
+    "wav",        "wav64",     "wavpack", "wma",
+    "wmapro",
+};
+const lib_names = [_][]const u8{
+    "liba52",        "libalac",   "libasap",  "libasf",
+    "libatrac",      "libcook",   "libdemac", "libfaad",
+    "libffmpegFLAC", "libm4a",    "libmad",   "libmusepack",
+    "libopus",       "libpcm",    "librm",    "libspc",
+    "libspeex",      "libtremor", "libtta",   "libwavpack",
+    "libwma",        "libwmapro",
+};
+
 pub fn build(b: *std.Build) void {
     // Standard target options allow the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
@@ -173,16 +193,6 @@ pub fn build(b: *std.Build) void {
         //
         // scripts/build-headless.sh Step 2.5 extracts these files into
         //   <fw_dir>/lib/rbcodec/codecs/codec-objects/<name>/
-        const codec_names = [_][]const u8{
-            "a52",        "a52_rm",    "aac",     "aac_bsf",
-            "adx",        "aiff",      "alac",    "ape",
-            "atrac3_oma", "atrac3_rm", "au",      "cook",
-            "flac",       "mod",       "mpa",     "mpc",
-            "opus",       "raac",      "shorten", "smaf",
-            "speex",      "tta",       "vorbis",  "vox",
-            "wav",        "wav64",     "wavpack", "wma",
-            "wmapro",
-        };
         const codec_dir = b.pathJoin(&.{ fw_dir, "lib/rbcodec/codecs" });
         const obj_base = b.pathJoin(&.{ codec_dir, "codec-objects" });
         for (codec_names) |name| {
@@ -199,14 +209,6 @@ pub fn build(b: *std.Build) void {
         // Support libraries referenced by the codec objects above.
         // Passed as archives (lazy scanning) because code references from the
         // directly-linked codec .o files drive archive member inclusion correctly.
-        const lib_names = [_][]const u8{
-            "liba52",        "libalac",   "libasap",  "libasf",
-            "libatrac",      "libcook",   "libdemac", "libfaad",
-            "libffmpegFLAC", "libm4a",    "libmad",   "libmusepack",
-            "libopus",       "libpcm",    "librm",    "libspc",
-            "libspeex",      "libtremor", "libtta",   "libwavpack",
-            "libwma",        "libwmapro",
-        };
         for (lib_names) |lib| {
             exe.root_module.addObjectFile(b.path(b.pathJoin(&.{ codec_dir, b.fmt("{s}.a", .{lib}) })));
         }
@@ -290,4 +292,88 @@ pub fn build(b: *std.Build) void {
     //
     // Lastly, the Zig build system is relatively simple and self-contained,
     // and reading its source code will allow you to master it.
+
+    // ── Embeddable static library (always headless/cpal) ──────────────────────
+    // Build with:  zig build lib
+    // Output:      zig-out/lib/librockboxd.a
+    //
+    // Prerequisites (same as the headless binary):
+    //   cd build-headless && make lib
+    //   cargo build --release -p rockbox-embed -p rockbox-server
+    //
+    // Consumers link: librockboxd.a + system audio libs
+    //   macOS: -framework CoreAudio -framework AudioUnit -framework AudioToolbox
+    //          -framework CoreFoundation -framework Security
+    //   Linux: -lasound -lunwind -ldbus-1
+    {
+        const hw = "../build-headless";
+
+        const embed_lib = b.addStaticLibrary(.{
+            .name = "rockboxd",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/lib.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "rockboxd", .module = mod },
+                },
+            }),
+        });
+
+        embed_lib.root_module.addLibraryPath(.{ .cwd_relative = "../target/release" });
+
+        if (target.result.os.tag == .macos) {
+            if (target.result.cpu.arch == .aarch64) {
+                embed_lib.root_module.addLibraryPath(.{ .cwd_relative = "/opt/homebrew/lib" });
+            } else {
+                embed_lib.root_module.addLibraryPath(.{ .cwd_relative = "/usr/local/lib" });
+            }
+            embed_lib.root_module.linkFramework("CoreFoundation", .{});
+            embed_lib.root_module.linkFramework("Security", .{});
+            embed_lib.root_module.linkFramework("CoreAudio", .{});
+            embed_lib.root_module.linkFramework("AudioUnit", .{});
+            embed_lib.root_module.linkFramework("AudioToolbox", .{});
+        }
+
+        if (target.result.os.tag == .linux) {
+            embed_lib.root_module.linkSystemLibrary("unwind", .{});
+            embed_lib.root_module.linkSystemLibrary("dbus-1", .{});
+            embed_lib.root_module.linkSystemLibrary("asound", .{});
+        }
+
+        if (target.result.os.tag == .freebsd or target.result.os.tag == .openbsd) {
+            embed_lib.root_module.linkSystemLibrary("asound", .{});
+        }
+
+        // Firmware archives (headless build)
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "librockbox.a" })));
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "firmware/libfirmware.a" })));
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "lib/libfixedpoint.a" })));
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "lib/libskin_parser.a" })));
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "lib/librbcodec.a" })));
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ hw, "lib/libtlsf.a" })));
+
+        // Rust libraries
+        embed_lib.root_module.addObjectFile(b.path("../target/release/librockbox_embed.a"));
+        embed_lib.root_module.addObjectFile(b.path("../target/release/librockbox_server.a"));
+
+        // Statically-linked codecs (same extraction as the headless executable)
+        const ecodec_dir = b.pathJoin(&.{ hw, "lib/rbcodec/codecs" });
+        const eobj_base = b.pathJoin(&.{ ecodec_dir, "codec-objects" });
+        for (codec_names) |name| {
+            const dir = b.pathJoin(&.{ eobj_base, name });
+            embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ dir, b.fmt("{s}.o", .{name}) })));
+            embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ dir, b.fmt("{s}-crt0.o", .{name}) })));
+        }
+        embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ ecodec_dir, "libcodec.a" })));
+        for (lib_names) |lib| {
+            embed_lib.root_module.addObjectFile(b.path(b.pathJoin(&.{ ecodec_dir, b.fmt("{s}.a", .{lib}) })));
+        }
+
+        embed_lib.root_module.link_libc = true;
+        b.installArtifact(embed_lib);
+
+        const lib_step = b.step("lib", "Build the embeddable static library (zig-out/lib/librockboxd.a)");
+        lib_step.dependOn(b.getInstallStep());
+    }
 }

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -372,9 +372,25 @@ pub fn build(b: *std.Build) void {
         }
 
         embed_lib.root_module.link_libc = true;
-        b.installArtifact(embed_lib);
+
+        // Use addInstallArtifact (not installArtifact) so the embed library is
+        // NOT added to the default install step. Plain `zig build` must only
+        // build the rockboxd executable; `zig build lib` is the explicit entry
+        // point. This prevents build-headless.sh from trying to link
+        // librockbox_embed.a which is only present when rockbox-embed is built.
+        const install_embed = b.addInstallArtifact(embed_lib, .{});
 
         const lib_step = b.step("lib", "Build the embeddable static library (zig-out/lib/librockboxd.a)");
-        lib_step.dependOn(b.getInstallStep());
+        if (target.result.os.tag == .macos) {
+            // Zig's llvm-ar emits a GNU-format archive; Apple's ld rejects it
+            // with "archive member invalid control bits". Repack in-place with
+            // libtool -static to produce a BSD-format archive macOS ld accepts.
+            const lib_out = b.getInstallPath(.lib, "librockboxd.a");
+            const repack = b.addSystemCommand(&.{ "libtool", "-static", "-o", lib_out, lib_out });
+            repack.step.dependOn(&install_embed.step);
+            lib_step.dependOn(&repack.step);
+        } else {
+            lib_step.dependOn(&install_embed.step);
+        }
     }
 }

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -308,8 +308,9 @@ pub fn build(b: *std.Build) void {
     {
         const hw = "../build-headless";
 
-        const embed_lib = b.addStaticLibrary(.{
+        const embed_lib = b.addLibrary(.{
             .name = "rockboxd",
+            .linkage = .static,
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/lib.zig"),
                 .target = target,

--- a/zig/src/lib.zig
+++ b/zig/src/lib.zig
@@ -1,0 +1,83 @@
+// Exported C-ABI symbols for the embeddable librockboxd.a target.
+// Same as main.zig but without a main() entry point.
+
+const playlist = @import("rockbox/playlist.zig");
+const metadata = @import("rockbox/metadata.zig");
+const tree = @import("rockbox/tree.zig");
+const settings = @import("rockbox/settings.zig");
+
+export fn rb_get_metadata(fd: c_int, trackname: [*]const u8) metadata.mp3entry {
+    return metadata._get_metadata(fd, trackname);
+}
+
+export fn rb_rockbox_browse() c_int {
+    return tree._rockbox_browse();
+}
+
+export fn rb_tree_get_context() tree.tree_context {
+    return tree._tree_get_context();
+}
+
+export fn rb_tree_get_entries() *tree.entry {
+    return tree._tree_get_entries();
+}
+
+export fn rb_tree_get_entry_at(index: c_int) tree.entry {
+    return tree._tree_get_entry_at(index);
+}
+
+export fn rb_get_track_info_from_current_playlist(index: c_int) playlist.PlaylistTrackInfo {
+    return playlist._get_track_info_from_current_playlist(index);
+}
+
+export fn rb_build_playlist(files: [*]const [*]const u8, start_index: c_int, size: c_int) c_int {
+    return playlist.build_playlist(files, start_index, size);
+}
+
+export fn rb_playlist_insert_tracks(files: [*]const [*]const u8, position: c_int, size: c_int) c_int {
+    return playlist.insert_tracks(files, position, size);
+}
+
+export fn rb_playlist_insert_track(filename: [*]const u8, position: c_int, queue: bool, sync: bool) c_int {
+    return playlist.insert_track(filename, position, queue, sync);
+}
+
+export fn rb_playlist_delete_track(index: c_int) c_int {
+    return playlist.delete_track(index);
+}
+
+export fn rb_playlist_insert_directory(dir: [*]const u8, position: c_int, queue: bool, recurse: bool) c_int {
+    return playlist.insert_directory(dir, position, queue, recurse);
+}
+
+export fn rb_playlist_remove_all_tracks() c_int {
+    return playlist.remove_all_tracks();
+}
+
+export fn rb_playlist_index() c_int {
+    return playlist.playlist_index();
+}
+
+export fn rb_playlist_first_index() c_int {
+    return playlist.playlist_first_index();
+}
+
+export fn rb_playlist_last_insert_pos() c_int {
+    return playlist.playlist_last_insert_pos();
+}
+
+export fn rb_playlist_seed() c_int {
+    return playlist.playlist_seed();
+}
+
+export fn rb_playlist_last_shuffled_start() c_int {
+    return playlist.playlist_last_shuffled_start();
+}
+
+export fn rb_max_playlist_size() c_int {
+    return playlist.max_playlist_size();
+}
+
+export fn rb_get_crossfade_mode() c_int {
+    return settings.get_crossfade_mode();
+}


### PR DESCRIPTION
Add a new crates/embed staticlib that exposes a flat C ABI (rb_* functions) and can boot the headless Rockbox daemon in-process on desktop. Add zig lib target and zig/src/lib.zig exports, public header include/rockboxd.h, and gpui integration to link and start the embedded daemon. Add GitHub Actions workflow to build and upload platform archives (librockboxd.a + include). Update docs/memory and build files (build-headless, Cargo, gpui, zig) to support the embeddable library.