### PR TITLE
ci: bind macOS cache keys to arch + force-relink embed staticlib

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -40,8 +40,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             zig/.zig-cache
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ matrix.os }}-cargo-
+          key: ${{ matrix.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ matrix.os }}-${{ matrix.arch }}-cargo-
 
       - name: Install LLVM@21
         run: |

--- a/.github/workflows/release-embed-lib.yml
+++ b/.github/workflows/release-embed-lib.yml
@@ -79,8 +79,8 @@ jobs:
             ~/.cargo/git
             zig/.zig-cache
             target
-          key: embed-lib-${{ matrix.runner }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: embed-lib-${{ matrix.runner }}-
+          key: embed-lib-${{ matrix.runner }}-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: embed-lib-${{ matrix.runner }}-${{ matrix.arch }}-
 
       # ── macOS dependencies ────────────────────────────────────────────────
       - name: Install macOS dependencies
@@ -141,13 +141,31 @@ jobs:
 
       # ── Step 3: rockbox-embed Rust crate ──────────────────────────────────
       - name: Build rockbox-embed
-        run: cargo build --release -p rockbox-embed
+        # Remove the cached static archive so cargo always re-links it from the
+        # current target/release/deps. The cache key only hashes Cargo.lock and
+        # `restore-keys` falls back to any prior embed-lib-${{ matrix.runner }}-
+        # ${{ matrix.arch }}- cache, so a crates/embed-only change can otherwise
+        # restore a stale .a missing newer exports (e.g. rb_daemon_start).
+        # Mirrors the release-gpui / linux-x86_64-build force-relink step.
+        run: |
+          rm -f target/release/librockbox_embed.a
+          cargo build --release -p rockbox-embed
+          echo "--- verify rb_daemon_start is present ---"
+          nm --defined-only target/release/librockbox_embed.a 2>/dev/null \
+            | grep rb_daemon_start \
+            || { echo "rb_daemon_start NOT in librockbox_embed.a — abort"; exit 1; }
 
       # ── Step 4: Zig lib step ──────────────────────────────────────────────
       - name: Build librockboxd.a
         run: |
+          rm -f zig/zig-out/lib/librockboxd.a
           cd zig
           zig build lib -Doptimize=ReleaseFast ${{ matrix.zig_cpu }}
+          cd ..
+          echo "--- verify rb_daemon_start survived into librockboxd.a ---"
+          nm --defined-only zig/zig-out/lib/librockboxd.a 2>/dev/null \
+            | grep rb_daemon_start \
+            || { echo "rb_daemon_start NOT in librockboxd.a — abort"; exit 1; }
 
       - name: Clean build artifacts
         run: |

--- a/.github/workflows/release-gpui.yml
+++ b/.github/workflows/release-gpui.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   build-dmg:
     runs-on: ${{ matrix.os }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!startsWith(github.event.release.tag_name, 'clojure-v') &&
+       !startsWith(github.event.release.tag_name, 'clojure-ffi-v') &&
+       !startsWith(github.event.release.tag_name, 'bindings-v'))
     permissions:
       contents: write
 
@@ -58,8 +63,8 @@ jobs:
             zig/.zig-cache
             target
             gpui/target
-          key: gpui-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: gpui-${{ matrix.os }}-
+          key: gpui-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: gpui-${{ matrix.os }}-${{ matrix.arch }}-
 
       # llvm@22 crashes in setSymbolInRelocationInfo on Mach-O — use llvm@21
       - name: Install macOS dependencies
@@ -102,7 +107,20 @@ jobs:
 
       # ── Step 3: rockbox-embed Rust crate ──────────────────────────────────
       - name: Build rockbox-embed
-        run: cargo build --release -p rockbox-embed
+        # Remove the cached static archive so cargo always re-links it from the
+        # current target/release/deps. Cargo's mtime check usually catches
+        # source edits, but the cache key only hashes Cargo.lock and
+        # `restore-keys` falls back to any prior gpui-${{ matrix.os }}- cache,
+        # so a crates/embed-only change can otherwise restore a stale .a that
+        # is missing newer exports (e.g. rb_daemon_start). Mirrors the
+        # linux-x86_64-build workflow's force-relink step.
+        run: |
+          rm -f target/release/librockbox_embed.a
+          cargo build --release -p rockbox-embed
+          echo "--- verify rb_daemon_start is present ---"
+          nm --defined-only target/release/librockbox_embed.a 2>/dev/null \
+            | grep rb_daemon_start \
+            || { echo "rb_daemon_start NOT in librockbox_embed.a — abort"; exit 1; }
 
       # ── Step 4: Fat static library ────────────────────────────────────────
       # Remove the cached archive so the zig link step always re-runs — the
@@ -113,6 +131,11 @@ jobs:
           rm -f zig/zig-out/lib/librockboxd.a
           cd zig
           zig build lib -Doptimize=ReleaseFast ${{ matrix.zig_cpu }}
+          cd ..
+          echo "--- verify rb_daemon_start survived into librockboxd.a ---"
+          nm --defined-only zig/zig-out/lib/librockboxd.a 2>/dev/null \
+            | grep rb_daemon_start \
+            || { echo "rb_daemon_start NOT in librockboxd.a — abort"; exit 1; }
 
       # ── Step 5: GPUI app + DMG ────────────────────────────────────────────
       - name: Build and package


### PR DESCRIPTION
The gpui/embed macOS builds intermittently failed to link with "Undefined symbols for architecture arm64: _rb_daemon_start".

Root cause: two independent cache issues on the workflows that build the embeddable librockboxd.a.

1. Same-OS / different-arch cache slots keyed on a drift-prone runner *label* (macos-latest, ubuntu-latest) while caching arch-specific outputs (target/, zig/.zig-cache). A stale/wrong-vintage librockbox_embed.a could be restored, missing rb_daemon_start. Fix: add ${{ matrix.arch }} to the cache key + restore-keys in release-gpui.yml, macos-build.yml and release-embed-lib.yml.

2. Cargo's mtime fingerprint did not reliably relink the staticlib from the restored target/, so the stale .a survived into the zig link. Fix: rm -f the archive before `cargo build` and add nm fail-fast guards on both librockbox_embed.a and librockboxd.a (mirrors the existing linux-x86_64-build.yml step).