### PR TITLE
tools/console: add Clojure/babashka REPL centralizing monorepo commands

### DIFF
--- a/tools/console/.gitignore
+++ b/tools/console/.gitignore
@@ -1,0 +1,6 @@
+.cpcache/
+.clj-kondo/
+.lsp/
+.nrepl-port
+target/
+.rebel_readline_history

--- a/tools/console/.mise.toml
+++ b/tools/console/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+java = "temurin-21"
+clojure = "1.12.0.1530"
+babashka = "1.12.205"

--- a/tools/console/README.md
+++ b/tools/console/README.md
@@ -1,0 +1,119 @@
+# Rockbox Console
+
+A REPL-driven, single entry point for **every build / dev / ops command** in
+the rockboxd monorepo. Instead of remembering the exact `make`, `cargo`,
+`zig`, `bun`, and `bash scripts/*.sh` incantations scattered across
+`CLAUDE.md`, you get one Clojure namespace tree you can drive from a REPL or
+one-shot [babashka](https://babashka.org) tasks.
+
+```
+tools/console/
+├── deps.edn                 Clojure deps + :dev (nREPL) / :rebel aliases
+├── bb.edn                   babashka task surface (bb <task>)
+├── .mise.toml               pinned java / clojure / babashka versions
+├── dev/user.clj             auto-loaded REPL helpers (aliases + .env load)
+└── src/console/
+    ├── path.clj             repo-root discovery (Cargo.toml + zig/build.zig)
+    ├── shell.clj            sh / sh! / sh* + make/cargo/zig/bun/bash shims
+    ├── env.clj              dotenv loader; injected into every subprocess
+    ├── core.clj             command registry, (help)/(ls)/dispatch
+    ├── build.clj            firmware → crates → zig → rockboxd pipeline
+    ├── make.clj             raw make + tools/configure escape hatches
+    ├── run.clj              run the daemon (plain / RUST_LOG / ffplay pipe)
+    ├── dev.clj              cargo fmt / clippy / test / check
+    ├── wasm.clj             WASM build + dev server
+    ├── expo.clj             mobile app + native gRPC module builds
+    ├── bindings.clj         rockbox-ffi + multi-language publish
+    ├── verify.clj           nm / ar / stale-binary sanity checks
+    └── scripts.clj          auto-discovers & runs every scripts/*.sh
+```
+
+## Setup
+
+Versions are pinned in `.mise.toml` (Java 21 / Clojure / babashka). With
+[mise](https://mise.jdx.dev):
+
+```sh
+cd tools/console
+mise install          # installs java, clojure, babashka
+```
+
+Or install `clojure` + `bb` however you like.
+
+## Two ways to run
+
+### 1. One-shot tasks (`bb <task>`)
+
+```sh
+cd tools/console
+
+bb help                 # pretty command tour
+bb tasks                # raw babashka task list
+
+bb build:all            # firmware → crates → zig → rockboxd
+bb run                  # ./zig/zig-out/bin/rockboxd
+bb run:debug            # RUST_LOG=debug rockboxd
+bb wasm:build           # bash scripts/build-wasm.sh
+bb verify:stale         # binary vs .a timestamps
+bb scripts              # list every scripts/*.sh
+bb script build-armhf   # run one of them
+```
+
+### 2. REPL (recommended for anything iterative)
+
+```sh
+cd tools/console
+clj -M:rebel            # rich terminal REPL
+# or: clj -M:dev        # nREPL for your editor (CIDER / Calva)
+```
+
+`dev/user.clj` loads on start, drops every namespace into scope under short
+aliases, and auto-loads `<repo>/.env`:
+
+```clojure
+user=> (help)                 ; command tour
+user=> (build/all)            ; full rebuild
+user=> (run/daemon)           ; launch rockboxd
+user=> (run/debug "rockbox_airplay=debug,info")
+user=> (verify/stale)         ; check the stale-binary pitfall
+user=> (scripts/build-wasm)   ; every scripts/*.sh is a fn
+user=> (env/set! "RUST_LOG" "debug")  ; propagates to later subprocesses
+```
+
+## Command groups
+
+| Group      | Namespace          | What it wraps                                             |
+| ---------- | ------------------ | -------------------------------------------------------- |
+| `build`    | `console.build`    | The C→Rust→Zig pipeline into `rockboxd` / `librockboxd.a`|
+| `make`     | `console.make`     | Raw `make` in a build dir + `tools/configure`            |
+| `run`      | `console.run`      | Run the daemon (plain / `RUST_LOG` / ffplay pipe)        |
+| `dev`      | `console.dev`      | `cargo fmt` / `clippy` / `test` / `check`                |
+| `wasm`     | `console.wasm`     | `scripts/build-wasm.sh` + the COOP/COEP dev server       |
+| `expo`     | `console.expo`     | Mobile app dev + iOS/Android native gRPC module builds   |
+| `bindings` | `console.bindings` | `rockbox-ffi` + npm/python/ruby publish scripts          |
+| `verify`   | `console.verify`   | `nm` / `ar` / timestamp sanity checks from `CLAUDE.md`   |
+| `scripts`  | `console.scripts`  | Auto-discovered `scripts/*.sh` (no hand-maintained list) |
+| `env`      | `console.env`      | dotenv loader injected into every spawned subprocess     |
+
+## How it works
+
+- **Repo-root aware.** `console.path/repo-root` walks up from the cwd looking
+  for the workspace `Cargo.toml` next to `zig/build.zig`, so commands run from
+  the right directory no matter where you invoke them.
+- **Env injection.** Whatever you load with `(env/load!)` / `(env/set! …)` is
+  merged into every subprocess's environment via `console.shell` — handy for
+  `RUST_LOG`, `ROCKBOX_LIBRARY`, `ANDROID_NDK_HOME`, etc.
+- **Scripts are free.** Drop a new `scripts/foo.sh` in the repo and it shows up
+  in `(scripts/ls)` / `bb scripts` and becomes callable as `(scripts/foo)` —
+  no edit here required.
+
+## Adding a command
+
+1. Add a function to the relevant `console.<group>` namespace (or create a new
+   one). Use the `console.shell` helpers (`sh`, `make`, `cargo`, `zig`, `bun`,
+   `bash`) so it inherits the repo-root dir and loaded env.
+2. Add a one-liner to the `registry` in `console.core` so `(help)`/`(ls)` list
+   it.
+3. (Optional) Add a matching `bb.edn` task for shell-only use.
+
+Pure `scripts/*.sh` need none of this — they are picked up automatically.

--- a/tools/console/bb.edn
+++ b/tools/console/bb.edn
@@ -1,0 +1,116 @@
+{:paths ["src"]
+ :deps  {}
+
+ :tasks
+ {:requires ([console.core :as c])
+
+  ;; ── meta ─────────────────────────────────────────────────────
+  help    {:doc "Show all available console commands"
+           :override-builtin true
+           :task (c/help)}
+  ls      {:doc "List every registered command grouped by namespace"
+           :task (c/ls)}
+
+  ;; ── build (firmware -> crates -> zig) ────────────────────────
+  build:all      {:doc  "Full rebuild: firmware -> crates -> zig -> rockboxd"
+                  :task (do (require 'console.build) ((resolve 'console.build/all)))}
+  build:firmware {:doc  "make lib in build-lib (SDL firmware)"
+                  :task (do (require 'console.build) ((resolve 'console.build/firmware)))}
+  build:cli      {:task (do (require 'console.build) ((resolve 'console.build/cli)))}
+  build:server   {:task (do (require 'console.build) ((resolve 'console.build/server)))}
+  build:crates   {:doc  "Build rockbox-cli + rockbox-server staticlibs"
+                  :task (do (require 'console.build) ((resolve 'console.build/crates)))}
+  build:zig      {:doc  "cd zig && zig build -> rockboxd"
+                  :task (do (require 'console.build) ((resolve 'console.build/zig)))}
+  build:lib      {:doc  "Embeddable librockboxd.a (headless -> embed -> zig lib)"
+                  :task (do (require 'console.build) ((resolve 'console.build/lib)))}
+  build:headless {:task (do (require 'console.build) ((resolve 'console.build/headless)))}
+  build:gpui     {:doc  "GPUI desktop client"
+                  :task (do (require 'console.build) ((resolve 'console.build/gpui)))}
+  build:armhf    {:task (do (require 'console.build) ((resolve 'console.build/armhf)))}
+
+  ;; ── make / configure ─────────────────────────────────────────
+  make       {:doc  "make <targets> in a build dir. Usage: bb make <build-dir> [targets...]"
+              :task (do (require 'console.make)
+                        (apply (resolve 'console.make/make) *command-line-args*))}
+  make:lib   {:doc  "make lib in a build dir. Usage: bb make:lib [build-dir]"
+              :task (do (require 'console.make)
+                        (apply (resolve 'console.make/lib) *command-line-args*))}
+  make:clean {:doc  "make clean in a build dir. Usage: bb make:clean [build-dir]"
+              :task (do (require 'console.make)
+                        (apply (resolve 'console.make/clean) *command-line-args*))}
+  configure  {:doc  "tools/configure in a build dir (regenerates Makefile!). Usage: bb configure <build-dir> [args...]"
+              :task (do (require 'console.make)
+                        (apply (resolve 'console.make/configure) *command-line-args*))}
+
+  ;; ── run ──────────────────────────────────────────────────────
+  run        {:doc  "Run rockboxd. Extra args pass through."
+              :override-builtin true
+              :task (do (require 'console.run)
+                        (apply (resolve 'console.run/daemon) *command-line-args*))}
+  run:debug  {:doc  "Run rockboxd with RUST_LOG. Usage: bb run:debug [rust-log] [args...]"
+              :task (do (require 'console.run)
+                        (apply (resolve 'console.run/debug) *command-line-args*))}
+  run:pipe   {:doc  "FIFO stdout -> ffplay"
+              :task (do (require 'console.run) ((resolve 'console.run/pipe)))}
+
+  ;; ── dev (rust code quality) ──────────────────────────────────
+  fmt        {:task (do (require 'console.dev) ((resolve 'console.dev/fmt)))}
+  fmt:check  {:task (do (require 'console.dev) ((resolve 'console.dev/fmt-check)))}
+  clippy     {:task (do (require 'console.dev)
+                        (apply (resolve 'console.dev/clippy) *command-line-args*))}
+  test       {:task (do (require 'console.dev)
+                        (apply (resolve 'console.dev/test) *command-line-args*))}
+  check      {:task (do (require 'console.dev) ((resolve 'console.dev/check)))}
+
+  ;; ── wasm ─────────────────────────────────────────────────────
+  wasm:build {:task (do (require 'console.wasm) ((resolve 'console.wasm/build)))}
+  wasm:serve {:task (do (require 'console.wasm) ((resolve 'console.wasm/serve)))}
+
+  ;; ── expo (mobile) ────────────────────────────────────────────
+  expo:install    {:task (do (require 'console.expo) ((resolve 'console.expo/install)))}
+  expo:start      {:task (do (require 'console.expo) ((resolve 'console.expo/start)))}
+  expo:typecheck  {:task (do (require 'console.expo) ((resolve 'console.expo/typecheck)))}
+  expo:lint       {:task (do (require 'console.expo) ((resolve 'console.expo/lint)))}
+  expo:export-web {:task (do (require 'console.expo) ((resolve 'console.expo/export-web)))}
+  expo:ios        {:task (do (require 'console.expo) ((resolve 'console.expo/ios)))}
+  expo:android    {:task (do (require 'console.expo) ((resolve 'console.expo/android)))}
+  expo:prebuild   {:task (do (require 'console.expo) ((resolve 'console.expo/prebuild)))}
+  expo:run-ios    {:task (do (require 'console.expo) ((resolve 'console.expo/run-ios)))}
+  expo:run-android {:task (do (require 'console.expo) ((resolve 'console.expo/run-android)))}
+
+  ;; ── bindings (multi-language) ────────────────────────────────
+  bindings:ffi        {:task (do (require 'console.bindings) ((resolve 'console.bindings/ffi)))}
+  bindings:fetch-libs {:doc  "Stage prebuilt libs. Usage: bb bindings:fetch-libs [args...]"
+                       :task (do (require 'console.bindings)
+                                 (apply (resolve 'console.bindings/fetch-libs) *command-line-args*))}
+  bindings:publish    {:doc  "Publish packages. Usage: bb bindings:publish <npm|python|ruby> [flags]"
+                       :task (do (require 'console.bindings)
+                                 (apply (resolve 'console.bindings/publish) *command-line-args*))}
+
+  ;; ── verify (symbol / timestamp sanity) ───────────────────────
+  verify:stale     {:task (do (require 'console.verify) ((resolve 'console.verify/stale)))}
+  verify:symbols   {:task (do (require 'console.verify) ((resolve 'console.verify/symbols)))}
+  verify:staticlib {:task (do (require 'console.verify) ((resolve 'console.verify/staticlib)))}
+  nm               {:doc  "grep rockboxd symbols. Usage: bb nm <pattern>"
+                    :task (do (require 'console.verify)
+                              ((resolve 'console.verify/nm) (first *command-line-args*)))}
+  ar               {:doc  "grep librockbox_cli.a members. Usage: bb ar <pattern>"
+                    :task (do (require 'console.verify)
+                              ((resolve 'console.verify/ar) (first *command-line-args*)))}
+
+  ;; ── scripts (auto-discovered scripts/*.sh) ───────────────────
+  scripts     {:doc  "List every scripts/*.sh"
+               :task (do (require 'console.scripts) ((resolve 'console.scripts/ls)))}
+  script      {:doc  "Run a script. Usage: bb script <name> [args...]"
+               :task (do (require 'console.scripts)
+                         (apply (resolve 'console.scripts/run) *command-line-args*))}
+
+  ;; ── env ──────────────────────────────────────────────────────
+  env:show    {:doc  "Show every loaded key (masked)."
+               :task (do (require 'console.env)
+                         ((resolve 'console.env/load!))
+                         ((resolve 'console.env/show)))}
+  env:set     {:doc  "Set one key. Usage: bb env:set <KEY> <VALUE>"
+               :task (do (require 'console.env)
+                         (apply (resolve 'console.env/set!) *command-line-args*))}}}

--- a/tools/console/deps.edn
+++ b/tools/console/deps.edn
@@ -1,0 +1,24 @@
+{:paths ["src"]
+
+ :deps
+ {babashka/process {:mvn/version "0.5.22"}
+  babashka/fs      {:mvn/version "0.5.20"}}
+
+ :aliases
+ {:dev
+  {:extra-paths ["dev"]
+   :extra-deps {nrepl/nrepl       {:mvn/version "1.3.0"}
+                cider/cider-nrepl {:mvn/version "0.50.2"}}
+   :main-opts ["-m" "nrepl.cmdline"
+               "--middleware" "[cider.nrepl/cider-middleware]"
+               "--interactive"]}
+
+  ;; Terminal REPL with syntax highlighting, multi-line editing,
+  ;; inline docs, and tab-completion. `clj -M:rebel`
+  :rebel
+  {:extra-paths ["dev"]
+   :extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+   :main-opts ["-m" "rebel-readline.main"]}
+
+  :run
+  {:exec-fn console.core/dispatch}}}

--- a/tools/console/dev/user.clj
+++ b/tools/console/dev/user.clj
@@ -1,0 +1,34 @@
+(ns user
+  "Auto-loaded REPL helpers. Drops every console namespace into scope under
+  short aliases so you can poke around immediately.
+
+      user=> (help)
+      user=> (build/all)
+      user=> (run/daemon)
+      user=> (scripts/build-wasm)
+      user=> (verify/stale)"
+  (:require [console.core    :as c]
+            [console.shell   :as sh]
+            [console.env     :as env]
+            [console.build   :as build]
+            [console.make    :as make]
+            [console.run     :as run]
+            [console.dev     :as dev]
+            [console.wasm    :as wasm]
+            [console.expo    :as expo]
+            [console.bindings :as bindings]
+            [console.verify  :as verify]
+            [console.scripts :as scripts]))
+
+(def help c/help)
+(def ls   c/ls)
+
+;; Auto-load <repo>/.env on REPL startup. Silent if the file is missing,
+;; so a fresh clone still drops into a usable REPL.
+(let [n (try (env/load!) (catch Exception _ nil))]
+  (println)
+  (println "Rockbox Console — REPL loaded. Try (help) or (ls).")
+  (println "Aliases: c, sh, env, build, make, run, dev, wasm, expo, bindings, verify, scripts")
+  (when n
+    (println (str "Loaded " n " env vars from .env — `(env/show)` to inspect.")))
+  (println))

--- a/tools/console/src/console/bindings.clj
+++ b/tools/console/src/console/bindings.clj
@@ -1,0 +1,42 @@
+(ns console.bindings
+  "Multi-language bindings around the shared C ABI in `crates/rockbox-ffi`
+  (cdylib + staticlib), consumed by bindings/{python,typescript,ruby,go,
+  kotlin,clojure,elixir,gleam,swift}.
+
+      (bindings/ffi)          ;; cargo build --release -p rockbox-ffi
+      (bindings/fetch-libs)   ;; stage prebuilt libs from a GH release
+      (bindings/publish :npm) ;; publish npm packages from a GH release
+      (bindings/publish :python)
+      (bindings/publish :ruby)"
+  (:require [console.shell :as sh]))
+
+(defn ffi
+  "Build the shared FFI library: `cargo build --release -p rockbox-ffi`.
+  Produces the cdylib (librockbox_ffi.{dylib,so}) + staticlib every binding
+  links against."
+  [& args]
+  (apply sh/cargo-build "rockbox-ffi" args))
+
+(defn fetch-libs
+  "Download prebuilt librockbox_ffi shared libs from a GitHub Release and
+  stage them into each binding. Extra args pass through, e.g.
+
+      (bindings/fetch-libs \"--all\")
+      (bindings/fetch-libs \"--target\" \"linux-x64\")"
+  [& args]
+  (apply sh/bash "bindings/scripts/fetch-libs.sh" args))
+
+(defn publish
+  "Publish a language's packages from a GitHub Release.
+
+      (bindings/publish :npm)
+      (bindings/publish :python \"--dry-run\")
+      (bindings/publish :ruby)"
+  [lang & args]
+  (let [script (case (keyword lang)
+                 :npm    "bindings/scripts/publish-npm.sh"
+                 :python "bindings/scripts/publish-python.sh"
+                 :ruby   "bindings/scripts/publish-ruby.sh"
+                 (throw (ex-info "Unknown binding target"
+                                 {:lang lang :known [:npm :python :ruby]})))]
+    (apply sh/bash script args)))

--- a/tools/console/src/console/build.clj
+++ b/tools/console/src/console/build.clj
@@ -1,0 +1,107 @@
+(ns console.build
+  "The rockboxd build pipeline. Three stages link into one binary:
+
+    1. C firmware   (Make)  -> build-lib/libfirmware.a & friends
+    2. Rust crates  (Cargo) -> target/release/librockbox_{cli,server}.a
+    3. Zig linker   (Zig)   -> zig/zig-out/bin/rockboxd
+
+  Stale-binary pitfall: `zig build` only re-links when the `.a` files are
+  newer than the binary. After touching C, run `(firmware)` first; after
+  touching Rust, run `(cli)`/`(server)`. `(all)` does the whole chain in
+  order. `(console.verify/stale)` prints the relevant timestamps.
+
+  REPL examples:
+
+      (build/all)          ;; firmware + cli + server + zig -> rockboxd
+      (build/firmware)     ;; just `make lib` in build-lib
+      (build/zig)          ;; just re-link
+      (build/lib)          ;; embeddable librockboxd.a (headless chain)
+      (build/gpui)         ;; desktop client"
+  (:require [console.shell :as sh]))
+
+;; ── stage 1: C firmware ──────────────────────────────────────────────
+
+(defn firmware
+  "Stage 1 — build the SDL firmware: `cd build-lib && make lib`.
+  Produces libfirmware.a, librockbox.a and the codec libs."
+  []
+  (sh/make "build-lib" "lib"))
+
+(defn headless
+  "Build the headless (no-SDL) firmware for the embeddable library:
+  `cd build-headless && make lib`."
+  []
+  (sh/make "build-headless" "lib"))
+
+;; ── stage 2: Rust crates ─────────────────────────────────────────────
+
+(defn cli
+  "Stage 2 — `cargo build --release -p rockbox-cli`
+  (produces target/release/librockbox_cli.a)."
+  []
+  (sh/cargo-build "rockbox-cli"))
+
+(defn server
+  "Stage 2 — `cargo build --release -p rockbox-server`
+  (produces target/release/librockbox_server.a)."
+  []
+  (sh/cargo-build "rockbox-server"))
+
+(defn crates
+  "Stage 2 — build both staticlib crates in one cargo invocation."
+  []
+  (sh/cargo-build "rockbox-cli" "rockbox-server"))
+
+;; ── stage 3: Zig linker ──────────────────────────────────────────────
+
+(defn zig
+  "Stage 3 — `cd zig && zig build` (links zig-out/bin/rockboxd)."
+  []
+  (sh/zig "build"))
+
+;; ── full pipelines ───────────────────────────────────────────────────
+
+(defn all
+  "Full rebuild in dependency order: firmware -> crates -> zig.
+  Stops at the first stage that fails (non-zero exit)."
+  []
+  (let [steps [["firmware" firmware] ["crates" crates] ["zig" zig]]]
+    (reduce (fn [_ [label f]]
+              (println (str "\n▶ build: " label))
+              (let [code (f)]
+                (if (zero? code)
+                  code
+                  (reduced (do (println (str "✗ " label " failed (exit " code ")"))
+                               code)))))
+            0 steps)))
+
+(defn lib
+  "Build the embeddable `librockboxd.a` fat archive (headless/cpal, no SDL):
+  headless firmware -> rockbox-embed + rockbox-server -> `zig build lib`.
+
+  Output: zig/zig-out/lib/librockboxd.a. Consumed by the GPUI client."
+  []
+  (let [steps [["headless firmware" headless]
+               ["embed+server"      #(sh/cargo-build "rockbox-embed" "rockbox-server")]
+               ["zig build lib"     #(sh/zig "build" "lib")]]]
+    (reduce (fn [_ [label f]]
+              (println (str "\n▶ lib: " label))
+              (let [code (f)]
+                (if (zero? code) code
+                    (reduced (do (println (str "✗ " label " failed (exit " code ")"))
+                                 code)))))
+            0 steps)))
+
+;; ── extra targets ────────────────────────────────────────────────────
+
+(defn gpui
+  "Build the GPUI desktop client (`cd gpui && cargo build --release`).
+  Links librockboxd.a automatically via gpui/build.rs — run `(lib)` first
+  if the embeddable archive is stale."
+  []
+  (sh/cargo "build" "--release" "--manifest-path" (sh/in "gpui" "Cargo.toml")))
+
+(defn armhf
+  "Cross-build the firmware for armhf via scripts/build-armhf.sh."
+  []
+  (sh/bash "scripts/build-armhf.sh"))

--- a/tools/console/src/console/core.clj
+++ b/tools/console/src/console/core.clj
@@ -1,0 +1,132 @@
+(ns console.core
+  "Rockbox console — a centralized REPL for every build/dev/ops command in
+  the monorepo. One place to build the firmware, link rockboxd, run the
+  daemon, drive the WASM + Expo targets, and publish the language bindings.
+
+  Quick start (REPL):
+      (require '[console.core :as c])
+      (c/help)   ;; or (c/ls)
+
+  Or as one-shot babashka tasks:
+      $ bb build:all
+      $ bb run
+      $ bb wasm:build"
+  (:require [console.shell :as sh]
+            [console.scripts :as scripts]))
+
+(def ^:private registry
+  "Hand-written index of every command grouped by namespace. Keeps `(help)`
+  cheap and discoverable — namespaces are still loaded lazily. The
+  `scripts` group is generated at runtime from `scripts/*.sh`."
+  [{:group "build" :ns 'console.build
+    :cmds [[:all            "Full rebuild: firmware -> crates -> zig -> rockboxd"]
+           [:firmware       "Stage 1: make lib in build-lib (SDL firmware)"]
+           [:cli            "Stage 2: cargo build --release -p rockbox-cli"]
+           [:server         "Stage 2: cargo build --release -p rockbox-server"]
+           [:crates         "Stage 2: build cli + server in one cargo run"]
+           [:zig            "Stage 3: cd zig && zig build -> rockboxd"]
+           [:lib            "Embeddable librockboxd.a (headless -> embed -> zig lib)"]
+           [:headless       "Headless (no-SDL) firmware for the embeddable lib"]
+           [:gpui           "GPUI desktop client (links librockboxd.a)"]
+           [:armhf          "Cross-build firmware for armhf"]]}
+
+   {:group "make" :ns 'console.make
+    :cmds [[:make           "make <targets> in a build dir. Args: build-dir & targets"]
+           [:lib            "make lib in a build dir (default build-lib)"]
+           [:clean          "make clean in a build dir (default build-lib)"]
+           [:configure      "tools/configure in a build dir — regenerates Makefile (careful!)"]]}
+
+   {:group "run" :ns 'console.run
+    :cmds [[:daemon         "Run ./zig/zig-out/bin/rockboxd"]
+           [:debug          "Run with RUST_LOG (default debug). Args: [rust-log]"]
+           [:pipe           "FIFO stdout mode piped into ffplay"]]}
+
+   {:group "dev" :ns 'console.dev
+    :cmds [[:fmt            "cargo fmt --all"]
+           [:fmt-check      "cargo fmt --all --check"]
+           [:clippy         "cargo clippy --workspace"]
+           [:test           "cargo test --workspace"]
+           [:check          "cargo check --workspace"]
+           [:build          "cargo build --release --workspace"]]}
+
+   {:group "wasm" :ns 'console.wasm
+    :cmds [[:build          "bash scripts/build-wasm.sh -> web/rockboxd.{js,wasm}"]
+           [:serve          "node scripts/wasm-dev-server.mjs (COOP/COEP headers)"]]}
+
+   {:group "expo" :ns 'console.expo
+    :cmds [[:install        "bun install"]
+           [:start          "bun run start (Metro / expo-router)"]
+           [:typecheck      "bunx tsc --noEmit"]
+           [:lint           "bunx expo lint"]
+           [:export-web     "bunx expo export --platform web (smoke test)"]
+           [:ios            "Build RockboxExpo.xcframework"]
+           [:android        "Build librockbox_expo.so (embedded-daemon)"]
+           [:prebuild       "bunx expo prebuild"]
+           [:run-ios        "bunx expo run:ios"]
+           [:run-android    "bunx expo run:android"]]}
+
+   {:group "bindings" :ns 'console.bindings
+    :cmds [[:ffi            "cargo build --release -p rockbox-ffi"]
+           [:fetch-libs     "Stage prebuilt libs from a GH release"]
+           [:publish        "Publish npm/python/ruby packages. Args: lang [flags]"]]}
+
+   {:group "verify" :ns 'console.verify
+    :cmds [[:stale          "Binary vs .a timestamps (stale-binary pitfall)"]
+           [:symbols        "airplay + squeezelite symbols present in rockboxd"]
+           [:staticlib      "airplay + slim object files inside librockbox_cli.a"]
+           [:nm             "grep the binary's symbol table. Args: pattern"]
+           [:ar             "grep the cli staticlib's members. Args: pattern"]]}
+
+   {:group "env" :ns 'console.env
+    :cmds [[:load!          "Load a .env file (defaults to <repo>/.env)"]
+           [:set!           "Set one key. Args: key value (in-memory)"]
+           [:unset!         "Remove one key. Args: key"]
+           [:show           "Print loaded keys (masked). (show :unmask) for raw"]
+           [:get            "Fetch one value (raw). Args: key [default]"]
+           [:save!          "Write current env to disk (default <repo>/.env.local)"]]}])
+
+(defn- pad [s n] (let [s (str s)] (str s (apply str (repeat (max 0 (- n (count s))) " ")))))
+
+(defn- print-group [{:keys [group ns cmds]}]
+  (println)
+  (println (str "── " group "  (" ns ") ──"))
+  (doseq [[sym desc] cmds]
+    (println " " (pad sym 22) "  " desc)))
+
+(defn ls
+  "Print every registered command, grouped by namespace, with a one-liner.
+  The `scripts` group is discovered live from `scripts/*.sh`."
+  []
+  (doseq [g registry] (print-group g))
+  ;; Dynamic scripts group.
+  (println)
+  (println (str "── scripts  (console.scripts — bash scripts/*.sh) ──"))
+  (doseq [n (try (scripts/names) (catch Exception _ nil))]
+    (println " " (pad n 22) "  " (str "bash scripts/" n ".sh")))
+  :ok)
+
+(defn help
+  "Pretty banner + ls. Use this from the REPL for a quick tour."
+  []
+  (println)
+  (println "Rockbox Console — REPL-driven ops for the whole monorepo")
+  (println "    (require '[console.build :as build])")
+  (println "    (build/all)   ;; then (run/daemon)")
+  (println)
+  (println "Commands:")
+  (ls)
+  (println)
+  (println "From shell:   bb <task>     (see `bb tasks`)")
+  (println "Repo root:   " (sh/repo-root))
+  :ok)
+
+(defn dispatch
+  "Entry point for `clj -X console.core/dispatch :cmd :build/all :args []`."
+  [{:keys [cmd args] :or {args []}}]
+  (let [[grp sym] ((juxt namespace name) cmd)
+        ns-sym    (symbol (str "console." grp))]
+    (require ns-sym)
+    (let [f (ns-resolve ns-sym (symbol sym))]
+      (when-not f
+        (throw (ex-info (str "Unknown command: " cmd) {:cmd cmd})))
+      (apply f args))))

--- a/tools/console/src/console/dev.clj
+++ b/tools/console/src/console/dev.clj
@@ -1,0 +1,18 @@
+(ns console.dev
+  "Workspace code-quality shortcuts for the Rust crates.
+
+      (dev/fmt)        ;; cargo fmt --all
+      (dev/fmt-check)  ;; cargo fmt --all --check (CI-style)
+      (dev/clippy)     ;; cargo clippy --workspace
+      (dev/test)       ;; cargo test --workspace
+      (dev/check)      ;; cargo check --workspace
+      (dev/build)      ;; cargo build --release --workspace"
+  (:refer-clojure :exclude [test])
+  (:require [console.shell :as sh]))
+
+(defn fmt        [] (sh/cargo "fmt" "--all"))
+(defn fmt-check  [] (sh/cargo "fmt" "--all" "--check"))
+(defn clippy     [& args] (apply sh/cargo "clippy" "--workspace" args))
+(defn test       [& args] (apply sh/cargo "test" "--workspace" args))
+(defn check      [] (sh/cargo "check" "--workspace"))
+(defn build      [] (sh/cargo "build" "--release" "--workspace"))

--- a/tools/console/src/console/env.clj
+++ b/tools/console/src/console/env.clj
@@ -1,0 +1,189 @@
+(ns console.env
+  "Load env vars from `.env` files into a Clojure atom, and have every
+  console command inherit them via subprocess env injection
+  (see `console.shell`).
+
+  Handy for the knobs rockboxd reads at runtime — e.g. `RUST_LOG`,
+  `ROCKBOX_LIBRARY`, `ROCKBOX_UPDATE_LIBRARY`, `ANDROID_NDK_HOME`.
+
+  Quick tour:
+
+      (env/load!)                  ; loads <repo>/.env
+      (env/set! \"RUST_LOG\" \"debug\") ; in-memory, wins for later subprocesses
+      (env/show)                   ; prints loaded keys, values masked
+      (env/get \"RUST_LOG\")          ; raw value
+      (env/save!)                  ; write to <repo>/.env.local
+
+  Sources are layered: each `load!` merges on top of whatever is already
+  there, so later sources win. `reload!` replays every source in order."
+  (:refer-clojure :exclude [get])
+  (:require [clojure.string :as str]
+            [console.path :as path]
+            [babashka.fs :as fs]))
+
+(def ^:dynamic *env*
+  "Atom holding the currently loaded env map ({string -> string}).
+  Read by `console.shell/sh` and friends when spawning subprocesses."
+  (atom {}))
+
+(defonce ^:private sources
+  ;; Vector of {:type :file :path "..."}
+  (atom []))
+
+;; ── parsing (dotenv format) ──────────────────────────────────────────
+
+(defn- strip-quotes [s]
+  (let [s (str/trim s)]
+    (cond
+      (and (>= (count s) 2)
+           (str/starts-with? s "\"") (str/ends-with? s "\"")) (subs s 1 (dec (count s)))
+      (and (>= (count s) 2)
+           (str/starts-with? s "'")  (str/ends-with? s "'"))  (subs s 1 (dec (count s)))
+      :else s)))
+
+(defn parse-dotenv
+  "Parse a dotenv-format string into {string -> string}. Handles
+  `KEY=value`, quoted values, `export ` prefix, `# comments`, blanks."
+  [text]
+  (->> (str/split-lines text)
+       (keep (fn [raw]
+               (let [line (str/trim raw)]
+                 (when-not (or (empty? line) (str/starts-with? line "#"))
+                   (let [line (cond-> line
+                                (str/starts-with? line "export ") (subs 7))
+                         idx  (.indexOf line "=")]
+                     (when (pos? idx)
+                       [(str/trim (subs line 0 idx))
+                        (strip-quotes (subs line (inc idx)))]))))))
+       (into {})))
+
+;; ── source management ───────────────────────────────────────────────
+
+(defn- record-source! [src]
+  (swap! sources (fn [xs] (-> xs (->> (remove #(= % src))) vec (conj src)))))
+
+(defn- resolve-path [p]
+  (let [p (str p)]
+    (if (fs/absolute? p) p (str (fs/path (path/repo-root) p)))))
+
+(defn load!
+  "Merge a `.env` file into `*env*`. Path is relative to repo root if not
+  absolute. With no args, loads `<repo>/.env`. Returns key-count or
+  `nil` if the file does not exist."
+  ([] (load! ".env"))
+  ([path]
+   (let [resolved (resolve-path path)]
+     (when (fs/exists? resolved)
+       (let [m (parse-dotenv (slurp resolved))]
+         (swap! *env* merge m)
+         (record-source! {:type :file :path resolved})
+         (count m))))))
+
+(defn set!
+  "Set one key in `*env*`. Immediately visible to every subsequent
+  subprocess; does not write to disk.
+
+      (env/set! \"RUST_LOG\" \"debug\")"
+  [k v]
+  (swap! *env* assoc (str k) (str v))
+  k)
+
+(defn unset!
+  "Remove one key from `*env*`. In-memory only."
+  [k]
+  (swap! *env* dissoc (str k))
+  k)
+
+(defn merge!
+  "Merge a map of {key value} into `*env*` (later values win)."
+  [m]
+  (let [m (into {} (for [[k v] m] [(str k) (str v)]))]
+    (swap! *env* clojure.core/merge m)
+    (count m)))
+
+(defn unload!
+  "Clear `*env*` and forget every loaded source."
+  []
+  (reset! *env* {})
+  (reset! sources [])
+  :ok)
+
+(defn reload!
+  "Re-load every previously loaded file, in order."
+  []
+  (let [srcs @sources]
+    (reset! *env* {})
+    (reset! sources [])
+    (doseq [s srcs] (load! (:path s)))
+    (count @*env*)))
+
+;; ── persistence ─────────────────────────────────────────────────────
+
+(defn- needs-quoting? [v]
+  (re-find #"[\s\"'#$=]" (str v)))
+
+(defn- emit-dotenv [m]
+  (->> (sort-by key m)
+       (map (fn [[k v]]
+              (let [v (str v)]
+                (str k "="
+                     (if (needs-quoting? v)
+                       (str "\""
+                            (-> v
+                                (str/replace "\\" "\\\\")
+                                (str/replace "\"" "\\\""))
+                            "\"")
+                       v)))))
+       (str/join "\n")))
+
+(defn save!
+  "Write the current `*env*` to disk as a `.env`-format file.
+
+  Path is relative to repo root if not absolute. With no args, writes
+  `.env.local` — so the original `.env` is never silently clobbered.
+
+  NOTE: writes the *resolved* in-memory map. Comments, ordering, and
+  `${VAR}` interpolation from the original source files are lost."
+  ([] (save! ".env.local"))
+  ([path]
+   (let [resolved (resolve-path path)]
+     (spit resolved (str (emit-dotenv @*env*) "\n"))
+     resolved)))
+
+;; ── inspection ──────────────────────────────────────────────────────
+
+(defn- mask [v]
+  (let [s (str v)]
+    (cond
+      (empty? s)        ""
+      (<= (count s) 4)  "***"
+      :else             (str (subs s 0 2) "***" (subs s (- (count s) 2))))))
+
+(defn show
+  "Print every loaded key, values masked. Pass `:unmask` for raw values
+  (never paste that anywhere shared)."
+  ([] (show {}))
+  ([opts]
+   (let [unmask? (or (= opts :unmask) (true? (:unmask? opts)))
+         render  (if unmask? identity mask)
+         m       @*env*]
+     (if (empty? m)
+       (println "(env empty — try (env/load!) or (env/set! ...))")
+       (do
+         (println (str (count m) " key(s) loaded from "
+                       (mapv :path @sources)
+                       (when unmask? "  [UNMASKED]") ":"))
+         (doseq [[k v] (sort-by key m)]
+           (println " " k "=" (render v)))))
+     :ok)))
+
+(defn get
+  "Fetch one value (raw, not masked)."
+  ([k] (get k nil))
+  ([k default] (clojure.core/get @*env* (str k) default)))
+
+(defn as-map
+  "Return a copy of the current env map. Used by `console.shell` to seed
+  every subprocess's `:extra-env`."
+  []
+  (into {} @*env*))

--- a/tools/console/src/console/expo.clj
+++ b/tools/console/src/console/expo.clj
@@ -1,0 +1,53 @@
+(ns console.expo
+  "Expo mobile app (`expo/`) + its native gRPC module
+  (`expo/modules/rockbox-rpc`).
+
+  App dev:
+      (expo/install)      ;; bun install
+      (expo/start)        ;; bun run start (Metro / expo-router)
+      (expo/typecheck)    ;; bunx tsc --noEmit
+      (expo/lint)         ;; bunx expo lint
+      (expo/export-web)   ;; bunx expo export --platform web (smoke test)
+
+  Native libs (rebuild after changing crates/expo — Metro doesn't pick up
+  native changes):
+      (expo/ios)          ;; RockboxExpo.xcframework
+      (expo/android)      ;; librockbox_expo.so per ABI (embedded-daemon)
+      (expo/prebuild)     ;; bunx expo prebuild
+      (expo/run-ios)      ;; bunx expo run:ios
+      (expo/run-android)  ;; bunx expo run:android"
+  (:require [console.shell :as sh]))
+
+(def ^:private module "expo/modules/rockbox-rpc")
+
+;; ── JS app ───────────────────────────────────────────────────────────
+
+(defn install   [] (sh/bun "expo" "install"))
+(defn start     [] (sh/bun "expo" "run" "start"))
+(defn typecheck [] (sh/bunx "expo" "tsc" "--noEmit"))
+(defn lint      [] (sh/bunx "expo" "expo" "lint"))
+
+(defn export-web
+  "Bundle the web target — catches NativeWind transform issues."
+  []
+  (sh/bunx "expo" "expo" "export" "--platform" "web"))
+
+;; ── native module ────────────────────────────────────────────────────
+
+(defn ios
+  "Build the iOS xcframework (expo/modules/rockbox-rpc/scripts/build-ios.sh)."
+  []
+  (sh/bun module "run" "build:ios"))
+
+(defn android
+  "Build the Android cdylib with the full embedded daemon
+  (embedded-daemon feature, API 26). Drops librockbox_expo.so per ABI into
+  android/src/main/jniLibs. Pass a profile via the PROFILE env var."
+  []
+  (sh/bash (str module "/scripts/build-android.sh")))
+
+;; ── prebuild + native run ────────────────────────────────────────────
+
+(defn prebuild   [] (sh/bunx "expo" "expo" "prebuild"))
+(defn run-ios     [] (sh/bunx "expo" "expo" "run:ios"))
+(defn run-android [] (sh/bunx "expo" "expo" "run:android"))

--- a/tools/console/src/console/make.clj
+++ b/tools/console/src/console/make.clj
@@ -1,0 +1,37 @@
+(ns console.make
+  "Direct access to the Rockbox Make build dirs and the `tools/configure`
+  target generator — the escape hatches beneath `console.build`.
+
+      (make/make \"build-lib\" \"lib\")   ;; cd build-lib && make lib
+      (make/lib)                       ;; make lib in build-lib (default)
+      (make/clean \"build-headless\")    ;; make clean
+      (make/configure \"build-lib\")     ;; regenerate the Makefile (careful!)"
+  (:refer-clojure :exclude [make])
+  (:require [console.shell :as sh]))
+
+(defn make
+  "Run `make <targets...>` inside `build-dir` (relative to repo root).
+  With just a build dir, runs bare `make` (default target)."
+  [build-dir & targets]
+  (apply sh/make build-dir targets))
+
+(defn lib
+  "`make lib` inside a build dir (defaults to build-lib)."
+  ([] (lib "build-lib"))
+  ([build-dir] (sh/make build-dir "lib")))
+
+(defn clean
+  "`make clean` inside a build dir (defaults to build-lib)."
+  ([] (clean "build-lib"))
+  ([build-dir] (sh/make build-dir "clean")))
+
+(defn configure
+  "Run `tools/configure` from inside `build-dir` to (re)generate its
+  Makefile for a target. Extra args are passed to configure.
+
+  ⚠ build-lib and build-headless were pre-configured for their targets;
+  re-running configure overwrites the Makefile and any local edits. Only
+  do this if you know what you're doing (see CLAUDE.md → Build system)."
+  [build-dir & args]
+  (sh/sh (into [(sh/in "tools/configure")] (map str args))
+         {:dir (sh/in build-dir)}))

--- a/tools/console/src/console/path.clj
+++ b/tools/console/src/console/path.clj
@@ -1,0 +1,22 @@
+(ns console.path
+  "Repo-root discovery. Lives in its own namespace so both `console.env`
+  and `console.shell` can use it without forming a cycle."
+  (:require [babashka.fs :as fs]))
+
+(defn repo-root
+  "Walk up from cwd until we find the rockboxd monorepo root, identified
+  by the Zig build script (`zig/build.zig`) sitting next to the workspace
+  `Cargo.toml`. Both markers together disambiguate the root from any nested
+  crate directory (which also has its own `Cargo.toml`)."
+  []
+  (loop [dir (fs/absolutize (fs/cwd))]
+    (cond
+      (nil? dir)
+      (throw (ex-info "Could not locate rockboxd repo root"
+                      {:cwd (str (fs/cwd))}))
+
+      (and (fs/exists? (fs/path dir "Cargo.toml"))
+           (fs/exists? (fs/path dir "zig" "build.zig")))
+      (str dir)
+
+      :else (recur (fs/parent dir)))))

--- a/tools/console/src/console/run.clj
+++ b/tools/console/src/console/run.clj
@@ -1,0 +1,37 @@
+(ns console.run
+  "Run the built rockboxd daemon and common dev variants.
+
+      (run/daemon)          ;; ./zig/zig-out/bin/rockboxd
+      (run/debug)           ;; RUST_LOG=debug rockboxd
+      (run/debug \"rockbox_airplay=debug,info\")
+      (run/pipe)            ;; FIFO stdout -> ffplay (raw s16le 44100 stereo)
+
+  These run in the foreground so you see logs and Ctrl-C stops them. Wrap
+  with `console.shell/sh*` if you want the daemon backgrounded in your REPL."
+  (:require [console.shell :as sh]))
+
+(def ^:private bin "zig/zig-out/bin/rockboxd")
+
+(defn daemon
+  "Run the daemon in the foreground with inherited stdio.
+  Extra args are passed through verbatim."
+  [& args]
+  (sh/sh (into [(sh/in bin)] (map str args))))
+
+(defn debug
+  "Run the daemon with `RUST_LOG` set (defaults to `debug`).
+
+      (run/debug)
+      (run/debug \"rockbox_airplay=debug,info\")"
+  ([] (debug "debug"))
+  ([rust-log & args]
+   (sh/sh (into [(sh/in bin)] (map str args))
+          {:extra-env {"RUST_LOG" rust-log}})))
+
+(defn pipe
+  "Pipe the daemon's stdout PCM stream into ffplay — for FIFO/`-` output
+  mode. Assumes `audio_output = \"fifo\"` with `fifo_path = \"-\"` in
+  settings.toml. Uses a shell so the `|` is honored."
+  []
+  (sh/sh ["sh" "-c"
+          (str (sh/in bin) " | ffplay -f s16le -ar 44100 -ac 2 -")]))

--- a/tools/console/src/console/scripts.clj
+++ b/tools/console/src/console/scripts.clj
@@ -1,0 +1,61 @@
+(ns console.scripts
+  "Every shell script under `<repo>/scripts/*.sh`, auto-discovered and
+  runnable from the REPL. No hand-maintained list — drop a new `.sh` in
+  `scripts/` and it shows up here on next load.
+
+      (scripts/ls)                    ;; list every scripts/*.sh
+      (scripts/run \"build-wasm\")       ;; bash scripts/build-wasm.sh
+      (scripts/run \"build-armhf\" \"--clean\")
+
+  For convenience, each discovered script is also interned as a plain
+  function on this namespace (dashes preserved), so you can call it
+  directly:
+
+      (scripts/build-wasm)
+      (scripts/build-headless)
+      (scripts/flatten-archive \"...\")"
+  (:require [console.shell :as sh]
+            [babashka.fs :as fs]
+            [clojure.string :as str]))
+
+(defn- scripts-dir [] (sh/in "scripts"))
+
+(defn names
+  "Sorted vector of script base names (without the `.sh` extension)."
+  []
+  (->> (fs/glob (scripts-dir) "*.sh")
+       (map (comp #(str/replace % #"\.sh$" "") str fs/file-name))
+       sort
+       vec))
+
+(defn ls
+  "Print every script found in `scripts/`."
+  []
+  (println (str "scripts/  (" (scripts-dir) ")"))
+  (doseq [n (names)]
+    (println "  " n))
+  :ok)
+
+(defn run
+  "Run `bash scripts/<name>.sh [args...]` from the repo root. The `.sh`
+  suffix is optional. Extra args pass straight through to the script."
+  [name & args]
+  (let [base (str/replace (str name) #"\.sh$" "")
+        file (str "scripts/" base ".sh")]
+    (when-not (fs/exists? (sh/in file))
+      (throw (ex-info (str "No such script: " file)
+                      {:name name :available (names)})))
+    (apply sh/bash file args)))
+
+;; ── intern one fn per script so `(scripts/build-wasm)` works ──────────
+
+(defn- intern-scripts! []
+  (doseq [n (try (names) (catch Exception _ nil))]
+    (let [sym (symbol n)]
+      (intern *ns* (with-meta sym
+                     {:doc (str "Run scripts/" n ".sh (auto-generated). "
+                                "Extra args pass through.")
+                      :arglists '([& args])})
+              (fn [& args] (apply run n args))))))
+
+(intern-scripts!)

--- a/tools/console/src/console/shell.clj
+++ b/tools/console/src/console/shell.clj
@@ -1,0 +1,108 @@
+(ns console.shell
+  "Shell-out helpers shared by every command wrapper.
+
+  Two flavors:
+    `sh`   — inherit stdio (you see live output, exit-code returned)
+    `sh!`  — capture (returns {:out :err :exit}), throws on non-zero
+    `sh*`  — background (returns a process handle you can deref)
+
+  Every subprocess automatically inherits `@console.env/*env*` via
+  `:extra-env`. Pass `:extra-env {...}` in opts to override individual
+  keys for one call."
+  (:require [babashka.process :as p]
+            [babashka.fs :as fs]
+            [clojure.string :as str]
+            [console.path :as path]
+            [console.env  :as env]))
+
+(defn repo-root
+  "Re-exported for callers that want the repo root."
+  []
+  (path/repo-root))
+
+(defn in
+  "Absolute path of `rel` (a sub-path relative to repo root)."
+  [& rel]
+  (str (apply fs/path (path/repo-root) rel)))
+
+(defn- with-env
+  "Make `@env/*env*` the default `:extra-env`. Per-call `:extra-env` wins."
+  [opts]
+  (assoc opts :extra-env (merge (env/as-map) (:extra-env opts))))
+
+(defn- in-repo [opts]
+  (-> (merge {:dir (path/repo-root) :inherit true} opts)
+      with-env))
+
+(defn sh
+  "Run a command with inherited stdio. Returns the exit code.
+  Accepts either a vector of args or a single string (which is split)."
+  ([cmd] (sh cmd {}))
+  ([cmd opts]
+   (let [args (cond
+                (vector? cmd) (mapv str cmd)
+                (string? cmd) (str/split cmd #"\s+")
+                :else (throw (ex-info "cmd must be string or vector" {:cmd cmd})))
+         proc (p/process args (in-repo opts))]
+     (:exit @proc))))
+
+(defn sh!
+  "Like `sh` but captures stdout/stderr and throws on non-zero exit."
+  ([cmd] (sh! cmd {}))
+  ([cmd opts]
+   (let [args (if (vector? cmd) (mapv str cmd) (str/split cmd #"\s+"))
+         opts (-> {:dir (path/repo-root) :out :string :err :string}
+                  (merge opts)
+                  with-env)]
+     @(p/process args opts))))
+
+(defn sh*
+  "Run in the background. Returns a process handle (deref for exit info)."
+  ([cmd] (sh* cmd {}))
+  ([cmd opts]
+   (let [args (if (vector? cmd) (mapv str cmd) (str/split cmd #"\s+"))]
+     (p/process args (in-repo opts)))))
+
+;; ── project-specific shortcuts ───────────────────────────────────────
+
+(defn make
+  "Run `make <targets...>` inside a build dir relative to repo root.
+
+      (make \"build-lib\" \"lib\")   ;; cd build-lib && make lib"
+  [build-dir & targets]
+  (sh (into ["make"] (map str targets)) {:dir (in build-dir)}))
+
+(defn cargo
+  "Run `cargo <args...>` from repo root.
+
+      (cargo \"build\" \"--release\" \"-p\" \"rockbox-cli\")"
+  [& args]
+  (sh (into ["cargo"] (map str args))))
+
+(defn cargo-build
+  "`cargo build --release -p <crate> [-p <crate> ...]`."
+  [& crates]
+  (apply cargo "build" "--release" (mapcat (fn [c] ["-p" c]) crates)))
+
+(defn zig
+  "Run `zig <args...>` inside the `zig/` dir.
+
+      (zig \"build\")       ;; links zig-out/bin/rockboxd
+      (zig \"build\" \"lib\") ;; librockboxd.a"
+  [& args]
+  (sh (into ["zig"] (map str args)) {:dir (in "zig")}))
+
+(defn bun
+  "`bun <args...>` inside `dir` (relative to repo root)."
+  [dir & args]
+  (sh (into ["bun"] (map str args)) {:dir (in dir)}))
+
+(defn bunx
+  "`bunx <args...>` inside `dir` (relative to repo root)."
+  [dir & args]
+  (sh (into ["bunx"] (map str args)) {:dir (in dir)}))
+
+(defn bash
+  "`bash <script> [args...]` from repo root (script path is repo-relative)."
+  [script & args]
+  (sh (into ["bash" (in script)] (map str args))))

--- a/tools/console/src/console/verify.clj
+++ b/tools/console/src/console/verify.clj
@@ -1,0 +1,55 @@
+(ns console.verify
+  "Sanity checks for the linked binary and staticlibs — the `nm`/`ar`/
+  timestamp probes from CLAUDE.md, wrapped so you don't have to remember
+  the incantations.
+
+      (verify/stale)      ;; binary vs .a timestamps (the stale-binary pitfall)
+      (verify/symbols)    ;; airplay + squeezelite symbols present in rockboxd
+      (verify/staticlib)  ;; airplay + slim object files inside librockbox_cli.a
+      (verify/nm \"pcm_\")   ;; grep the binary's symbol table
+      (verify/ar  \"chromecast\") ;; grep the cli staticlib's member list"
+  (:require [console.shell :as sh]
+            [clojure.string :as str]))
+
+(def ^:private bin "zig/zig-out/bin/rockboxd")
+(def ^:private cli-a "target/release/librockbox_cli.a")
+
+(defn stale
+  "Print the mtimes behind the stale-binary pitfall so you can eyeball
+  whether the binary is older than the libs it links."
+  []
+  (sh/sh ["ls" "-la"
+          (sh/in bin)
+          (sh/in "build-lib/libfirmware.a")
+          (sh/in cli-a)
+          (sh/in "target/release/librockbox_server.a")]))
+
+(defn nm
+  "Grep the daemon binary's symbol table for `pattern`.
+
+      (verify/nm \"pcm_airplay\")"
+  [pattern]
+  (sh/sh ["sh" "-c"
+          (str "nm " (sh/in bin) " | grep " (pr-str pattern))]))
+
+(defn ar
+  "Grep the cli staticlib's member (object-file) list for `pattern`.
+
+      (verify/ar \"slim\")"
+  [pattern]
+  (sh/sh ["sh" "-c"
+          (str "ar t " (sh/in cli-a) " | grep " (pr-str pattern))]))
+
+(defn symbols
+  "Check the airplay + squeezelite PCM-sink symbols made it into rockboxd."
+  []
+  (doseq [p ["pcm_airplay" "pcm_squeezelite"]]
+    (println (str "── nm | grep " p " ──"))
+    (nm p)))
+
+(defn staticlib
+  "Check the airplay + slim rlibs got bundled into librockbox_cli.a."
+  []
+  (doseq [p ["airplay" "slim"]]
+    (println (str "── ar t | grep " p " ──"))
+    (ar p)))

--- a/tools/console/src/console/wasm.clj
+++ b/tools/console/src/console/wasm.clj
@@ -1,0 +1,22 @@
+(ns console.wasm
+  "WASM browser build. Compiles the Rockbox C firmware + the `crates/wasm`
+  shim into web/rockboxd.{js,wasm} via Emscripten, and serves web/ with the
+  COOP/COEP headers SharedArrayBuffer needs.
+
+      (wasm/build)   ;; bash scripts/build-wasm.sh
+      (wasm/serve)   ;; node scripts/wasm-dev-server.mjs
+
+  Reminder: adding a new `#[no_mangle]` export in crates/wasm also needs an
+  entry in EXPORTED_FUNCTIONS inside scripts/build-wasm.sh, then a rebuild —
+  a Rust-only recompile won't re-run the emcc link step."
+  (:require [console.shell :as sh]))
+
+(defn build
+  "Compile the WASM build via scripts/build-wasm.sh."
+  []
+  (sh/bash "scripts/build-wasm.sh"))
+
+(defn serve
+  "Serve web/ over HTTP with COOP/COEP headers (node scripts/wasm-dev-server.mjs)."
+  []
+  (sh/sh ["node" (sh/in "scripts/wasm-dev-server.mjs")]))


### PR DESCRIPTION
A single entry point for every build/dev/ops command in the rockboxd monorepo, modeled on rocksky/tools/console. Runnable as one-shot babashka tasks (`bb <task>`) or from a REPL (`clj -M:rebel`).

Command groups: build (firmware -> crates -> zig -> rockboxd, plus librockboxd.a / gpui / armhf), make (raw make + tools/configure), run (daemon / RUST_LOG / ffplay pipe), dev (cargo fmt/clippy/test/check), wasm, expo (app + native gRPC module builds), bindings (rockbox-ffi + npm/python/ruby publish), verify (nm/ar/stale-binary checks), and env (dotenv injected into every subprocess). Every scripts/*.sh is auto-discovered and callable — no hand-maintained list.

Java/Clojure/babashka versions pinned in .mise.toml.