### PR TITLE
ci(bindings/go): force external linker on macOS

### DIFF
--- a/.github/workflows/bindings-go-test.yml
+++ b/.github/workflows/bindings-go-test.yml
@@ -62,4 +62,11 @@ jobs:
 
       - name: go test
         working-directory: bindings/go
+        # CGO_ENABLED=1 forces the external system linker. purego dlopens the
+        # shared library at runtime; on macOS the Go *internal* linker (the
+        # CGO_ENABLED=0 default) omits the LC_UUID Mach-O load command, and
+        # newer dyld aborts any process that dlopens without it. We use no cgo
+        # ourselves — this only swaps the linker.
+        env:
+          CGO_ENABLED: 1
         run: go test -v ./...


### PR DESCRIPTION
The go test job aborted on macOS with "missing LC_UUID load command": purego dlopens librockbox_ffi at runtime, but Go's internal linker (the CGO_ENABLED=0 default) omits the LC_UUID Mach-O load command, and newer dyld refuses to run a process that dlopens without it. Set CGO_ENABLED=1 so the external system linker (which emits LC_UUID) is used. No cgo is used in the binding itself — this only swaps the linker.