### PR TITLE
feat(bindings): add Go bindings via purego

### DIFF
--- a/.github/workflows/bindings-go-test.yml
+++ b/.github/workflows/bindings-go-test.yml
@@ -1,0 +1,65 @@
+name: bindings-go-test
+
+# Build librockbox_ffi and run the Go binding's test suite. The tests dlopen
+# the freshly built shared library (via the target/release fallback) and run
+# the same native pipeline parity check as the other bindings.
+on:
+  push:
+    paths:
+      - "bindings/go/**"
+      - "crates/rockbox-ffi/**"
+      - "include/rockbox_ffi.h"
+      - ".github/workflows/bindings-go-test.yml"
+  pull_request:
+    paths:
+      - "bindings/go/**"
+      - "crates/rockbox-ffi/**"
+      - "include/rockbox_ffi.h"
+      - ".github/workflows/bindings-go-test.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: go test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: bindings/go/go.mod
+          cache-dependency-path: bindings/go/go.sum
+
+      - name: Install Linux audio deps
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+
+      - name: Load dummy sound card (best-effort)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo modprobe snd-dummy || true
+
+      - name: Build librockbox_ffi
+        run: cargo build --release -p rockbox-ffi
+
+      - name: go vet
+        working-directory: bindings/go
+        # -unsafeptr=false: purego hands back C-owned addresses as uintptr, so
+        # the uintptr->unsafe.Pointer conversions are safe (not GC-managed) but
+        # the unsafeptr analyzer can't prove it. Every other check still runs.
+        run: go vet -unsafeptr=false ./...
+
+      - name: go test
+        working-directory: bindings/go
+        run: go test -v ./...

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,6 +1,7 @@
 # Language bindings
 
 ![Python](https://img.shields.io/badge/Python-cffi-3776AB?logo=python&logoColor=white)
+![Go](https://img.shields.io/badge/Go-purego-00ADD8?logo=go&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-Bun%20%7C%20Deno%20%7C%20Node-3178C6?logo=typescript&logoColor=white)
 ![Elixir](https://img.shields.io/badge/Elixir-erl__nif-4B275F?logo=elixir&logoColor=white)
 ![Gleam](https://img.shields.io/badge/Gleam-erl__nif-FFAFF3?logo=gleam&logoColor=white)
@@ -19,10 +20,10 @@ surface is declared in [`include/rockbox_ffi.h`](../include/rockbox_ffi.h).
                  crates/rockbox-ffi  (cdylib + staticlib)
              rb_dsp_* / rb_meta_* / rb_player_*   ← include/rockbox_ffi.h
                                    │
-   ┌────────┬──────────┬────────┬───────┬───────┬───────┬────────┬────────┐
- Python TypeScript  Elixir   Gleam  Ruby   Swift  Kotlin  Clojure
- (cffi) (Bun/Deno/  (erl_nif)─(erl_nif)(fiddle)(dlopen)(Java FFM)(Java FFM)
-          Node)        └─ shared rockbox_ffi_nif.{c,erl} ─┘
+   ┌──────┬──────┬──────────┬────────┬───────┬───────┬───────┬────────┬────────┐
+ Python  Go  TypeScript  Elixir   Gleam  Ruby   Swift  Kotlin  Clojure
+ (cffi)(purego)(Bun/Deno/ (erl_nif)─(erl_nif)(fiddle)(dlopen)(Java FFM)(Java FFM)
+                Node)        └─ shared rockbox_ffi_nif.{c,erl} ─┘
 ```
 
 Build the shared library once from the repo root:
@@ -37,6 +38,7 @@ cargo build --release -p rockbox-ffi
 | Language       | Directory                      | Mechanism                     | Verify                                            |
 | -------------- | ------------------------------ | ----------------------------- | ------------------------------------------------- |
 | Python         | [`python/`](python)            | `cffi` (dlopen)               | `uv run python examples/smoke.py`                 |
+| Go             | [`go/`](go)                    | `purego` (dlopen, no cgo)     | `go run ./examples/smoke`                         |
 | TypeScript     | [`typescript/`](typescript)    | Bun / Deno / Node.js FFI      | `bun run examples/smoke.bun.ts`                   |
 | Elixir         | [`elixir/`](elixir)            | `erl_nif` (shared)            | `mix test`                                        |
 | Gleam          | [`gleam/`](gleam)              | `erl_nif` (shared)            | `make && gleam test`                              |

--- a/bindings/go/.gitignore
+++ b/bindings/go/.gitignore
@@ -1,0 +1,2 @@
+# CI-built native lib bundled next to the package for releases
+/lib/

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,123 @@
+# rockbox (Go)
+
+![Go](https://img.shields.io/badge/Go-1.22%2B-00ADD8?logo=go&logoColor=white)
+![FFI](https://img.shields.io/badge/FFI-purego-00ADD8)
+![License](https://img.shields.io/badge/license-GPL--2.0--or--later-blue)
+
+Go bindings for the Rockbox **DSP**, **metadata**, and **playback** engine, via
+[`purego`](https://github.com/ebitengine/purego) over the prebuilt
+`librockbox_ffi` shared library. **No cgo and no C toolchain** — the package
+`dlopen`s the shared library at process start.
+
+## Setup
+
+Build the shared library once (from the repo root):
+
+```sh
+cargo build --release -p rockbox-ffi
+```
+
+Then add the module and run the smoke test:
+
+```sh
+go get github.com/tsirysndr/rockboxd/bindings/go
+
+# from a checkout:
+cd bindings/go
+go run ./examples/smoke   # end-to-end check
+go test ./...
+```
+
+The library is located automatically. Precedence:
+
+1. `ROCKBOX_FFI_LIB` environment variable (explicit path override).
+2. a `lib/librockbox_ffi.{dylib,so,dll}` bundled next to the package source.
+3. `target/release/librockbox_ffi.*`, by walking up from the package source,
+   the executable, and the current directory (repo checkout / dev).
+
+Because Go modules are consumed from source (`go get`), the usual story for a
+standalone binary is to point `ROCKBOX_FFI_LIB` at the shared library, or drop
+it next to the executable's `target/release`. CI attaches the per-target
+`librockbox_ffi.*` to each `bindings-v*` release.
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+
+	rockbox "github.com/tsirysndr/rockboxd/bindings/go"
+)
+
+func main() {
+	// --- metadata -----------------------------------------------------
+	meta, _ := rockbox.Metadata.Read("song.flac")
+	fmt.Printf("%s — %s (%d ms)\n", meta.Artist, meta.Title, meta.DurationMs)
+	label, _ := rockbox.Metadata.Probe("track.opus") // => "Opus"
+	_ = label
+
+	// --- DSP (interleaved stereo int16) -------------------------------
+	dsp, _ := rockbox.NewDsp(44100)
+	defer dsp.Close()
+	dsp.EqEnable(true)
+	dsp.SetEqBand(0, 60, 0.7, 3.0)
+	dsp.SetReplaygain(rockbox.DspReplayGainTrack, true, 0.0)
+	dsp.SetReplaygainGains(rockbox.Opt(-6.02), nil, nil, nil) // halves amplitude
+	processed, _ := dsp.Process(samples)                      // []int16
+	_ = processed
+
+	// --- playback (needs an output device) ----------------------------
+	cfg := rockbox.DefaultConfig()
+	cfg.Volume = 0.8
+	player, _ := rockbox.NewPlayer(cfg)
+	defer player.Close()
+	player.SetReplaygain(rockbox.ReplayGainTrack, 0.0, true)
+	player.SetCrossfade(rockbox.CrossfadeAlways, 0, 2000, 0, 2000, rockbox.MixCrossfade)
+	player.SetQueue([]string{"a.flac", "b.mp3", "c.opus"})
+	player.Play()
+	st, _ := player.Status() // => &Status{State: "playing", ...}
+	_ = st
+}
+```
+
+`Dsp` and `Player` own native resources — call `Close` (a `defer` is idiomatic)
+when done.
+
+## API
+
+| Symbol                          | Contents                                                           |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `rockbox.Metadata.Read/Probe`   | `Read(path) (*Meta, error)`, `Probe(name) (string, bool)`          |
+| `rockbox.NewDsp` → `*Dsp`       | EQ / tone / surround / compressor / ReplayGain, `Process([]int16)` |
+| `rockbox.NewPlayer` → `*Player` | queue + transport + crossfade + ReplayGain, `Status()`             |
+| `rockbox.*` consts              | `DspReplayGain*`, `ReplayGain*`, `Crossfade*`, `Mix*`, `Channel*`  |
+
+Rich values (metadata, player status) cross the FFI boundary as JSON and are
+decoded into typed structs (`Meta`, `Status`). Sample buffers are plain
+`[]int16` of interleaved-stereo signed 16-bit samples. Optional metadata fields
+(track number, per-track ReplayGain, album art, cuesheet) are pointer fields
+that are `nil` when the tag is absent.
+
+### Two ReplayGain encodings
+
+The DSP and player use *different* mode integers (a quirk of the C ABI):
+
+- `Dsp.SetReplaygain` → `DspReplayGainMode` (`Track=0, Album=1, Shuffle=2, Off=3`)
+- `Player.SetReplaygain` / `Config.ReplayGainMode` → `ReplayGainMode`
+  (`Off=0, Track=1, Album=2`)
+
+Use the named constants and you won't have to remember which is which.
+
+## Examples
+
+```sh
+go run ./examples/smoke   # metadata + DSP + player checks
+```
+
+## Test
+
+```sh
+go test ./...
+```

--- a/bindings/go/dsp.go
+++ b/bindings/go/dsp.go
@@ -1,0 +1,130 @@
+package rockbox
+
+import (
+	"errors"
+	"math"
+	"unsafe"
+)
+
+// Dsp is the Rockbox DSP pipeline: EQ, tone, surround, compressor, ReplayGain,
+// and resampler.
+//
+// The underlying dsp_config is a process-wide singleton, so only one Dsp may
+// exist at a time and it must be used from one goroutine. Call [Dsp.Close] when
+// done.
+type Dsp struct {
+	ptr uintptr
+}
+
+// NewDsp creates a Dsp configured for the given output sample rate (Hz).
+func NewDsp(sampleRate uint32) (*Dsp, error) {
+	ptr := rbDspNew(sampleRate)
+	if ptr == 0 {
+		return nil, errors.New("rockbox: rb_dsp_new returned NULL")
+	}
+	return &Dsp{ptr: ptr}, nil
+}
+
+// Close frees the native DSP. It is safe to call more than once.
+func (d *Dsp) Close() {
+	if d.ptr == 0 {
+		return
+	}
+	rbDspFree(d.ptr)
+	d.ptr = 0
+}
+
+// SetInputFrequency sets the sample rate (Hz) of the audio fed to Process, so
+// the resampler can convert it to the output rate.
+func (d *Dsp) SetInputFrequency(hz uint32) { rbDspSetInputFrequency(d.ptr, hz) }
+
+// Flush clears the internal resampler / filter state.
+func (d *Dsp) Flush() { rbDspFlush(d.ptr) }
+
+// EqEnable turns the parametric EQ on or off.
+func (d *Dsp) EqEnable(enable bool) { rbDspEqEnable(d.ptr, enable) }
+
+// SetEqBand configures one EQ band (0..=9; band 0 is the low shelf, 9 the high
+// shelf). q is the Q factor and gainDb the gain in dB, both in plain units —
+// the binding applies Rockbox's tenths scaling internally.
+func (d *Dsp) SetEqBand(band int, cutoffHz int32, q, gainDb float32) {
+	rbDspSetEqBand(d.ptr, uint64(band), cutoffHz, q, gainDb)
+}
+
+// SetEqPrecut sets the EQ pre-cut in dB.
+func (d *Dsp) SetEqPrecut(db float32) { rbDspSetEqPrecut(d.ptr, db) }
+
+// SetTone sets the bass and treble shelves in dB.
+func (d *Dsp) SetTone(bassDb, trebleDb int32) { rbDspSetTone(d.ptr, bassDb, trebleDb) }
+
+// SetToneCutoffs sets the bass and treble shelf cutoff frequencies (Hz).
+func (d *Dsp) SetToneCutoffs(bassHz, trebleHz int32) { rbDspSetToneCutoffs(d.ptr, bassHz, trebleHz) }
+
+// SetSurround configures the surround effect.
+func (d *Dsp) SetSurround(delayMs, balance, fx1, fx2 int32) {
+	rbDspSetSurround(d.ptr, delayMs, balance, fx1, fx2)
+}
+
+// SetChannelConfig selects the channel routing (see [ChannelConfig]).
+func (d *Dsp) SetChannelConfig(mode ChannelConfig) { rbDspSetChannelConfig(d.ptr, int32(mode)) }
+
+// SetStereoWidth sets the stereo width as a percentage.
+func (d *Dsp) SetStereoWidth(percent int32) { rbDspSetStereoWidth(d.ptr, percent) }
+
+// SetCompressor configures the dynamic-range compressor.
+func (d *Dsp) SetCompressor(threshold, makeupGain, ratio, knee, releaseTime, attackTime int32) {
+	rbDspSetCompressor(d.ptr, threshold, makeupGain, ratio, knee, releaseTime, attackTime)
+}
+
+// SetReplaygain selects the ReplayGain mode (see [DspReplayGainMode]). When
+// noclip is true, gains that would clip are reduced; preampDb is applied on top.
+func (d *Dsp) SetReplaygain(mode DspReplayGainMode, noclip bool, preampDb float32) {
+	rbDspSetReplaygain(d.ptr, int32(mode), noclip, preampDb)
+}
+
+// SetReplaygainGains sets the per-track ReplayGain values: gains in plain dB
+// and peaks as linear amplitude (1.0 = full scale). Pass a nil pointer for any
+// absent tag (mapped to the ABI's NaN sentinel). Use [Opt] to build pointers.
+func (d *Dsp) SetReplaygainGains(trackGainDb, albumGainDb, trackPeak, albumPeak *float32) {
+	rbDspSetReplaygainGains(d.ptr, optF32(trackGainDb), optF32(albumGainDb), optF32(trackPeak), optF32(albumPeak))
+}
+
+// SetReplaygainGainsRaw sets the native Q7.24 linear factors (the Raw* fields
+// of [ReplayGain] from [Metadata.Read]); 0 means "not tagged".
+func (d *Dsp) SetReplaygainGainsRaw(trackGain, albumGain, trackPeak, albumPeak int64) {
+	rbDspSetReplaygainGainsRaw(d.ptr, trackGain, albumGain, trackPeak, albumPeak)
+}
+
+// Process runs interleaved stereo S16 samples through the pipeline and returns
+// the processed samples. The output length may differ from the input (the
+// resampler buffers). input must have even length (L/R pairs).
+func (d *Dsp) Process(input []int16) ([]int16, error) {
+	if len(input)%2 != 0 {
+		return nil, errors.New("rockbox: input must be interleaved stereo (even length)")
+	}
+	if len(input) == 0 {
+		return nil, nil
+	}
+	var outLen uint64
+	outPtr := rbDspProcess(d.ptr, unsafe.Pointer(&input[0]), uint64(len(input)), unsafe.Pointer(&outLen))
+	if outPtr == 0 || outLen == 0 {
+		return nil, nil
+	}
+	src := unsafe.Slice((*int16)(unsafe.Pointer(outPtr)), outLen)
+	out := make([]int16, outLen)
+	copy(out, src)
+	rbBufferFree(outPtr, outLen)
+	return out, nil
+}
+
+// Opt returns a pointer to v, for the optional *float32 arguments of
+// [Dsp.SetReplaygainGains].
+func Opt(v float32) *float32 { return &v }
+
+// optF32 maps a nil pointer to NaN (the ABI's "tag absent" sentinel).
+func optF32(v *float32) float32 {
+	if v == nil {
+		return float32(math.NaN())
+	}
+	return *v
+}

--- a/bindings/go/enums.go
+++ b/bindings/go/enums.go
@@ -1,0 +1,58 @@
+package rockbox
+
+// Note the two *different* ReplayGain encodings in the C ABI.
+
+// DspReplayGainMode selects the ReplayGain mode for [Dsp.SetReplaygain]
+// (native Rockbox encoding).
+type DspReplayGainMode int32
+
+const (
+	DspReplayGainTrack   DspReplayGainMode = 0
+	DspReplayGainAlbum   DspReplayGainMode = 1
+	DspReplayGainShuffle DspReplayGainMode = 2
+	DspReplayGainOff     DspReplayGainMode = 3
+)
+
+// ReplayGainMode selects the ReplayGain mode for [Player.SetReplaygain] and
+// [Config.ReplayGainMode] (player encoding).
+type ReplayGainMode int32
+
+const (
+	ReplayGainOff   ReplayGainMode = 0
+	ReplayGainTrack ReplayGainMode = 1
+	ReplayGainAlbum ReplayGainMode = 2
+)
+
+// CrossfadeMode selects the crossfade behaviour for [Player.SetCrossfade] and
+// [Config.CrossfadeMode].
+type CrossfadeMode int32
+
+const (
+	CrossfadeOff             CrossfadeMode = 0
+	CrossfadeAutoSkip        CrossfadeMode = 1
+	CrossfadeManualSkip      CrossfadeMode = 2
+	CrossfadeShuffle         CrossfadeMode = 3
+	CrossfadeShuffleOrManual CrossfadeMode = 4
+	CrossfadeAlways          CrossfadeMode = 5
+)
+
+// MixMode selects how crossfading tracks are combined.
+type MixMode int32
+
+const (
+	MixCrossfade MixMode = 0
+	MixMix       MixMode = 1
+)
+
+// ChannelConfig selects the DSP channel routing for [Dsp.SetChannelConfig].
+type ChannelConfig int32
+
+const (
+	ChannelStereo    ChannelConfig = 0
+	ChannelMono      ChannelConfig = 1
+	ChannelCustom    ChannelConfig = 2
+	ChannelMonoLeft  ChannelConfig = 3
+	ChannelMonoRight ChannelConfig = 4
+	ChannelKaraoke   ChannelConfig = 5
+	ChannelSwap      ChannelConfig = 6
+)

--- a/bindings/go/examples/smoke/main.go
+++ b/bindings/go/examples/smoke/main.go
@@ -1,0 +1,106 @@
+// End-to-end smoke test for the Go bindings.
+//
+// Run from the binding root: go run ./examples/smoke
+package main
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	rockbox "github.com/tsirysndr/rockboxd/bindings/go"
+)
+
+func main() {
+	// Locate the repo root relative to this source file.
+	_, file, _, _ := runtime.Caller(0)
+	repo := filepath.Join(filepath.Dir(file), "..", "..", "..", "..")
+	fixture := filepath.Join(repo, "crates", "rocksky", "fixtures",
+		"08 - Internet Money - Speak(Explicit).m4a")
+
+	fmt.Printf("ABI version: %d\n", rockbox.ABIVersion())
+
+	// -- metadata ---------------------------------------------------------
+	meta, err := rockbox.Metadata.Read(fixture)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("codec=%q title=%q artist=%q duration_ms=%d sample_rate=%d\n",
+		meta.Codec, meta.Title, meta.Artist, meta.DurationMs, meta.SampleRate)
+	if meta.Codec == "" {
+		log.Fatal("codec label should not be empty")
+	}
+
+	probe, ok := rockbox.Metadata.Probe("song.flac")
+	fmt.Printf("Probe(\"song.flac\") = %q (ok=%v)\n", probe, ok)
+	if probe != "FLAC" {
+		log.Fatalf("expected FLAC, got %q", probe)
+	}
+
+	// -- DSP: -6.0206 dB track gain should HALVE amplitude ----------------
+	const rate = 44100
+	dsp, err := rockbox.NewDsp(rate)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dsp.Close()
+
+	dsp.SetReplaygain(rockbox.DspReplayGainTrack, false, 0.0)
+	dsp.SetReplaygainGains(rockbox.Opt(-6.0206), nil, nil, nil) // x0.5
+
+	sine := rockbox.SineStereo(1000, 1.0, rate, 16000)
+	out, err := dsp.Process(sine)
+	if err != nil {
+		log.Fatal(err)
+	}
+	peak := 0
+	for _, s := range out {
+		v := int(s)
+		if v < 0 {
+			v = -v
+		}
+		if v > peak {
+			peak = v
+		}
+	}
+	fmt.Printf("DSP peak after -6.02 dB track gain: %d (expected ~8000)\n", peak)
+	if peak < 7600 || peak > 8400 {
+		log.Fatalf("peak %d out of range", peak)
+	}
+
+	// -- Player (construct only, no audible playback) ---------------------
+	cfg := rockbox.DefaultConfig()
+	cfg.Volume = 0.0
+	player, err := rockbox.NewPlayer(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer player.Close()
+
+	sr := player.SampleRate()
+	fmt.Printf("Player sample_rate=%d\n", sr)
+	if sr == 0 {
+		log.Fatal("sample_rate should be > 0")
+	}
+	player.SetVolume(0.0)
+	if err := player.SetQueue([]string{fixture}); err != nil {
+		log.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond) // queue command is applied asynchronously
+
+	st, err := player.Status()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Player status: state=%q queue_len=%d\n", st.State, st.QueueLen)
+	if st.State != "stopped" {
+		log.Fatalf("expected stopped, got %q", st.State)
+	}
+	if st.QueueLen != 1 {
+		log.Fatalf("expected queue_len 1, got %d", st.QueueLen)
+	}
+
+	fmt.Println("\nALL CHECKS PASSED ✔")
+}

--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -1,0 +1,261 @@
+// Package rockbox provides Go bindings for the Rockbox DSP / metadata /
+// playback engine.
+//
+// It sits on top of the flat C ABI librockbox_ffi (crates/rockbox-ffi, header
+// include/rockbox_ffi.h) and loads the prebuilt shared library at runtime with
+// purego — no cgo and no C toolchain required. The library is located via the
+// ROCKBOX_FFI_LIB env var, a bundled lib/ directory, or by walking up to the
+// repo's target/release directory (see libraryPath).
+//
+// Three surfaces mirror the other language bindings:
+//
+//   - [Metadata.Read] / [Metadata.Probe] — audio file tags & codec probing.
+//   - [Dsp]    — EQ / tone / surround / compressor / ReplayGain over int16 PCM.
+//   - [Player] — queue + transport with crossfade and ReplayGain.
+package rockbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+// Raw C ABI bindings. Each variable is bound to a symbol in librockbox_ffi by
+// purego.RegisterLibFunc in load(). Opaque handles (RbDsp*, RbPlayer*) and
+// heap char*/int16* returns cross as uintptr; scalars as their fixed-width Go
+// type. Keep in sync with include/rockbox_ffi.h.
+var (
+	rbFFIABIVersion func() uint32
+
+	rbStringFree func(uintptr)
+	rbBufferFree func(uintptr, uint64)
+
+	// ---- DSP ----------------------------------------------------------
+	rbDspNew                   func(uint32) uintptr
+	rbDspFree                  func(uintptr)
+	rbDspSetInputFrequency     func(uintptr, uint32)
+	rbDspFlush                 func(uintptr)
+	rbDspEqEnable              func(uintptr, bool)
+	rbDspSetTone               func(uintptr, int32, int32)
+	rbDspSetToneCutoffs        func(uintptr, int32, int32)
+	rbDspSetSurround           func(uintptr, int32, int32, int32, int32)
+	rbDspSetChannelConfig      func(uintptr, int32)
+	rbDspSetStereoWidth        func(uintptr, int32)
+	rbDspSetCompressor         func(uintptr, int32, int32, int32, int32, int32, int32)
+	rbDspSetReplaygain         func(uintptr, int32, bool, float32)
+	rbDspSetReplaygainGains    func(uintptr, float32, float32, float32, float32)
+	rbDspSetReplaygainGainsRaw func(uintptr, int64, int64, int64, int64)
+	rbDspSetEqBand             func(uintptr, uint64, int32, float32, float32)
+	rbDspSetEqPrecut           func(uintptr, float32)
+	rbDspProcess               func(uintptr, unsafe.Pointer, uint64, unsafe.Pointer) uintptr
+
+	// ---- metadata -----------------------------------------------------
+	rbMetaReadJSON func(string) uintptr
+	rbMetaProbe    func(string) uintptr
+
+	// ---- player -------------------------------------------------------
+	rbPlayerNew           func() uintptr
+	rbPlayerNewWithConfig func(uint32, float32, float32, int32, float32, bool, int32, uint32, uint32, uint32, uint32, int32) uintptr
+	rbPlayerFree          func(uintptr)
+	rbPlayerSetQueueJSON  func(uintptr, string)
+	rbPlayerEnqueue       func(uintptr, string)
+	rbPlayerPlay          func(uintptr)
+	rbPlayerPause         func(uintptr)
+	rbPlayerToggle        func(uintptr)
+	rbPlayerStop          func(uintptr)
+	rbPlayerNext          func(uintptr)
+	rbPlayerPrevious      func(uintptr)
+	rbPlayerSkipTo        func(uintptr, uint64)
+	rbPlayerSeekMs        func(uintptr, uint64)
+	rbPlayerSetVolume     func(uintptr, float32)
+	rbPlayerSetCrossfade  func(uintptr, int32, uint32, uint32, uint32, uint32, int32)
+	rbPlayerSetReplaygain func(uintptr, int32, float32, bool)
+	rbPlayerVolume        func(uintptr) float32
+	rbPlayerSampleRate    func(uintptr) uint32
+	rbPlayerStatusJSON    func(uintptr) uintptr
+)
+
+func init() {
+	handle, err := purego.Dlopen(libraryPath(), purego.RTLD_NOW|purego.RTLD_GLOBAL)
+	if err != nil {
+		panic(fmt.Sprintf("rockbox: %v", err))
+	}
+
+	purego.RegisterLibFunc(&rbFFIABIVersion, handle, "rb_ffi_abi_version")
+	purego.RegisterLibFunc(&rbStringFree, handle, "rb_string_free")
+	purego.RegisterLibFunc(&rbBufferFree, handle, "rb_buffer_free")
+
+	purego.RegisterLibFunc(&rbDspNew, handle, "rb_dsp_new")
+	purego.RegisterLibFunc(&rbDspFree, handle, "rb_dsp_free")
+	purego.RegisterLibFunc(&rbDspSetInputFrequency, handle, "rb_dsp_set_input_frequency")
+	purego.RegisterLibFunc(&rbDspFlush, handle, "rb_dsp_flush")
+	purego.RegisterLibFunc(&rbDspEqEnable, handle, "rb_dsp_eq_enable")
+	purego.RegisterLibFunc(&rbDspSetTone, handle, "rb_dsp_set_tone")
+	purego.RegisterLibFunc(&rbDspSetToneCutoffs, handle, "rb_dsp_set_tone_cutoffs")
+	purego.RegisterLibFunc(&rbDspSetSurround, handle, "rb_dsp_set_surround")
+	purego.RegisterLibFunc(&rbDspSetChannelConfig, handle, "rb_dsp_set_channel_config")
+	purego.RegisterLibFunc(&rbDspSetStereoWidth, handle, "rb_dsp_set_stereo_width")
+	purego.RegisterLibFunc(&rbDspSetCompressor, handle, "rb_dsp_set_compressor")
+	purego.RegisterLibFunc(&rbDspSetReplaygain, handle, "rb_dsp_set_replaygain")
+	purego.RegisterLibFunc(&rbDspSetReplaygainGains, handle, "rb_dsp_set_replaygain_gains")
+	purego.RegisterLibFunc(&rbDspSetReplaygainGainsRaw, handle, "rb_dsp_set_replaygain_gains_raw")
+	purego.RegisterLibFunc(&rbDspSetEqBand, handle, "rb_dsp_set_eq_band")
+	purego.RegisterLibFunc(&rbDspSetEqPrecut, handle, "rb_dsp_set_eq_precut")
+	purego.RegisterLibFunc(&rbDspProcess, handle, "rb_dsp_process")
+
+	purego.RegisterLibFunc(&rbMetaReadJSON, handle, "rb_meta_read_json")
+	purego.RegisterLibFunc(&rbMetaProbe, handle, "rb_meta_probe")
+
+	purego.RegisterLibFunc(&rbPlayerNew, handle, "rb_player_new")
+	purego.RegisterLibFunc(&rbPlayerNewWithConfig, handle, "rb_player_new_with_config")
+	purego.RegisterLibFunc(&rbPlayerFree, handle, "rb_player_free")
+	purego.RegisterLibFunc(&rbPlayerSetQueueJSON, handle, "rb_player_set_queue_json")
+	purego.RegisterLibFunc(&rbPlayerEnqueue, handle, "rb_player_enqueue")
+	purego.RegisterLibFunc(&rbPlayerPlay, handle, "rb_player_play")
+	purego.RegisterLibFunc(&rbPlayerPause, handle, "rb_player_pause")
+	purego.RegisterLibFunc(&rbPlayerToggle, handle, "rb_player_toggle")
+	purego.RegisterLibFunc(&rbPlayerStop, handle, "rb_player_stop")
+	purego.RegisterLibFunc(&rbPlayerNext, handle, "rb_player_next")
+	purego.RegisterLibFunc(&rbPlayerPrevious, handle, "rb_player_previous")
+	purego.RegisterLibFunc(&rbPlayerSkipTo, handle, "rb_player_skip_to")
+	purego.RegisterLibFunc(&rbPlayerSeekMs, handle, "rb_player_seek_ms")
+	purego.RegisterLibFunc(&rbPlayerSetVolume, handle, "rb_player_set_volume")
+	purego.RegisterLibFunc(&rbPlayerSetCrossfade, handle, "rb_player_set_crossfade")
+	purego.RegisterLibFunc(&rbPlayerSetReplaygain, handle, "rb_player_set_replaygain")
+	purego.RegisterLibFunc(&rbPlayerVolume, handle, "rb_player_volume")
+	purego.RegisterLibFunc(&rbPlayerSampleRate, handle, "rb_player_sample_rate")
+	purego.RegisterLibFunc(&rbPlayerStatusJSON, handle, "rb_player_status_json")
+}
+
+// libNames returns the platform's shared-library filenames, most-specific
+// first.
+func libNames() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{"librockbox_ffi.dylib"}
+	case "windows":
+		return []string{"rockbox_ffi.dll"}
+	default:
+		return []string{"librockbox_ffi.so"}
+	}
+}
+
+// libraryPath locates the prebuilt shared library. Precedence:
+//
+//  1. ROCKBOX_FFI_LIB env var (explicit override).
+//  2. a lib/ dir next to this source file (bundled in a checkout / release).
+//  3. target/release, by walking up from this source file (repo checkout).
+//  4. target/release, by walking up from the executable and the cwd.
+//
+// It returns the first existing candidate, or panics with the list it tried.
+func libraryPath() string {
+	names := libNames()
+	var tried []string
+
+	try := func(cand string) (string, bool) {
+		tried = append(tried, cand)
+		if _, err := os.Stat(cand); err == nil {
+			return cand, true
+		}
+		return "", false
+	}
+
+	// 1. Explicit override.
+	if env := os.Getenv("ROCKBOX_FFI_LIB"); env != "" {
+		if p, ok := try(env); ok {
+			return p
+		}
+	}
+
+	// Source-file directory (present when built from a checkout).
+	var srcDir string
+	if _, file, _, ok := runtime.Caller(0); ok {
+		srcDir = filepath.Dir(file)
+	}
+
+	// 2. Bundled binary next to the source (lib/<name>).
+	if srcDir != "" {
+		for _, name := range names {
+			if p, ok := try(filepath.Join(srcDir, "lib", name)); ok {
+				return p
+			}
+		}
+	}
+
+	// 3 & 4. Walk up from the source dir, the executable dir, and the cwd
+	// looking for target/release.
+	var roots []string
+	if srcDir != "" {
+		roots = append(roots, srcDir)
+	}
+	if exe, err := os.Executable(); err == nil {
+		roots = append(roots, filepath.Dir(exe))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+	}
+	for _, root := range roots {
+		for dir := root; ; {
+			rel := filepath.Join(dir, "target", "release")
+			if info, err := os.Stat(rel); err == nil && info.IsDir() {
+				for _, name := range names {
+					if p, ok := try(filepath.Join(rel, name)); ok {
+						return p
+					}
+				}
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+
+	panic(fmt.Sprintf("rockbox: could not locate librockbox_ffi shared "+
+		"library. Set ROCKBOX_FFI_LIB or run `cargo build --release -p "+
+		"rockbox-ffi`. Tried:\n  %s", filepathListJoin(tried)))
+}
+
+func filepathListJoin(paths []string) string {
+	out := ""
+	for i, p := range paths {
+		if i > 0 {
+			out += "\n  "
+		}
+		out += p
+	}
+	return out
+}
+
+// goString copies a NUL-terminated C string at p into a Go string. Returns ""
+// for a NULL pointer.
+func goString(p uintptr) string {
+	if p == 0 {
+		return ""
+	}
+	var n int
+	for {
+		if *(*byte)(unsafe.Pointer(p + uintptr(n))) == 0 {
+			break
+		}
+		n++
+	}
+	return string(unsafe.Slice((*byte)(unsafe.Pointer(p)), n))
+}
+
+// takeString copies a heap C string returned by the ABI into a Go string, then
+// frees it. The bool is false for a NULL pointer (the ABI's error/absent
+// signal).
+func takeString(p uintptr) (string, bool) {
+	if p == 0 {
+		return "", false
+	}
+	s := goString(p)
+	rbStringFree(p)
+	return s, true
+}

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/tsirysndr/rockboxd/bindings/go
+
+go 1.22
+
+require github.com/ebitengine/purego v0.9.0

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,0 +1,2 @@
+github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=

--- a/bindings/go/metadata.go
+++ b/bindings/go/metadata.go
@@ -1,0 +1,97 @@
+package rockbox
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ReplayGain holds the ReplayGain tags parsed from an audio file. The *Db /
+// *Peak fields are nil when the corresponding tag is absent; the Raw* fields
+// are the native Q7.24 fixed-point values Rockbox uses internally (0 = not
+// tagged) and can be fed straight to [Dsp.SetReplaygainGainsRaw].
+type ReplayGain struct {
+	TrackGainDb  *float32 `json:"track_gain_db"`
+	AlbumGainDb  *float32 `json:"album_gain_db"`
+	TrackPeak    *float32 `json:"track_peak"`
+	AlbumPeak    *float32 `json:"album_peak"`
+	RawTrackGain int64    `json:"raw_track_gain"`
+	RawAlbumGain int64    `json:"raw_album_gain"`
+	RawTrackPeak int64    `json:"raw_track_peak"`
+	RawAlbumPeak int64    `json:"raw_album_peak"`
+}
+
+// AlbumArt locates embedded cover art inside the audio file (Rockbox does not
+// decode it — it hands back the byte range so the caller can).
+type AlbumArt struct {
+	Kind         string `json:"kind"` // "bmp" | "png" | "jpeg" | "unknown"
+	Offset       uint64 `json:"offset"`
+	Size         uint32 `json:"size"`
+	ID3Unsync    bool   `json:"id3_unsync"`
+	VorbisBase64 bool   `json:"vorbis_base64"`
+}
+
+// Cuesheet locates an embedded cuesheet inside the audio file.
+type Cuesheet struct {
+	Offset   uint64 `json:"offset"`
+	Size     uint32 `json:"size"`
+	Encoding string `json:"encoding"` // "latin1" | "utf8" | "utf16le" | "utf16be" | "unknown"
+}
+
+// Meta is the parsed metadata of an audio file returned by [Metadata.Read].
+type Meta struct {
+	Codec            string     `json:"codec"`
+	CodecID          uint32     `json:"codec_id"`
+	Title            string     `json:"title"`
+	Artist           string     `json:"artist"`
+	Album            string     `json:"album"`
+	AlbumArtist      string     `json:"albumartist"`
+	Composer         string     `json:"composer"`
+	Grouping         string     `json:"grouping"`
+	Comment          string     `json:"comment"`
+	Genre            string     `json:"genre"`
+	YearString       string     `json:"year_string"`
+	TrackString      string     `json:"track_string"`
+	DiscString       string     `json:"disc_string"`
+	MBTrackID        string     `json:"mb_track_id"`
+	TrackNumber      *uint32    `json:"track_number"`
+	DiscNumber       *uint32    `json:"disc_number"`
+	Year             *uint32    `json:"year"`
+	DurationMs       uint64     `json:"duration_ms"`
+	Bitrate          uint32     `json:"bitrate"`
+	SampleRate       uint32     `json:"sample_rate"`
+	Filesize         uint64     `json:"filesize"`
+	Samples          uint64     `json:"samples"`
+	VBR              bool       `json:"vbr"`
+	FirstFrameOffset uint64     `json:"first_frame_offset"`
+	ReplayGain       ReplayGain `json:"replaygain"`
+	AlbumArt         *AlbumArt  `json:"album_art"`
+	Cuesheet         *Cuesheet  `json:"cuesheet"`
+}
+
+// Metadata is the audio-file metadata surface. It is stateless; use the
+// package-level [Read] and [Probe] functions via the Metadata value, e.g.
+// rockbox.Metadata.Read(path).
+type metadataNS struct{}
+
+// Metadata groups the metadata functions ([Metadata.Read], [Metadata.Probe]).
+var Metadata metadataNS
+
+// Read parses the metadata of the audio file at path. It returns an error if
+// the file cannot be opened or no parser recognises it.
+func (metadataNS) Read(path string) (*Meta, error) {
+	s, ok := takeString(rbMetaReadJSON(path))
+	if !ok {
+		return nil, fmt.Errorf("rockbox: could not read metadata from %q", path)
+	}
+	var m Meta
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, fmt.Errorf("rockbox: decoding metadata json: %w", err)
+	}
+	return &m, nil
+}
+
+// Probe guesses the codec label (e.g. "FLAC") from a filename's extension
+// without opening the file. The bool is false for an unknown extension.
+func (metadataNS) Probe(filename string) (string, bool) {
+	return takeString(rbMetaProbe(filename))
+}

--- a/bindings/go/player.go
+++ b/bindings/go/player.go
@@ -1,0 +1,170 @@
+package rockbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Config holds the tunables for [NewPlayer]. Use [DefaultConfig] and override
+// the fields you care about. SampleRate 0 means the output device default.
+type Config struct {
+	SampleRate                uint32
+	BufferSeconds             float32
+	Volume                    float32
+	ReplayGainMode            ReplayGainMode
+	ReplayGainPreampDb        float32
+	ReplayGainPreventClipping bool
+	CrossfadeMode             CrossfadeMode
+	FadeOutDelayMs            uint32
+	FadeOutDurationMs         uint32
+	FadeInDelayMs             uint32
+	FadeInDurationMs          uint32
+	MixMode                   MixMode
+}
+
+// DefaultConfig returns the Rockbox default player configuration.
+func DefaultConfig() Config {
+	return Config{
+		SampleRate:                0, // device default
+		BufferSeconds:             4.0,
+		Volume:                    1.0,
+		ReplayGainMode:            ReplayGainOff,
+		ReplayGainPreampDb:        0.0,
+		ReplayGainPreventClipping: true,
+		CrossfadeMode:             CrossfadeOff,
+		FadeOutDelayMs:            0,
+		FadeOutDurationMs:         2000,
+		FadeInDelayMs:             0,
+		FadeInDurationMs:          2000,
+		MixMode:                   MixCrossfade,
+	}
+}
+
+// Player is a queue-based audio player with native ReplayGain and Rockbox
+// crossfade.
+//
+// A Player owns a live audio output device and a background engine thread —
+// construct it only where an output device exists. Call [Player.Close] when
+// done.
+//
+// The ReplayGain mode here uses the *player* encoding (see [ReplayGainMode],
+// Off=0, Track=1, Album=2) — distinct from the DSP encoding.
+type Player struct {
+	ptr uintptr
+}
+
+// NewPlayer creates a player on the default device with the given
+// configuration (start from [DefaultConfig]).
+func NewPlayer(c Config) (*Player, error) {
+	ptr := rbPlayerNewWithConfig(
+		c.SampleRate, c.BufferSeconds, c.Volume, int32(c.ReplayGainMode),
+		c.ReplayGainPreampDb, c.ReplayGainPreventClipping, int32(c.CrossfadeMode),
+		c.FadeOutDelayMs, c.FadeOutDurationMs, c.FadeInDelayMs, c.FadeInDurationMs,
+		int32(c.MixMode),
+	)
+	if ptr == 0 {
+		return nil, errors.New("rockbox: failed to create Player (no output device?)")
+	}
+	return &Player{ptr: ptr}, nil
+}
+
+// NewDefaultPlayer creates a player on the default device with Rockbox default
+// settings.
+func NewDefaultPlayer() (*Player, error) {
+	ptr := rbPlayerNew()
+	if ptr == 0 {
+		return nil, errors.New("rockbox: failed to create Player (no output device?)")
+	}
+	return &Player{ptr: ptr}, nil
+}
+
+// Close frees the native player and stops its engine thread. Safe to call more
+// than once.
+func (p *Player) Close() {
+	if p.ptr == 0 {
+		return
+	}
+	rbPlayerFree(p.ptr)
+	p.ptr = 0
+}
+
+// SetQueue replaces the queue with the given file paths.
+func (p *Player) SetQueue(paths []string) error {
+	b, err := json.Marshal(paths)
+	if err != nil {
+		return fmt.Errorf("rockbox: marshaling queue: %w", err)
+	}
+	rbPlayerSetQueueJSON(p.ptr, string(b))
+	return nil
+}
+
+// Enqueue appends a single file path to the queue.
+func (p *Player) Enqueue(path string) { rbPlayerEnqueue(p.ptr, path) }
+
+// Play starts (or resumes) playback.
+func (p *Player) Play() { rbPlayerPlay(p.ptr) }
+
+// Pause pauses playback.
+func (p *Player) Pause() { rbPlayerPause(p.ptr) }
+
+// Toggle flips between playing and paused.
+func (p *Player) Toggle() { rbPlayerToggle(p.ptr) }
+
+// Stop stops playback and resets the position.
+func (p *Player) Stop() { rbPlayerStop(p.ptr) }
+
+// Next skips to the next track.
+func (p *Player) Next() { rbPlayerNext(p.ptr) }
+
+// Previous skips to the previous track.
+func (p *Player) Previous() { rbPlayerPrevious(p.ptr) }
+
+// SkipTo jumps to the queue entry at index.
+func (p *Player) SkipTo(index int) { rbPlayerSkipTo(p.ptr, uint64(index)) }
+
+// SeekMs seeks within the current track to ms milliseconds.
+func (p *Player) SeekMs(ms uint64) { rbPlayerSeekMs(p.ptr, ms) }
+
+// SetVolume sets the linear output volume (0.0..=1.0).
+func (p *Player) SetVolume(vol float32) { rbPlayerSetVolume(p.ptr, vol) }
+
+// Volume reports the current linear output volume.
+func (p *Player) Volume() float32 { return rbPlayerVolume(p.ptr) }
+
+// SampleRate reports the output device sample rate (Hz).
+func (p *Player) SampleRate() uint32 { return rbPlayerSampleRate(p.ptr) }
+
+// SetCrossfade configures crossfading (see [CrossfadeMode], [MixMode]).
+func (p *Player) SetCrossfade(mode CrossfadeMode, fadeOutDelayMs, fadeOutDurationMs, fadeInDelayMs, fadeInDurationMs uint32, mix MixMode) {
+	rbPlayerSetCrossfade(p.ptr, int32(mode), fadeOutDelayMs, fadeOutDurationMs, fadeInDelayMs, fadeInDurationMs, int32(mix))
+}
+
+// SetReplaygain sets the ReplayGain mode (see [ReplayGainMode], Off=0, Track=1,
+// Album=2), pre-amp in dB, and clipping prevention.
+func (p *Player) SetReplaygain(mode ReplayGainMode, preampDb float32, preventClipping bool) {
+	rbPlayerSetReplaygain(p.ptr, int32(mode), preampDb, preventClipping)
+}
+
+// Status is a snapshot of the player's playback state.
+type Status struct {
+	State      string `json:"state"` // "stopped" | "playing" | "paused"
+	Index      *int   `json:"index"`
+	PositionMs uint64 `json:"position_ms"`
+	DurationMs uint64 `json:"duration_ms"`
+	QueueLen   int    `json:"queue_len"`
+	Metadata   *Meta  `json:"metadata"`
+}
+
+// Status returns a snapshot of the player's status.
+func (p *Player) Status() (*Status, error) {
+	s, ok := takeString(rbPlayerStatusJSON(p.ptr))
+	if !ok {
+		return nil, errors.New("rockbox: rb_player_status_json returned NULL")
+	}
+	var st Status
+	if err := json.Unmarshal([]byte(s), &st); err != nil {
+		return nil, fmt.Errorf("rockbox: decoding status json: %w", err)
+	}
+	return &st, nil
+}

--- a/bindings/go/rockbox.go
+++ b/bindings/go/rockbox.go
@@ -1,0 +1,28 @@
+package rockbox
+
+import "math"
+
+// ABIVersion reports the ABI major version of the loaded library (bumped on
+// breaking changes).
+func ABIVersion() uint32 {
+	return rbFFIABIVersion()
+}
+
+// SineStereo generates seconds of a sine at freqHz as interleaved stereo int16
+// samples at the given sample rate. amplitude is the peak (e.g. 16000).
+func SineStereo(freqHz float64, seconds float64, rate int, amplitude int) []int16 {
+	n := int(seconds * float64(rate))
+	buf := make([]int16, n*2)
+	for i := 0; i < n; i++ {
+		s := int(math.Sin(float64(i)*2.0*math.Pi*freqHz/float64(rate)) * float64(amplitude))
+		if s < math.MinInt16 {
+			s = math.MinInt16
+		}
+		if s > math.MaxInt16 {
+			s = math.MaxInt16
+		}
+		buf[i*2] = int16(s)
+		buf[i*2+1] = int16(s)
+	}
+	return buf
+}

--- a/bindings/go/rockbox_test.go
+++ b/bindings/go/rockbox_test.go
@@ -1,0 +1,112 @@
+package rockbox_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"testing"
+
+	rockbox "github.com/tsirysndr/rockboxd/bindings/go"
+)
+
+func fixture(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate test source")
+	}
+	repo := filepath.Join(filepath.Dir(file), "..", "..")
+	return filepath.Join(repo, "crates", "rocksky", "fixtures",
+		"08 - Internet Money - Speak(Explicit).m4a")
+}
+
+func TestABIVersion(t *testing.T) {
+	if got := rockbox.ABIVersion(); got != 1 {
+		t.Fatalf("ABIVersion() = %d, want 1", got)
+	}
+}
+
+func TestMetadataReadAndProbe(t *testing.T) {
+	meta, err := rockbox.Metadata.Read(fixture(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Codec != "AAC" {
+		t.Errorf("Codec = %q, want AAC", meta.Codec)
+	}
+	if meta.SampleRate != 44100 {
+		t.Errorf("SampleRate = %d, want 44100", meta.SampleRate)
+	}
+	if meta.DurationMs == 0 {
+		t.Error("DurationMs should be > 0")
+	}
+
+	if got, ok := rockbox.Metadata.Probe("song.flac"); !ok || got != "FLAC" {
+		t.Errorf("Probe(song.flac) = %q, %v; want FLAC, true", got, ok)
+	}
+	if _, ok := rockbox.Metadata.Probe("nope.xyz"); ok {
+		t.Error("Probe(nope.xyz) should report ok=false")
+	}
+}
+
+func TestDspReplaygainHalvesAmplitude(t *testing.T) {
+	dsp, err := rockbox.NewDsp(44100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dsp.Close()
+
+	dsp.SetReplaygain(rockbox.DspReplayGainTrack, false, 0.0)
+	dsp.SetReplaygainGains(rockbox.Opt(-6.0206), nil, nil, nil) // x0.5
+
+	out, err := dsp.Process(rockbox.SineStereo(1000, 1.0, 44100, 16000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	peak := 0
+	for _, s := range out {
+		v := int(s)
+		if v < 0 {
+			v = -v
+		}
+		if v > peak {
+			peak = v
+		}
+	}
+	if peak < 7600 || peak > 8400 {
+		t.Errorf("peak = %d, want ~8000", peak)
+	}
+}
+
+func TestPlayerConstructAndStatus(t *testing.T) {
+	cfg := rockbox.DefaultConfig()
+	cfg.Volume = 0.0
+	player, err := rockbox.NewPlayer(cfg)
+	if err != nil {
+		// Constructing a Player opens a live output device; headless CI
+		// runners often have none. Skip rather than fail there.
+		t.Skipf("no audio output device available: %v", err)
+	}
+	defer player.Close()
+
+	if player.SampleRate() == 0 {
+		t.Fatal("SampleRate should be > 0")
+	}
+	player.SetVolume(0.0)
+	if err := player.SetQueue([]string{fixture(t)}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond) // queue command is applied asynchronously
+
+	st, err := player.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != "stopped" {
+		t.Errorf("State = %q, want stopped", st.State)
+	}
+	if st.QueueLen != 1 {
+		t.Errorf("QueueLen = %d, want 1", st.QueueLen)
+	}
+}

--- a/bindings/scripts/fetch-libs.sh
+++ b/bindings/scripts/fetch-libs.sh
@@ -22,6 +22,7 @@
 # Staging locations (per target <t>, ext = dylib on macOS, so elsewhere):
 #   ruby       -> bindings/ruby/vendor/librockbox_ffi.<ext>
 #   python     -> bindings/python/src/rockbox_ffi/_lib/librockbox_ffi.<ext>
+#   go         -> bindings/go/lib/librockbox_ffi.<ext>
 #   typescript -> bindings/typescript/npm/<t>/librockbox_ffi.<ext>
 #   kotlin     -> bindings/kotlin/src/main/resources/native/<t>/librockbox_ffi.<ext>
 #   clojure    -> bindings/clojure/resources/native/<t>/librockbox_ffi.<ext>
@@ -134,6 +135,7 @@ stage() {  # stage <target> <dest-file>
 stage_npm()     { local t="$1"; stage "$t" "$BINDINGS_DIR/typescript/npm/${t}/librockbox_ffi.$(libext "$t")"; }
 stage_ruby()    { local t="$1"; stage "$t" "$BINDINGS_DIR/ruby/vendor/librockbox_ffi.$(libext "$t")"; }
 stage_python()  { local t="$1"; stage "$t" "$BINDINGS_DIR/python/src/rockbox_ffi/_lib/librockbox_ffi.$(libext "$t")"; }
+stage_go()      { local t="$1"; stage "$t" "$BINDINGS_DIR/go/lib/librockbox_ffi.$(libext "$t")"; }
 stage_kotlin()  { local t="$1"; stage "$t" "$BINDINGS_DIR/kotlin/src/main/resources/native/${t}/librockbox_ffi.$(libext "$t")"; }
 stage_clojure() { local t="$1"; stage "$t" "$BINDINGS_DIR/clojure/resources/native/${t}/librockbox_ffi.$(libext "$t")"; }
 
@@ -146,17 +148,19 @@ if [ "$ALL" -eq 1 ]; then
   done
   host="$(host_target)"
   if [ -n "$host" ]; then
-    echo "Staging host ($host) into ruby + python (single-slot — rerun with --target for others):"
+    echo "Staging host ($host) into ruby + python + go (single-slot — rerun with --target for others):"
     stage_ruby "$host" || true
     stage_python "$host" || true
+    stage_go "$host" || true
   fi
 else
   t="${TARGET:-$(host_target)}"
   [ -n "$t" ] || { echo "error: unsupported host $(uname -sm); pass --target" >&2; exit 1; }
-  echo "Staging $t into ruby + python + typescript/npm/$t + kotlin + clojure:"
+  echo "Staging $t into ruby + python + go + typescript/npm/$t + kotlin + clojure:"
   echo "  (JVM jars bundle every target — use --all before publishing kotlin/clojure)"
   stage_ruby "$t"
   stage_python "$t"
+  stage_go "$t"
   stage_npm "$t"
   stage_kotlin "$t"
   stage_clojure "$t"

--- a/crates/rockbox-ffi/README.md
+++ b/crates/rockbox-ffi/README.md
@@ -39,8 +39,9 @@ cargo build --release -p rockbox-ffi
 
 ## Language bindings
 
-See [`bindings/`](../../bindings) for Python (cffi), TypeScript (Bun/Deno
-FFI), Elixir, and Gleam packages that consume this library.
+See [`bindings/`](../../bindings) for Python (cffi), Go (purego), TypeScript
+(Bun/Deno FFI), Ruby, Swift, Elixir, Gleam, Kotlin, and Clojure packages that
+consume this library.
 
 ## ABI stability
 

--- a/mintlify/bindings/go.mdx
+++ b/mintlify/bindings/go.mdx
@@ -1,0 +1,86 @@
+---
+title: "Go"
+description: "Rockbox DSP, metadata, and playback in Go via purego over the librockbox_ffi C ABI — no cgo."
+icon: 'golang'
+---
+
+```sh
+go get github.com/tsirysndr/rockboxd/bindings/go
+```
+
+Requires **Go 1.22+**. Calls the native engine through
+[`purego`](https://github.com/ebitengine/purego) — **no cgo and no C
+toolchain**; the package `dlopen`s a prebuilt `librockbox_ffi` at process
+start. From a repo checkout the loader walks up to `target/release/`; override
+with `ROCKBOX_FFI_LIB`.
+
+## Quick start
+
+```go
+package main
+
+import (
+	"fmt"
+
+	rockbox "github.com/tsirysndr/rockboxd/bindings/go"
+)
+
+func main() {
+	// --- metadata -----------------------------------------------------
+	meta, _ := rockbox.Metadata.Read("song.flac")
+	fmt.Println(meta.Artist, "—", meta.Title, meta.DurationMs, "ms")
+	label, _ := rockbox.Metadata.Probe("track.opus") // "Opus" (no I/O, extension guess)
+	fmt.Println(label)
+
+	// --- DSP: process interleaved stereo int16 ------------------------
+	dsp, _ := rockbox.NewDsp(44_100)
+	defer dsp.Close()
+	dsp.EqEnable(true)
+	dsp.SetEqBand(0, 60, 0.7, 3.0)
+	dsp.SetReplaygain(rockbox.DspReplayGainTrack, true, 0.0)
+	dsp.SetReplaygainGains(rockbox.Opt(-6.02), nil, nil, nil) // −6 dB ≈ half amplitude
+	processed, _ := dsp.Process(samples)                      // []int16
+	_ = processed
+
+	// --- playback (needs an output device) ----------------------------
+	cfg := rockbox.DefaultConfig()
+	cfg.Volume = 0.8
+	player, _ := rockbox.NewPlayer(cfg)
+	defer player.Close()
+	player.SetReplaygain(rockbox.ReplayGainTrack, 0.0, true)
+	player.SetCrossfade(rockbox.CrossfadeAlways, 0, 2000, 0, 2000, rockbox.MixCrossfade)
+	player.SetQueue([]string{"a.flac", "b.mp3", "c.opus"})
+	player.Play()
+	st, _ := player.Status() // &Status{State: "playing", Index: 0, ...}
+	fmt.Println(st.State)
+}
+```
+
+## API
+
+| Symbol                          | Contents                                                           |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `rockbox.Metadata`              | `Read(path) (*Meta, error)`, `Probe(name) (string, bool)`          |
+| `rockbox.NewDsp` → `*Dsp`       | EQ / tone / surround / compressor / ReplayGain, `Process([]int16)` |
+| `rockbox.NewPlayer` → `*Player` | queue + transport + crossfade + ReplayGain, `Status()`             |
+| `rockbox.*` consts              | `DspReplayGainMode`, `ReplayGainMode`, `CrossfadeMode`, `MixMode`, `ChannelConfig` |
+
+- **Handles** own native resources — `defer dsp.Close()` / `defer player.Close()`
+  frees them.
+- **Rich values** (metadata, status) decode into typed structs (`Meta`,
+  `Status`); optional tags are `nil`-able pointer fields.
+- **Sample buffers** are `[]int16` of interleaved-stereo signed 16-bit samples.
+
+<Warning>
+  `Dsp.SetReplaygain` and `Player.SetReplaygain` take **different mode
+  integers**. Always pass the named constants — `DspReplayGain*` for the DSP,
+  `ReplayGain*` for the player. See [the overview](/bindings/overview#the-one-thing-to-know-two-replaygain-encodings).
+</Warning>
+
+## Smoke test
+
+```sh
+cd bindings/go
+go run ./examples/smoke   # metadata + DSP + player checks
+go test ./...
+```

--- a/mintlify/bindings/overview.mdx
+++ b/mintlify/bindings/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Native engine bindings"
-description: "Call the Rockbox DSP, metadata, and playback engine in-process from eight languages, all over one shared C ABI."
+description: "Call the Rockbox DSP, metadata, and playback engine in-process from nine languages, all over one shared C ABI."
 icon: 'plug'
 ---
 
@@ -50,6 +50,9 @@ Every binding exposes the same three namespaces with matching method names:
 <CardGroup cols={3}>
   <Card title="Python" icon="python" href="/bindings/python">
     `pip install rockbox-ffi` — cffi
+  </Card>
+  <Card title="Go" icon="golang" href="/bindings/go">
+    `go get …/bindings/go` — purego, no cgo
   </Card>
   <Card title="TypeScript" icon="square-js" href="/bindings/typescript">
     `npm install rockbox-ffi` — Bun / Deno / Node

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -137,6 +137,7 @@
             "pages": [
               "bindings/overview",
               "bindings/python",
+              "bindings/go",
               "bindings/typescript",
               "bindings/ruby",
               "bindings/elixir",


### PR DESCRIPTION
Go binding for the rockbox-ffi DSP / metadata / playback engine, sitting on the same flat C ABI as the other bindings. Uses purego (pure-Go dlopen, no cgo) with the shared ROCKBOX_FFI_LIB / target/release loader fallback, mirroring the Ruby/Swift/Python runtime-dlopen design.

- bindings/go: typed Meta/Status structs, Dsp, Player, enums, top-level ABIVersion/SineStereo; smoke example + test suite (same native-pipeline parity check: -6.02 dB track gain halves a 1 kHz sine to peak ~8000).
- CI: bindings-go-test workflow (ubuntu + macos) builds librockbox_ffi and runs go vet + go test; player test skips when no output device.
- fetch-libs.sh: stage host lib into bindings/go/lib/.
- docs: mintlify bindings/go.mdx + nav/overview, README updates.