### PR TITLE
bindings-release: derive package version from the tag, not hardcoded

### DIFF
--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -17,7 +17,7 @@ on:
       tag:
         description: "Release tag to create / upload assets to"
         required: true
-        default: "bindings-v0.1.1"
+        default: "bindings-v0.2.0"
   push:
     tags:
       - "bindings-v*"
@@ -25,12 +25,34 @@ on:
 permissions:
   contents: read
 
-env:
-  # Ruby gem version (drives the .gem filenames). Python and npm carry their
-  # own versions in their manifests — the Ruby gem intentionally lags at 0.1.0.
-  BINDING_VERSION: "0.1.0"
-
 jobs:
+  # 0. Single source of truth for the release version: derive it from the tag
+  # (`bindings-v0.2.0` -> `0.2.0`) so every packaged artifact — Ruby gem,
+  # Python wheel, npm tarball — carries the same version as the release. No
+  # manifest is trusted for the version; they are all stamped from this output
+  # before packaging, so the tag alone drives everything.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - id: v
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${{ github.ref_name }}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+          # Strip the leading "bindings-v" (or bare "bindings-") to get a plain
+          # semver the language packagers accept.
+          version="${tag#bindings-v}"
+          version="${version#bindings-}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release tag=${tag} -> package version=${version}"
+
   # 1. Build the shared library on a native runner per target.
   build-lib:
     name: build-lib (${{ matrix.target }})
@@ -189,8 +211,10 @@ jobs:
 
   # 2a. Ruby platform gems (packaging is host-independent — build all on one runner).
   ruby:
-    needs: [build-lib, build-lib-freebsd, build-lib-netbsd]
+    needs: [version, build-lib, build-lib-freebsd, build-lib-netbsd]
     runs-on: ubuntu-latest
+    env:
+      BINDING_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -200,6 +224,16 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - name: Stamp gem version from release tag
+        working-directory: bindings/ruby
+        run: |
+          set -euxo pipefail
+          # gem build reads RockboxFFI::VERSION from version.rb; keep it in lock-
+          # step with the -o filename (BINDING_VERSION) so the gem's internal
+          # version matches its filename and the release tag.
+          printf 'module RockboxFFI\n  VERSION = "%s"\nend\n' "$BINDING_VERSION" \
+            > lib/rockbox_ffi/version.rb
 
       - name: Build platform gems
         working-directory: bindings/ruby
@@ -246,8 +280,10 @@ jobs:
   # the manylinux tag. BSD wheels are best-effort — pip falls back to the
   # sdist when the tag does not match.
   python:
-    needs: [build-lib, build-lib-freebsd, build-lib-netbsd]
+    needs: [version, build-lib, build-lib-freebsd, build-lib-netbsd]
     runs-on: ubuntu-latest
+    env:
+      BINDING_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -257,6 +293,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - name: Stamp wheel version from release tag
+        working-directory: bindings/python
+        run: |
+          set -euxo pipefail
+          # Pin the first (project) `version = "..."` in pyproject.toml to the tag.
+          sed -i "0,/^version = .*/s//version = \"${BINDING_VERSION}\"/" pyproject.toml
+          grep -m1 '^version = ' pyproject.toml
 
       - name: Install build tooling
         run: pip install build wheel
@@ -305,8 +349,10 @@ jobs:
 
   # 2c. npm: pack the main package + per-platform binary packages into tarballs.
   npm:
-    needs: [build-lib, build-lib-freebsd, build-lib-netbsd]
+    needs: [version, build-lib, build-lib-freebsd, build-lib-netbsd]
     runs-on: ubuntu-latest
+    env:
+      BINDING_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -317,6 +363,35 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - name: Stamp npm versions from release tag
+        working-directory: bindings/typescript
+        run: |
+          set -euxo pipefail
+          # Bump the main package, every per-platform package, and the main
+          # package's optionalDependencies (which must pin the exact per-platform
+          # version) all to the tag — otherwise `npm install rockbox-ffi` pulls a
+          # stale prebuilt-binary package.
+          node -e '
+            const fs = require("fs");
+            const v = process.env.BINDING_VERSION;
+            const main = "package.json";
+            const m = JSON.parse(fs.readFileSync(main, "utf8"));
+            m.version = v;
+            for (const k of Object.keys(m.optionalDependencies || {})) {
+              m.optionalDependencies[k] = v;
+            }
+            fs.writeFileSync(main, JSON.stringify(m, null, 2) + "\n");
+            for (const d of fs.readdirSync("npm", { withFileTypes: true })) {
+              if (!d.isDirectory()) continue;
+              const p = `npm/${d.name}/package.json`;
+              if (!fs.existsSync(p)) continue;
+              const j = JSON.parse(fs.readFileSync(p, "utf8"));
+              j.version = v;
+              fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+            }
+            console.log("stamped npm packages to", v);
+          '
 
       - name: Build dist, stage binaries, pack tarballs
         working-directory: bindings/typescript
@@ -467,7 +542,7 @@ jobs:
 
   # 3. Collect every artifact and attach it to the GitHub Release.
   release:
-    needs: [build-lib, build-lib-freebsd, build-lib-netbsd, ruby, python, npm, swift]
+    needs: [version, build-lib, build-lib-freebsd, build-lib-netbsd, ruby, python, npm, swift]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -496,18 +571,9 @@ jobs:
           done
           ls -l release
 
-      - name: Determine tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.version.outputs.tag }}
           files: release/*
           fail_on_unmatched_files: true

--- a/bindings/typescript/npm/darwin-arm64/package.json
+++ b/bindings/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/darwin-arm64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for macOS arm64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["darwin"],
-  "cpu": ["arm64"],
-  "files": ["librockbox_ffi.dylib"]
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "librockbox_ffi.dylib"
+  ]
 }

--- a/bindings/typescript/npm/darwin-x64/package.json
+++ b/bindings/typescript/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/darwin-x64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for macOS x86_64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["darwin"],
-  "cpu": ["x64"],
-  "files": ["librockbox_ffi.dylib"]
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "librockbox_ffi.dylib"
+  ]
 }

--- a/bindings/typescript/npm/freebsd-x64/package.json
+++ b/bindings/typescript/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/freebsd-x64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for FreeBSD amd64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["freebsd"],
-  "cpu": ["x64"],
-  "files": ["librockbox_ffi.so"]
+  "os": [
+    "freebsd"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "librockbox_ffi.so"
+  ]
 }

--- a/bindings/typescript/npm/linux-arm64/package.json
+++ b/bindings/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/linux-arm64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for Linux arm64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["linux"],
-  "cpu": ["arm64"],
-  "files": ["librockbox_ffi.so"]
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "librockbox_ffi.so"
+  ]
 }

--- a/bindings/typescript/npm/linux-x64/package.json
+++ b/bindings/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/linux-x64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for Linux x86_64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["linux"],
-  "cpu": ["x64"],
-  "files": ["librockbox_ffi.so"]
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "librockbox_ffi.so"
+  ]
 }

--- a/bindings/typescript/npm/netbsd-x64/package.json
+++ b/bindings/typescript/npm/netbsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockbox-ffi/netbsd-x64",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Prebuilt librockbox_ffi shared library for NetBSD amd64",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -8,7 +8,13 @@
     "url": "git+https://github.com/tsirysndr/rockboxd.git",
     "directory": "bindings/typescript"
   },
-  "os": ["netbsd"],
-  "cpu": ["x64"],
-  "files": ["librockbox_ffi.so"]
+  "os": [
+    "netbsd"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "librockbox_ffi.so"
+  ]
 }

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -42,12 +42,12 @@
     "koffi": "^2.9.0"
   },
   "optionalDependencies": {
-    "@rockbox-ffi/darwin-arm64": "0.1.2",
-    "@rockbox-ffi/darwin-x64": "0.1.2",
-    "@rockbox-ffi/linux-x64": "0.1.2",
-    "@rockbox-ffi/linux-arm64": "0.1.2",
-    "@rockbox-ffi/freebsd-x64": "0.1.2",
-    "@rockbox-ffi/netbsd-x64": "0.1.2"
+    "@rockbox-ffi/darwin-arm64": "0.2.0",
+    "@rockbox-ffi/darwin-x64": "0.2.0",
+    "@rockbox-ffi/linux-x64": "0.2.0",
+    "@rockbox-ffi/linux-arm64": "0.2.0",
+    "@rockbox-ffi/freebsd-x64": "0.2.0",
+    "@rockbox-ffi/netbsd-x64": "0.2.0"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
The `bindings-v*` tag never fed into the packaged versions — the workflow stamped hardcoded numbers that had drifted apart (Ruby gems at 0.1.0 via env.BINDING_VERSION, npm platform packages at 0.1.2), so tagging bindings-v0.2.0 produced a release full of stale 0.1.0/0.1.2 artifacts.

Make the tag the single source of truth:
- New `version` job derives the version from the tag (bindings-v0.2.0 -> 0.2.0) and exposes it as an output; dropped env.BINDING_VERSION.
- Ruby/Python/npm jobs stamp their manifests from that output before packaging (version.rb, pyproject.toml, main + per-platform package.json, and the optionalDependencies pins).
- release job uploads to the derived tag instead of re-deriving it.

Also sync the checked-in npm manifests to 0.2.0 and bump the stale workflow_dispatch default.